### PR TITLE
chore: Setup conditional apk signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,3 @@ android/local.properties
 android/app/build/
 android/app/src/main/assets/public/
 android/.kotlin/
-android/app/release.keystore
-android/gradle.properties

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -18,11 +18,11 @@ android {
     }
     signingConfigs {
         release {
-            if (project.hasProperty('RELEASE_STORE_FILE')) {
-                storeFile file(RELEASE_STORE_FILE)
-                storePassword RELEASE_STORE_PASSWORD
-                keyAlias RELEASE_KEY_ALIAS
-                keyPassword RELEASE_KEY_PASSWORD
+            if (project.hasProperty('RELEASE_STORE_FILE') && file(project.property('RELEASE_STORE_FILE')).exists()) {
+                storeFile file(project.property('RELEASE_STORE_FILE'))
+                storePassword project.property('RELEASE_STORE_PASSWORD')
+                keyAlias project.property('RELEASE_KEY_ALIAS')
+                keyPassword project.property('RELEASE_KEY_PASSWORD')
             }
         }
     }
@@ -30,7 +30,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            if (project.hasProperty('RELEASE_STORE_FILE')) {
+            if (project.hasProperty('RELEASE_STORE_FILE') && file(project.property('RELEASE_STORE_FILE')).exists()) {
                 signingConfig signingConfigs.release
             }
         }


### PR DESCRIPTION
This commit adds a conditional signing configuration to the `android/app/build.gradle` file. The release APK is now only signed if the keystore properties (such as `RELEASE_STORE_FILE`) are present and the physical keystore file exists, preventing local and CI builds from failing when no keystore is provided. It fixes the "invalid package" installation error when properties are provided to properly sign the release APK.