### PR TITLE
ci: workflow GitHub Actions (typecheck + test + build) (#13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Annule les exécutions précédentes encore en cours sur la même réf.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Typecheck, test & build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Contexte

Résout [#13](https://github.com/DZTic/localstream/issues/13). Aucun workflow CI n'existait (`.github/workflows/` absent) : les régressions — et les conflits comme celui rencontré récemment — n'étaient détectés qu'en local.

## Changements

Ajout de `.github/workflows/ci.yml`. Sur **push vers `main`** et sur **chaque pull request** :

1. `npm ci`
2. `npm run lint` (`tsc --noEmit`)
3. `npm test` (vitest, 22 tests existants)
4. `npm run build` (bundle Vite)

Détails :
- Node 20 avec cache npm (`actions/setup-node@v4`).
- `concurrency` avec `cancel-in-progress` pour annuler les runs obsolètes sur une même réf.

## Vérification locale
- ✅ `npm run lint`
- ✅ `npm test` — 22/22
- ✅ `npm run build`

## Suite possible (hors scope ici)
Le job Android optionnel mentionné dans l'issue (`gradlew assembleRelease` + upload d'APK sur tags `v*`) est volontairement laissé de côté pour garder cette CI verte et simple ; il dépend de la stratégie de signature ([#15](https://github.com/DZTic/localstream/issues/15)) et de versionnement ([#16](https://github.com/DZTic/localstream/issues/16)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)