### PR TITLE
fix: modale Paramètres scrollable (débordement écran) (#3)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2174,14 +2174,14 @@ export default function App() {
       {/* Settings Modal */}
       {showSettings && (
         <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-          <div className="bg-zinc-900 border border-zinc-800 rounded-lg w-full max-w-md overflow-hidden shadow-2xl">
-            <div className="flex items-center justify-between p-4 border-b border-zinc-800">
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg w-full max-w-md max-h-[90vh] flex flex-col overflow-hidden shadow-2xl">
+            <div className="flex items-center justify-between p-4 border-b border-zinc-800 shrink-0">
               <h3 className="text-lg font-semibold">Paramètres</h3>
               <button onClick={() => setShowSettings(false)} className="p-2 rounded-full hover:bg-zinc-800 transition-colors">
                 <X className="w-5 h-5" />
               </button>
             </div>
-            <div className="p-6 space-y-4">
+            <div className="p-6 space-y-4 flex-1 overflow-y-auto">
               <div>
                 <h4 className="text-sm font-bold text-zinc-400 uppercase tracking-wider mb-3 flex items-center gap-2">
                   <Subtitles className="w-4 h-4" /> OpenSubtitles


### PR DESCRIPTION
## Contexte

Résout [#3](https://github.com/DZTic/localstream/issues/3). En choisissant le lecteur vidéo « externe », la fenêtre Paramètres s'agrandissait et sortait de l'écran, rendant impossible la fermeture (la croix devenait inaccessible).

## Cause

La carte de la modale (`fixed inset-0 … flex items-center justify-center`) était **centrée verticalement, sans hauteur maximale ni défilement** (`overflow-hidden` seul). Quand le contenu du lecteur externe s'affiche (liste des lecteurs + boutons), la carte dépasse la hauteur du viewport, débordant en haut **et** en bas.

## Correctif

Application du pattern déjà utilisé par la modale Sous-titres du même fichier :
- Carte : `max-h-[90vh] flex flex-col` (au lieu de grandir sans limite)
- En-tête : `shrink-0` (toujours visible, croix accessible)
- Corps : `flex-1 overflow-y-auto` (défile à l'intérieur)

3 lignes de classes Tailwind, aucun changement de logique.

## Vérification
- ✅ `npm run lint`
- ✅ `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)