### PR TITLE
fix: pop-up de création de listes visible en entier sur mobile (#1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1839,7 +1839,7 @@ export default function App() {
                         <span className="hidden sm:inline">MA LISTE</span>
                       </button>
                       {showPlaylistSelector && (
-                        <div className="absolute bottom-full mb-4 left-0 md:left-auto md:right-0 w-80 bg-zinc-900/90 border border-white/10 rounded-2xl shadow-[0_20px_50px_rgba(0,0,0,0.5)] z-50 overflow-hidden backdrop-blur-2xl animate-in fade-in slide-in-from-bottom-6 duration-500">
+                        <div className="absolute bottom-full mb-4 right-0 w-[min(20rem,calc(100vw_-_2rem))] md:w-80 bg-zinc-900/90 border border-white/10 rounded-2xl shadow-[0_20px_50px_rgba(0,0,0,0.5)] z-50 overflow-hidden backdrop-blur-2xl animate-in fade-in slide-in-from-bottom-6 duration-500">
                           <div className="p-5 bg-gradient-to-b from-zinc-800/50 to-transparent border-b border-white/5">
                             <h4 className="text-xs font-black text-white/40 uppercase tracking-[0.32em] mb-4">Mes Listes</h4>
                             <div className="max-h-64 overflow-y-auto space-y-2 pr-1 custom-scrollbar">


### PR DESCRIPTION
## Contexte

Résout [#1](https://github.com/DZTic/localstream/issues/1). Sur téléphone, la pop-up de création/sélection de playlist (depuis la fiche d'un film) débordait de l'écran et n'était pas visible en entier.

## Cause

Le dropdown s'ouvrait en `left-0` avec une **largeur fixe `w-80` (320px)**, ancré au bord gauche du bouton « MA LISTE » — un bouton `flex-1` situé à droite de la rangée d'actions. Résultat : sur un écran étroit, la pop-up s'étendait vers la droite au-delà du bord de l'écran.

## Correctif

- Ancrage **à droite** sur toutes les tailles (`right-0`) : la pop-up s'étend vers l'intérieur de la modale.
- Largeur **bornée au viewport** sur mobile : `w-[min(20rem,calc(100vw-2rem))]`, tout en conservant `md:w-80` sur desktop.

Une ligne de classes Tailwind, aucun changement de logique.

## Vérification
- ✅ `npm run lint`
- ✅ `npm run build` (classe compilée en `min(20rem,100vw - 2rem)`, CSS valide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)