### PR TITLE
build(android): versionnement dérivé de package.json (#16)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,17 @@
+import groovy.json.JsonSlurper
+
 apply plugin: 'com.android.application'
+
+// --- Versionnement : package.json comme source unique de vérité ---
+// versionName = champ "version" de package.json (ex. "1.2.3")
+// versionCode = dérivé du semver : MAJEUR*10000 + MINEUR*100 + CORRECTIF
+//   (1.0.0 -> 10000, 1.0.1 -> 10001, 1.1.0 -> 10100, 2.0.0 -> 20000)
+// => incrémenter la version dans package.json suffit pour publier une mise à jour.
+def pkgVersion = (new JsonSlurper().parse(file("$rootDir/../package.json"))).version as String
+def semverMatcher = (pkgVersion =~ /(\d+)\.(\d+)\.(\d+)/)
+def computedVersionCode = semverMatcher.find()
+        ? (semverMatcher.group(1).toInteger() * 10000 + semverMatcher.group(2).toInteger() * 100 + semverMatcher.group(3).toInteger())
+        : 1
 
 android {
     namespace = "com.localstream.app"
@@ -7,8 +20,8 @@ android {
         applicationId "com.localstream.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode computedVersionCode
+        versionName pkgVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.


### PR DESCRIPTION
## Contexte

Résout [#16](https://github.com/DZTic/localstream/issues/16). `versionCode 1` / `versionName "1.0"` étaient figés dans `android/app/build.gradle`. Android refusant d'installer une mise à jour si `versionCode` n'augmente pas, chaque release imposait une édition manuelle facile à oublier.

## Changements

`package.json` devient la **source unique de vérité** :
- `versionName` = champ `version` de `package.json`
- `versionCode` = dérivé du semver : `MAJEUR*10000 + MINEUR*100 + CORRECTIF`
  - `1.0.0 → 10000`, `1.0.1 → 10001`, `1.1.0 → 10100`, `2.0.0 → 20000`
  - strictement croissant tant que la version semver augmente

Concrètement : **incrémenter `version` dans `package.json` suffit** pour publier une mise à jour installable.

Implémentation : lecture via `JsonSlurper` au moment de la configuration Gradle (import en tête de fichier), extraction du semver par regex avec repli sur `1`.

## Vérification
- Chemin confirmé : `android/` est la racine Gradle (`settings.gradle` présent) → `$rootDir/../package.json` pointe sur le `package.json` du repo.
- Calcul validé : version actuelle `1.0.0` → `versionCode 10000` (augmente bien depuis `1`).
- ⚠️ Build Gradle complet non exécuté ici (pas de SDK Android dans l'environnement) ; le code est du Groovy standard et la logique/chemin sont vérifiés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)