### PR TITLE
feat: rotation du hero d'accueil (contenus non vus/non finis) (#4)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { srt2vtt, safeSetItem, getCleanTitle, getResolution, formatSize, formatD
 import { osLogin, osSearch, osDownloadVtt } from './lib/opensubtitles';
 import { getPopular } from './lib/tmdb';
 import { filterAndSortVideos } from './lib/sorting';
+import { getHeroCandidates } from './lib/hero';
 import { useTmdbMetadata } from './hooks/useTmdbMetadata';
 import { VideoRow } from './components/VideoRow';
 import { BottomNav } from './components/BottomNav';
@@ -842,10 +843,23 @@ export default function App() {
     return () => window.removeEventListener('focus', handleFocusScan);
   }, []);
 
-  const heroVideo = recentAdditions.find(v => {
-    if (v.isSeriesGroup) return v.episodes?.some(ep => !watchedVideos[ep.name]);
-    return !watchedVideos[v.name];
-  }) || recentAdditions[0] || groupedVideos[0];
+  // Hero rotatif (#4) : on fait défiler les films/séries non vus ou non terminés
+  // plutôt que d'afficher toujours le dernier ajouté.
+  const heroCandidates = React.useMemo(
+    () => getHeroCandidates(groupedVideos, watchedVideos, watchProgress),
+    [groupedVideos, watchedVideos, watchProgress]
+  );
+
+  const [heroIndex, setHeroIndex] = useState(0);
+  useEffect(() => {
+    if (heroCandidates.length <= 1) return;
+    const id = setInterval(() => setHeroIndex(i => i + 1), 10000);
+    return () => clearInterval(id);
+  }, [heroCandidates.length]);
+
+  const heroVideo = heroCandidates.length > 0
+    ? heroCandidates[heroIndex % heroCandidates.length]
+    : (recentAdditions[0] || groupedVideos[0]);
 
   const createPlaylist = () => {
     if (!newPlaylistName.trim()) return;

--- a/src/lib/__tests__/hero.test.ts
+++ b/src/lib/__tests__/hero.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { getHeroCandidates, isFullyWatched } from '../hero';
+import type { VideoFile } from '../types';
+
+const v = (name: string, extra: Partial<VideoFile> = {}): VideoFile => ({
+  url: 'blob:x', name, type: 'video/mp4', path: name, ...extra,
+});
+
+describe('isFullyWatched', () => {
+  it('film : suit son propre état', () => {
+    expect(isFullyWatched(v('Film.mkv'), { 'Film.mkv': true })).toBe(true);
+    expect(isFullyWatched(v('Film.mkv'), {})).toBe(false);
+  });
+  it('série : terminée seulement si tous les épisodes sont vus', () => {
+    const s = v('S', { isSeriesGroup: true, episodes: [v('S.E1.mkv'), v('S.E2.mkv')] });
+    expect(isFullyWatched(s, { 'S.E1.mkv': true })).toBe(false);
+    expect(isFullyWatched(s, { 'S.E1.mkv': true, 'S.E2.mkv': true })).toBe(true);
+  });
+});
+
+describe('getHeroCandidates', () => {
+  it('exclut les contenus entièrement vus', () => {
+    const res = getHeroCandidates(
+      [v('Vu.mkv'), v('NonVu.mkv')],
+      { 'Vu.mkv': true },
+    );
+    expect(res.map(r => r.name)).toEqual(['NonVu.mkv']);
+  });
+
+  it('ne se limite pas au dernier ajouté : retourne tous les non-vus pour rotation', () => {
+    const res = getHeroCandidates(
+      [v('A.mkv', { lastModified: 1 }), v('B.mkv', { lastModified: 2 }), v('C.mkv', { lastModified: 3 })],
+      {},
+    );
+    expect(res).toHaveLength(3);
+    // le plus récent en tête, mais les autres restent candidats
+    expect(res[0].name).toBe('C.mkv');
+  });
+
+  it('priorise les contenus en cours avant les non commencés', () => {
+    const res = getHeroCandidates(
+      [v('Recent.mkv', { lastModified: 10 }), v('EnCours.mkv', { lastModified: 1 })],
+      {},
+      { 'EnCours.mkv': 40 },
+    );
+    expect(res[0].name).toBe('EnCours.mkv');
+  });
+
+  it('ignore une progression terminée (>= 95%)', () => {
+    const res = getHeroCandidates(
+      [v('Presque.mkv', { lastModified: 1 }), v('Recent.mkv', { lastModified: 10 })],
+      {},
+      { 'Presque.mkv': 98 },
+    );
+    // 98% n'est pas "en cours" → l'ordre retombe sur la récence
+    expect(res[0].name).toBe('Recent.mkv');
+  });
+
+  it('renvoie une liste vide si tout est vu', () => {
+    expect(getHeroCandidates([v('A.mkv')], { 'A.mkv': true })).toHaveLength(0);
+  });
+});

--- a/src/lib/hero.ts
+++ b/src/lib/hero.ts
@@ -1,0 +1,40 @@
+// Sélection des candidats pour la bannière "hero" de l'accueil.
+// Objectif (#4) : faire tourner les films/séries non vus ou non terminés,
+// au lieu d'afficher toujours le dernier ajouté.
+
+import type { VideoFile } from './types';
+
+/** Un contenu est "terminé" si vu (film) ou si tous ses épisodes sont vus (série). */
+export const isFullyWatched = (
+  v: VideoFile,
+  watchedVideos: Record<string, boolean>,
+): boolean =>
+  v.isSeriesGroup
+    ? !!(v.episodes && v.episodes.length > 0 && v.episodes.every(ep => !!watchedVideos[ep.name]))
+    : !!watchedVideos[v.name];
+
+/** Un film est "en cours" si sa progression est entamée mais non terminée. */
+const isInProgress = (v: VideoFile, watchProgress: Record<string, number>): boolean => {
+  const p = watchProgress[v.name] || 0;
+  return p > 0 && p < 95;
+};
+
+/**
+ * Liste ordonnée des candidats pour la rotation du hero :
+ *  - uniquement les contenus non terminés (non vus ou en cours),
+ *  - les contenus en cours d'abord, puis les plus récemment ajoutés.
+ * Fonction pure (sans état React).
+ */
+export const getHeroCandidates = (
+  groupedVideos: VideoFile[],
+  watchedVideos: Record<string, boolean>,
+  watchProgress: Record<string, number> = {},
+): VideoFile[] =>
+  groupedVideos
+    .filter(v => !isFullyWatched(v, watchedVideos))
+    .sort((a, b) => {
+      const aProg = isInProgress(a, watchProgress);
+      const bProg = isInProgress(b, watchProgress);
+      if (aProg !== bProg) return aProg ? -1 : 1;
+      return (b.file?.lastModified || b.lastModified || 0) - (a.file?.lastModified || a.lastModified || 0);
+    });


### PR DESCRIPTION
## Contexte

Résout [#4](https://github.com/DZTic/localstream/issues/4). La bannière « hero » de l'accueil affichait toujours le premier contenu non vu trié par date d'ajout — donc, en pratique, **toujours le dernier film/série ajouté**.

## Changements

- **`src/lib/hero.ts`** — fonction pure `getHeroCandidates(groupedVideos, watchedVideos, watchProgress)` :
  - ne retient que les contenus **non terminés** (non vus, ou en cours),
  - ordonne les **en cours d'abord**, puis par récence d'ajout.
  - (+ helper `isFullyWatched`).
- **`App.tsx`** — le hero **tourne** parmi ces candidats : changement toutes les 10 s via un index incrémenté (`heroIndex % candidates.length`). Repli sur l'ancien comportement (`recentAdditions[0]`) si aucun candidat.

## Tests

`src/lib/__tests__/hero.test.ts` — **7 tests** : exclusion des contenus vus, conservation de tous les non-vus pour rotation, priorité aux contenus en cours, progression terminée ignorée (≥ 95 %), liste vide si tout est vu.

## Vérification
- ✅ `npm run lint`
- ✅ `npm test` — **29/29** (22 existants + 7 nouveaux)
- ✅ `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)