### PR TITLE
build(android): config de signature release + doc (#15)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,6 +13,17 @@ def computedVersionCode = semverMatcher.find()
         ? (semverMatcher.group(1).toInteger() * 10000 + semverMatcher.group(2).toInteger() * 100 + semverMatcher.group(3).toInteger())
         : 1
 
+// --- Signature release ---
+// Les identifiants de signature sont lus depuis une propriété Gradle
+// (-P… / ~/.gradle/gradle.properties) OU une variable d'environnement
+// (pratique en CI via des secrets). Ils ne doivent jamais être commités.
+// Voir docs/android-signing.md.
+def signingProp = { String name ->
+    project.hasProperty(name) ? project.property(name) : System.getenv(name)
+}
+def releaseStoreFile = signingProp('RELEASE_STORE_FILE')
+def hasReleaseSigning = releaseStoreFile != null && file(releaseStoreFile).exists()
+
 android {
     namespace = "com.localstream.app"
     compileSdk = rootProject.ext.compileSdkVersion
@@ -31,11 +42,11 @@ android {
     }
     signingConfigs {
         release {
-            if (project.hasProperty('RELEASE_STORE_FILE') && file(project.property('RELEASE_STORE_FILE')).exists()) {
-                storeFile file(project.property('RELEASE_STORE_FILE'))
-                storePassword project.property('RELEASE_STORE_PASSWORD')
-                keyAlias project.property('RELEASE_KEY_ALIAS')
-                keyPassword project.property('RELEASE_KEY_PASSWORD')
+            if (hasReleaseSigning) {
+                storeFile file(releaseStoreFile)
+                storePassword signingProp('RELEASE_STORE_PASSWORD')
+                keyAlias signingProp('RELEASE_KEY_ALIAS')
+                keyPassword signingProp('RELEASE_KEY_PASSWORD')
             }
         }
     }
@@ -43,9 +54,10 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            if (project.hasProperty('RELEASE_STORE_FILE') && file(project.property('RELEASE_STORE_FILE')).exists()) {
+            if (hasReleaseSigning) {
                 signingConfig signingConfigs.release
             } else {
+                logger.warn("⚠️  Aucune clé de signature release (RELEASE_STORE_FILE) : l'APK release sera signé avec la clé DEBUG, non destinée à la distribution. Voir docs/android-signing.md")
                 signingConfig signingConfigs.debug
             }
         }

--- a/docs/android-signing.md
+++ b/docs/android-signing.md
@@ -1,0 +1,75 @@
+# Signature de l'APK release (Android)
+
+Par défaut, si aucune clé de signature release n'est fournie, l'APK `release` est
+signé avec la **clé debug** d'Android (cf. `android/app/build.gradle`). Un APK
+signé en debug **ne convient pas à la distribution** : il ne peut pas être publié
+sur le Play Store et n'autorise pas les mises à jour d'un APK signé différemment.
+
+Pour produire des builds distribuables, générez une **clé release dédiée** et
+fournissez-la à Gradle. **Le keystore et les mots de passe ne doivent jamais être
+commités** dans le dépôt.
+
+## 1. Générer un keystore release
+
+```bash
+keytool -genkeypair -v \
+  -keystore localstream-release.jks \
+  -alias localstream \
+  -keyalg RSA -keysize 2048 -validity 10000
+```
+
+Conservez précieusement le fichier `.jks` et les mots de passe : **les perdre rend
+impossible toute mise à jour** de l'application déjà publiée.
+
+## 2. Fournir les identifiants à Gradle
+
+`build.gradle` lit quatre propriétés, depuis une **propriété Gradle** *ou* une
+**variable d'environnement** (la propriété Gradle est prioritaire) :
+
+| Propriété              | Description                              |
+|------------------------|------------------------------------------|
+| `RELEASE_STORE_FILE`     | Chemin vers le fichier `.jks`            |
+| `RELEASE_STORE_PASSWORD` | Mot de passe du keystore                 |
+| `RELEASE_KEY_ALIAS`      | Alias de la clé (ex. `localstream`)      |
+| `RELEASE_KEY_PASSWORD`   | Mot de passe de la clé                   |
+
+### Option A — `~/.gradle/gradle.properties` (hors du dépôt)
+
+```properties
+RELEASE_STORE_FILE=/chemin/absolu/localstream-release.jks
+RELEASE_STORE_PASSWORD=********
+RELEASE_KEY_ALIAS=localstream
+RELEASE_KEY_PASSWORD=********
+```
+
+### Option B — variables d'environnement (ex. CI / GitHub Actions)
+
+```bash
+export RELEASE_STORE_FILE="$PWD/localstream-release.jks"
+export RELEASE_STORE_PASSWORD="********"
+export RELEASE_KEY_ALIAS="localstream"
+export RELEASE_KEY_PASSWORD="********"
+```
+
+En CI, stockez ces valeurs (et le keystore encodé en base64) dans des **secrets**,
+puis reconstituez le fichier `.jks` avant le build.
+
+## 3. Construire l'APK signé
+
+```bash
+cd android
+./gradlew assembleRelease   # gradlew.bat sous Windows
+# → app/build/outputs/apk/release/app-release.apk
+```
+
+Si aucune clé n'est fournie, Gradle affiche un avertissement et retombe sur la
+clé debug.
+
+## 4. Vérifier la signature
+
+```bash
+apksigner verify --print-certs app/build/outputs/apk/release/app-release.apk
+```
+
+Le certificat affiché doit correspondre à votre clé release (et **non** au
+certificat « Android Debug »).


### PR DESCRIPTION
## Contexte

Résout [#15](https://github.com/DZTic/localstream/issues/15). L'APK `release` retombait **silencieusement** sur la clé debug quand `RELEASE_STORE_FILE` n'était pas défini, et la procédure de signature n'était pas documentée.

## Changements

- **`android/app/build.gradle`** :
  - les identifiants de signature sont résolus depuis une **propriété Gradle** *ou* une **variable d'environnement** (pratique pour signer en CI via des secrets) ;
  - **avertissement explicite** au moment du build quand on retombe sur la clé debug.
- **`docs/android-signing.md`** : procédure complète — génération du keystore (`keytool`), configuration (`~/.gradle/gradle.properties` ou variables d'env), build (`gradlew assembleRelease`) et vérification (`apksigner verify --print-certs`).

🔒 **Aucun keystore ni secret n'est ajouté au dépôt** — la génération de la clé et la gestion des mots de passe restent à la charge du mainteneur (documentées).

## À noter
- ⚠️ Build Gradle complet non exécuté ici (pas de SDK Android dans l'environnement) ; modifications en Groovy standard.
- Léger conflit attendu avec [#25](https://github.com/DZTic/localstream/pull/25) (les deux éditent le haut de `build.gradle`) — résolution triviale (conserver les deux blocs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #15
