### PR TITLE
refactor: extraire le hook usePlaylists d'App.tsx (#17)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { osLogin, osSearch, osDownloadVtt } from './lib/opensubtitles';
 import { getPopular } from './lib/tmdb';
 import { filterAndSortVideos } from './lib/sorting';
 import { useTmdbMetadata } from './hooks/useTmdbMetadata';
+import { usePlaylists } from './hooks/usePlaylists';
 import { VideoRow } from './components/VideoRow';
 import { BottomNav } from './components/BottomNav';
 
@@ -194,16 +195,16 @@ export default function App() {
   const [playerFeedback, setPlayerFeedback] = useState<{type: 'rewind' | 'forward' | 'pause' | 'play', visible: boolean}>({type: 'pause', visible: false});
   const [searchQuery, setSearchQuery] = useState('');
   
-  const [playlists, setPlaylists] = useState<Playlist[]>(() => {
-    try {
-      const saved = localStorage.getItem('playlists');
-      return saved ? JSON.parse(saved) : [];
-    } catch {
-      return [];
-    }
-  });
+  const {
+    playlists,
+    selectedPlaylist,
+    setSelectedPlaylist,
+    createPlaylist,
+    toggleVideoInPlaylist,
+    deletePlaylist,
+    removeVideoFromPlaylist,
+  } = usePlaylists();
   const [activeTab, setActiveTab] = useState<'home' | 'playlists' | 'history'>('home');
-  const [selectedPlaylist, setSelectedPlaylist] = useState<Playlist | null>(null);
   const [selectedSeason, setSelectedSeason] = useState<number | null>(null);
   const [showPlaylistSelector, setShowPlaylistSelector] = useState(false);
   const [newPlaylistName, setNewPlaylistName] = useState('');
@@ -287,10 +288,6 @@ export default function App() {
   useEffect(() => {
     safeSetItem('watchPositions', JSON.stringify(watchPositions));
   }, [watchPositions]);
-
-  useEffect(() => {
-    safeSetItem('playlists', JSON.stringify(playlists));
-  }, [playlists]);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -847,49 +844,10 @@ export default function App() {
     return !watchedVideos[v.name];
   }) || recentAdditions[0] || groupedVideos[0];
 
-  const createPlaylist = () => {
-    if (!newPlaylistName.trim()) return;
-    const newPlaylist: Playlist = {
-      id: Date.now().toString(),
-      name: newPlaylistName.trim(),
-      videoNames: infoVideo ? [infoVideo.name] : []
-    };
-    setPlaylists([...playlists, newPlaylist]);
+  // Crée la playlist depuis le champ de saisie, pré-remplie avec la vidéo affichée.
+  const handleCreatePlaylist = () => {
+    createPlaylist(newPlaylistName, infoVideo ? [infoVideo.name] : []);
     setNewPlaylistName('');
-  };
-
-  const toggleVideoInPlaylist = (playlistId: string, videoName: string) => {
-    setPlaylists(playlists.map(p => {
-      if (p.id === playlistId) {
-        const hasVideo = p.videoNames.includes(videoName);
-        return {
-          ...p,
-          videoNames: hasVideo 
-            ? p.videoNames.filter(name => name !== videoName)
-            : [...p.videoNames, videoName]
-        };
-      }
-      return p;
-    }));
-  };
-
-  const deletePlaylist = (playlistId: string) => {
-    setPlaylists(playlists.filter(p => p.id !== playlistId));
-    if (selectedPlaylist?.id === playlistId) {
-      setSelectedPlaylist(null);
-    }
-  };
-
-  const removeVideoFromPlaylist = (playlistId: string, videoName: string) => {
-    setPlaylists(playlists.map(p => {
-      if (p.id === playlistId) {
-        return { ...p, videoNames: p.videoNames.filter(name => name !== videoName) };
-      }
-      return p;
-    }));
-    if (selectedPlaylist?.id === playlistId) {
-      setSelectedPlaylist(prev => prev ? { ...prev, videoNames: prev.videoNames.filter(name => name !== videoName) } : null);
-    }
   };
 
   const handleOpenInfoModal = (video: VideoFile) => {
@@ -1866,10 +1824,10 @@ export default function App() {
                                 onChange={(e) => setNewPlaylistName(e.target.value)}
                                 placeholder="Nouvelle liste..." 
                                 className="flex-1 bg-zinc-900 border border-white/5 rounded-xl px-4 py-3 text-sm text-white focus:border-red-600 focus:outline-none transition-all placeholder:text-zinc-600"
-                                onKeyDown={(e) => e.key === 'Enter' && createPlaylist()}
+                                onKeyDown={(e) => e.key === 'Enter' && handleCreatePlaylist()}
                               />
-                              <button 
-                                onClick={createPlaylist}
+                              <button
+                                onClick={handleCreatePlaylist}
                                 disabled={!newPlaylistName.trim()}
                                 className="bg-red-600 hover:bg-red-700 disabled:opacity-30 text-white px-4 py-3 rounded-xl text-xs font-black transition-all active:scale-90 shadow-lg shadow-red-900/20"
                               >

--- a/src/hooks/__tests__/usePlaylists.test.ts
+++ b/src/hooks/__tests__/usePlaylists.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePlaylists } from '../usePlaylists';
+
+beforeEach(() => localStorage.clear());
+
+describe('usePlaylists', () => {
+  it('charge les playlists depuis localStorage', () => {
+    localStorage.setItem('playlists', JSON.stringify([{ id: '1', name: 'Favoris', videoNames: ['a.mkv'] }]));
+    const { result } = renderHook(() => usePlaylists());
+    expect(result.current.playlists).toHaveLength(1);
+    expect(result.current.playlists[0].name).toBe('Favoris');
+  });
+
+  it('crée une playlist (pré-remplie) et la persiste', () => {
+    const { result } = renderHook(() => usePlaylists());
+    act(() => result.current.createPlaylist('Soir', ['film.mkv']));
+    expect(result.current.playlists).toHaveLength(1);
+    expect(result.current.playlists[0]).toMatchObject({ name: 'Soir', videoNames: ['film.mkv'] });
+    expect(JSON.parse(localStorage.getItem('playlists')!)[0].name).toBe('Soir');
+  });
+
+  it('ignore un nom vide', () => {
+    const { result } = renderHook(() => usePlaylists());
+    act(() => result.current.createPlaylist('   '));
+    expect(result.current.playlists).toHaveLength(0);
+  });
+
+  it('ajoute puis retire une vidéo (toggle)', () => {
+    const { result } = renderHook(() => usePlaylists());
+    act(() => result.current.createPlaylist('L'));
+    const id = result.current.playlists[0].id;
+    act(() => result.current.toggleVideoInPlaylist(id, 'v.mkv'));
+    expect(result.current.playlists[0].videoNames).toEqual(['v.mkv']);
+    act(() => result.current.toggleVideoInPlaylist(id, 'v.mkv'));
+    expect(result.current.playlists[0].videoNames).toEqual([]);
+  });
+
+  it('supprime une playlist et désélectionne si besoin', () => {
+    const { result } = renderHook(() => usePlaylists());
+    act(() => result.current.createPlaylist('L'));
+    const pl = result.current.playlists[0];
+    act(() => result.current.setSelectedPlaylist(pl));
+    act(() => result.current.deletePlaylist(pl.id));
+    expect(result.current.playlists).toHaveLength(0);
+    expect(result.current.selectedPlaylist).toBeNull();
+  });
+
+  it('retire une vidéo et met à jour la playlist sélectionnée', () => {
+    const { result } = renderHook(() => usePlaylists());
+    act(() => result.current.createPlaylist('L', ['a.mkv', 'b.mkv']));
+    const pl = result.current.playlists[0];
+    act(() => result.current.setSelectedPlaylist(pl));
+    act(() => result.current.removeVideoFromPlaylist(pl.id, 'a.mkv'));
+    expect(result.current.playlists[0].videoNames).toEqual(['b.mkv']);
+    expect(result.current.selectedPlaylist!.videoNames).toEqual(['b.mkv']);
+  });
+});

--- a/src/hooks/usePlaylists.ts
+++ b/src/hooks/usePlaylists.ts
@@ -1,0 +1,79 @@
+import { useState, useEffect } from 'react';
+import { Playlist } from '../lib/types';
+import { safeSetItem } from '../lib/utils';
+
+const loadPlaylists = (): Playlist[] => {
+  try {
+    const saved = localStorage.getItem('playlists');
+    return saved ? JSON.parse(saved) : [];
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Gère les playlists : état persistant (localStorage), playlist sélectionnée,
+ * et opérations CRUD. Logique extraite d'App.tsx (#17).
+ */
+export function usePlaylists() {
+  const [playlists, setPlaylists] = useState<Playlist[]>(loadPlaylists);
+  const [selectedPlaylist, setSelectedPlaylist] = useState<Playlist | null>(null);
+
+  useEffect(() => {
+    safeSetItem('playlists', JSON.stringify(playlists));
+  }, [playlists]);
+
+  /** Crée une playlist, optionnellement pré-remplie. Ignore un nom vide. */
+  const createPlaylist = (name: string, initialVideoNames: string[] = []) => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const newPlaylist: Playlist = {
+      id: Date.now().toString(),
+      name: trimmed,
+      videoNames: initialVideoNames,
+    };
+    setPlaylists(prev => [...prev, newPlaylist]);
+  };
+
+  /** Ajoute ou retire une vidéo d'une playlist. */
+  const toggleVideoInPlaylist = (playlistId: string, videoName: string) => {
+    setPlaylists(prev => prev.map(p => {
+      if (p.id !== playlistId) return p;
+      const hasVideo = p.videoNames.includes(videoName);
+      return {
+        ...p,
+        videoNames: hasVideo
+          ? p.videoNames.filter(n => n !== videoName)
+          : [...p.videoNames, videoName],
+      };
+    }));
+  };
+
+  const deletePlaylist = (playlistId: string) => {
+    setPlaylists(prev => prev.filter(p => p.id !== playlistId));
+    setSelectedPlaylist(prev => (prev?.id === playlistId ? null : prev));
+  };
+
+  const removeVideoFromPlaylist = (playlistId: string, videoName: string) => {
+    setPlaylists(prev => prev.map(p =>
+      p.id === playlistId
+        ? { ...p, videoNames: p.videoNames.filter(n => n !== videoName) }
+        : p
+    ));
+    setSelectedPlaylist(prev =>
+      prev?.id === playlistId
+        ? { ...prev, videoNames: prev.videoNames.filter(n => n !== videoName) }
+        : prev
+    );
+  };
+
+  return {
+    playlists,
+    selectedPlaylist,
+    setSelectedPlaylist,
+    createPlaylist,
+    toggleVideoInPlaylist,
+    deletePlaylist,
+    removeVideoFromPlaylist,
+  };
+}


### PR DESCRIPTION
## Contexte

Première tranche du découpage d'`App.tsx` ([#17](https://github.com/DZTic/localstream/issues/17)), tranche sûre et bien délimitée : extraction de toute la gestion des playlists dans un hook dédié.

## Changements

- **`src/hooks/usePlaylists.ts`** : possède l'état `playlists` (chargement + persistance localStorage), `selectedPlaylist`, et les opérations `createPlaylist` / `toggleVideoInPlaylist` / `deletePlaylist` / `removeVideoFromPlaylist`.
- **`App.tsx`** : consomme le hook ; supprime l'état, l'effet de persistance et les 4 fonctions correspondantes. La saisie UI (`newPlaylistName`, `showPlaylistSelector`) et la lecture (`activePlaylist`) restent dans le composant ; un petit wrapper `handleCreatePlaylist` relie le champ de saisie au hook.

Au passage, les mutations utilisent désormais des **mises à jour fonctionnelles** (`setPlaylists(prev => …)`), évitant les closures sur un état potentiellement périmé.

## Tests

`src/hooks/__tests__/usePlaylists.test.ts` — **6 tests** : chargement depuis localStorage, création (pré-remplie) + persistance, nom vide ignoré, toggle d'une vidéo, suppression + désélection, retrait d'une vidéo synchronisé avec la playlist sélectionnée.

## Vérification
- ✅ `npm run lint`
- ✅ `npm test` — **51/51** (45 + 6)
- ✅ `npm run build`

## Suite
Prochaines tranches possibles de #17 (à valider) : `useWatchedState`, `useScan`, puis extraction des écrans (Playlists, Historique, Paramètres) et de la modale Info en composants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)