### PR TITLE
fix(player): fusionner les options de sous-titres redondantes (#18)

### DIFF
--- a/android/app/src/main/java/com/localstream/app/PlayerActivity.java
+++ b/android/app/src/main/java/com/localstream/app/PlayerActivity.java
@@ -356,7 +356,9 @@ public class PlayerActivity extends Activity {
     }
 
     private void showSettingsDialog() {
-        String[] options = {"Vitesse de lecture", "Pistes Audio", "Sous-titres", "Dimension de l'écran", "Ajouter un fichier de sous-titres (.srt, .vtt)"};
+        // L'ajout d'un fichier de sous-titres est regroupé dans le menu "Sous-titres"
+        // (cf. showSubtitleDialog) pour éviter deux entrées redondantes.
+        String[] options = {"Vitesse de lecture", "Pistes Audio", "Sous-titres", "Dimension de l'écran"};
         androidx.appcompat.app.AlertDialog.Builder builder = new androidx.appcompat.app.AlertDialog.Builder(this, R.style.CustomDialogTheme);
         builder.setTitle("Options du lecteur");
         builder.setItems(options, (dialog, which) -> {
@@ -372,9 +374,6 @@ public class PlayerActivity extends Activity {
                     break;
                 case 3: // Resize
                     showResizeDialog();
-                    break;
-                case 4: // Ajout manuel
-                    pickLocalSubtitle();
                     break;
             }
         });
@@ -411,7 +410,7 @@ public class PlayerActivity extends Activity {
     }
 
     private void showSubtitleDialog() {
-        String[] options = {"Désactiver les sous-titres", "Choisir une piste de sous-titres"};
+        String[] options = {"Désactiver les sous-titres", "Choisir une piste de sous-titres", "Ajouter un fichier (.srt, .vtt)…"};
         androidx.appcompat.app.AlertDialog.Builder builder =
             new androidx.appcompat.app.AlertDialog.Builder(this, R.style.CustomDialogTheme);
         builder.setTitle("Sous-titres");
@@ -425,7 +424,7 @@ public class PlayerActivity extends Activity {
                         .build()
                 );
                 Toast.makeText(this, "Sous-titres désactivés", Toast.LENGTH_SHORT).show();
-            } else {
+            } else if (which == 1) {
                 // Réactiver les pistes texte puis ouvrir le sélecteur natif
                 player.setTrackSelectionParameters(
                     player.getTrackSelectionParameters()
@@ -434,6 +433,9 @@ public class PlayerActivity extends Activity {
                         .build()
                 );
                 showTrackDialog(C.TRACK_TYPE_TEXT, "Piste de sous-titres");
+            } else {
+                // Ajouter un fichier de sous-titres externe (.srt, .vtt)
+                pickLocalSubtitle();
             }
         });
         builder.show();


### PR DESCRIPTION
## Contexte

Résout [#18](https://github.com/DZTic/localstream/issues/18). Dans le lecteur natif Android, le menu **« Options du lecteur »** affichait deux entrées liées aux sous-titres :
- **Sous-titres** (activer/désactiver/choisir une piste)
- **Ajouter un fichier de sous-titres (.srt, .vtt)**

…que l'on peut regrouper en une seule, comme le suggère l'issue.

## Changements (`PlayerActivity.java`)

- Le menu principal ne contient plus qu'une entrée **Sous-titres** (suppression de l'entrée « Ajouter un fichier… » et de son `case`).
- La boîte de dialogue **Sous-titres** (`showSubtitleDialog`) propose désormais trois choix :
  1. Désactiver les sous-titres
  2. Choisir une piste de sous-titres
  3. **Ajouter un fichier (.srt, .vtt)…** → ouvre le sélecteur de fichier (`pickLocalSubtitle`)

Aucun changement de comportement : l'ajout de fichier reste accessible, simplement regroupé au bon endroit.

## Vérification
- ⚠️ Build Android non exécuté ici (pas de SDK dans l'environnement) ; modification Java triviale (tableau d'options + `switch`), relue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)