### PR TITLE
refactor: extraire le hook useWatchedState d'App.tsx (#17)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { filterAndSortVideos } from './lib/sorting';
 import { getHeroCandidates } from './lib/hero';
 import { useTmdbMetadata } from './hooks/useTmdbMetadata';
 import { usePlaylists } from './hooks/usePlaylists';
+import { useWatchedState } from './hooks/useWatchedState';
 import { VideoRow } from './components/VideoRow';
 import { BottomNav } from './components/BottomNav';
 
@@ -62,71 +63,6 @@ export default function App() {
   };
 
   
-  // TMDB Credentials & Posters
-  const [watchedVideos, setWatchedVideos] = useState<Record<string, boolean>>(() => {
-    try {
-      const saved = localStorage.getItem('watchedVideos');
-      return saved ? JSON.parse(saved) : {};
-    } catch {
-      return {};
-    }
-  });
-  
-  const toggleWatched = (videoName: string) => {
-    setWatchedVideos(prev => {
-      // Trouver si c'est un groupe de vidéos (série ou collection)
-      const group = groupedVideos.find(v => (v.seriesName === videoName || v.name === videoName) && v.isSeriesGroup);
-      
-      let isCurrentlyWatched;
-      if (group && group.episodes) {
-        // Pour un groupe, on considère qu'il est vu si TOUS les épisodes sont vus
-        isCurrentlyWatched = group.episodes.every(ep => !!prev[ep.name]);
-      } else {
-        isCurrentlyWatched = !!prev[videoName];
-      }
-
-      const newState = { ...prev };
-      const targetValue = !isCurrentlyWatched;
-      
-      if (group && group.episodes) {
-        // On marque le nom du groupe ET tous ses épisodes
-        newState[videoName] = targetValue;
-        group.episodes.forEach(ep => {
-          newState[ep.name] = targetValue;
-        });
-      } else {
-        // C'est un épisode seul
-        newState[videoName] = targetValue;
-        
-        // Propagation automatique vers le groupe de série s'il existe
-        const parentSeries = groupedVideos.find(g => g.isSeriesGroup && g.episodes?.some(ep => ep.name === videoName));
-        if (parentSeries) {
-          const seriesKey = parentSeries.seriesName || parentSeries.name;
-          const allEpsWatched = parentSeries.episodes!.every(ep => !!newState[ep.name]);
-          newState[seriesKey] = allEpsWatched;
-        }
-      }
-      
-      safeSetItem('watchedVideos', JSON.stringify(newState));
-      return newState;
-    });
-  };
-
-  const resetProgress = (videoName: string) => {
-    setWatchProgress(prev => {
-      const newState = { ...prev };
-      delete newState[videoName];
-      safeSetItem('watchProgress', JSON.stringify(newState));
-      return newState;
-    });
-    setWatchPositions(prev => {
-      const newState = { ...prev };
-      delete newState[videoName];
-      safeSetItem('watchPositions', JSON.stringify(newState));
-      return newState;
-    });
-  };
-
   const [tmdbApiKey, setTmdbApiKey] = useState(localStorage.getItem('tmdbApiKey') || '');
   const [videoDurations, setVideoDurations] = useState<Record<string, number>>({});
 
@@ -134,15 +70,6 @@ export default function App() {
   const [filterGenre, setFilterGenre] = useState<number | 'all'>('all');
   const [filterResolution, setFilterResolution] = useState<string | 'all'>('all');
 
-  const [recentlyWatched, setRecentlyWatched] = useState<string[]>(() => {
-    try {
-      const saved = localStorage.getItem('recentlyWatched');
-      return saved ? JSON.parse(saved) : [];
-    } catch {
-      return [];
-    }
-  });
-  
   const [subtitles, setSubtitles] = useState<Subtitle[]>([]);
   const [localSubtitles, setLocalSubtitles] = useState<Subtitle[]>([]);
   const [isSearchingSubs, setIsSearchingSubs] = useState(false);
@@ -211,42 +138,13 @@ export default function App() {
   const [newPlaylistName, setNewPlaylistName] = useState('');
   
   const [newHistoryItemName, setNewHistoryItemName] = useState('');
-  const [forceAvailableVideos, setForceAvailableVideos] = useState<Record<string, boolean>>(() => {
-    try {
-      const saved = localStorage.getItem('forceAvailableVideos');
-      return saved ? JSON.parse(saved) : {};
-    } catch {
-      return {};
-    }
-  });
 
-  const toggleForceAvailable = (videoName: string) => {
-    setForceAvailableVideos(prev => {
-      const newState = { ...prev, [videoName]: !prev[videoName] };
-      safeSetItem('forceAvailableVideos', JSON.stringify(newState));
-      return newState;
-    });
-  };
-
-  const addManualHistoryItem = () => {
-    if (!newHistoryItemName.trim()) return;
-    const name = newHistoryItemName.trim();
-    
-    setWatchedVideos(prev => {
-      const newState = { ...prev, [name]: true };
-      safeSetItem('watchedVideos', JSON.stringify(newState));
-      return newState;
-    });
-    
-    setForceAvailableVideos(prev => {
-      const newState = { ...prev, [name]: true };
-      safeSetItem('forceAvailableVideos', JSON.stringify(newState));
-      return newState;
-    });
-
+  // Ajoute l'entrée saisie puis vide le champ.
+  const handleAddHistory = () => {
+    addManualHistoryItem(newHistoryItemName);
     setNewHistoryItemName('');
   };
-  
+
   const [isScanning, setIsScanning] = useState(false);
   const [diagLogs, setDiagLogs] = useState<string[]>([]);
   const addLog = (msg: string) => {
@@ -265,30 +163,21 @@ export default function App() {
   const [externalPlayers, setExternalPlayers] = useState<{name: string, packageId: string}[]>([]);
   const [selectedExternalPlayer, setSelectedExternalPlayer] = useState<string>(localStorage.getItem('selectedExternalPlayer') || '');
 
-  const [watchProgress, setWatchProgress] = useState<Record<string, number>>(() => {
-    try {
-      const saved = localStorage.getItem('watchProgress');
-      return saved ? JSON.parse(saved) : {};
-    } catch {
-      return {};
-    }
-  });
-
-  const [watchPositions, setWatchPositions] = useState<Record<string, number>>(() => {
-    try {
-      const saved = localStorage.getItem('watchPositions');
-      return saved ? JSON.parse(saved) : {};
-    } catch {
-      return {};
-    }
-  });
+  // État de visionnage : vu/non vu, progression, reprise, historique récent.
+  const {
+    watchedVideos,
+    watchProgress, setWatchProgress,
+    watchPositions, setWatchPositions,
+    recentlyWatched, setRecentlyWatched,
+    forceAvailableVideos,
+    toggleWatched,
+    resetProgress,
+    toggleForceAvailable,
+    addManualHistoryItem,
+  } = useWatchedState(groupedVideos);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
-
-  useEffect(() => {
-    safeSetItem('watchPositions', JSON.stringify(watchPositions));
-  }, [watchPositions]);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -1365,10 +1254,10 @@ export default function App() {
                           value={newHistoryItemName}
                           onChange={(e) => setNewHistoryItemName(e.target.value)}
                           className="flex-1 bg-zinc-900 border border-white/10 rounded-xl px-4 py-2 text-sm text-white focus:border-red-600 focus:outline-none transition-all placeholder:text-zinc-500"
-                          onKeyDown={(e) => e.key === 'Enter' && addManualHistoryItem()}
+                          onKeyDown={(e) => e.key === 'Enter' && handleAddHistory()}
                         />
                         <button
-                          onClick={addManualHistoryItem}
+                          onClick={handleAddHistory}
                           disabled={!newHistoryItemName.trim()}
                           className="bg-red-600 hover:bg-red-700 disabled:opacity-30 text-white px-4 py-2 rounded-xl text-xs font-black transition-all active:scale-95 shadow-lg shadow-red-900/20 whitespace-nowrap"
                         >

--- a/src/hooks/__tests__/useWatchedState.test.ts
+++ b/src/hooks/__tests__/useWatchedState.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useWatchedState } from '../useWatchedState';
+import type { VideoFile } from '../../lib/types';
+
+const v = (name: string, extra: Partial<VideoFile> = {}): VideoFile => ({
+  url: 'blob:x', name, type: 'video/mp4', path: name, ...extra,
+});
+
+const serie = v('Show', {
+  isSeriesGroup: true, seriesName: 'Show',
+  episodes: [v('Show.S01E01.mkv'), v('Show.S01E02.mkv')],
+});
+
+beforeEach(() => localStorage.clear());
+
+describe('useWatchedState', () => {
+  it('charge l\'état vu depuis localStorage', () => {
+    localStorage.setItem('watchedVideos', JSON.stringify({ 'Film.mkv': true }));
+    const { result } = renderHook(() => useWatchedState([]));
+    expect(result.current.watchedVideos['Film.mkv']).toBe(true);
+  });
+
+  it('bascule un film isolé et persiste', () => {
+    const { result } = renderHook(() => useWatchedState([v('Film.mkv')]));
+    act(() => result.current.toggleWatched('Film.mkv'));
+    expect(result.current.watchedVideos['Film.mkv']).toBe(true);
+    expect(JSON.parse(localStorage.getItem('watchedVideos')!)['Film.mkv']).toBe(true);
+    act(() => result.current.toggleWatched('Film.mkv'));
+    expect(result.current.watchedVideos['Film.mkv']).toBe(false);
+  });
+
+  it('marquer une série marque tous ses épisodes', () => {
+    const { result } = renderHook(() => useWatchedState([serie]));
+    act(() => result.current.toggleWatched('Show'));
+    expect(result.current.watchedVideos['Show']).toBe(true);
+    expect(result.current.watchedVideos['Show.S01E01.mkv']).toBe(true);
+    expect(result.current.watchedVideos['Show.S01E02.mkv']).toBe(true);
+  });
+
+  it('la série devient vue quand le dernier épisode est marqué', () => {
+    const { result } = renderHook(() => useWatchedState([serie]));
+    act(() => result.current.toggleWatched('Show.S01E01.mkv'));
+    expect(result.current.watchedVideos['Show']).toBeFalsy();
+    act(() => result.current.toggleWatched('Show.S01E02.mkv'));
+    expect(result.current.watchedVideos['Show']).toBe(true);
+  });
+
+  it('resetProgress efface progression et position', () => {
+    const { result } = renderHook(() => useWatchedState([]));
+    act(() => {
+      result.current.setWatchProgress({ 'F.mkv': 42 });
+      result.current.setWatchPositions({ 'F.mkv': 1000 });
+    });
+    act(() => result.current.resetProgress('F.mkv'));
+    expect(result.current.watchProgress['F.mkv']).toBeUndefined();
+    expect(result.current.watchPositions['F.mkv']).toBeUndefined();
+  });
+
+  it('addManualHistoryItem marque vu + disponible, ignore le vide', () => {
+    const { result } = renderHook(() => useWatchedState([]));
+    act(() => result.current.addManualHistoryItem('   '));
+    expect(result.current.watchedVideos).toEqual({});
+    act(() => result.current.addManualHistoryItem('Mon Film'));
+    expect(result.current.watchedVideos['Mon Film']).toBe(true);
+    expect(result.current.forceAvailableVideos['Mon Film']).toBe(true);
+  });
+
+  it('toggleForceAvailable bascule la disponibilité', () => {
+    const { result } = renderHook(() => useWatchedState([]));
+    act(() => result.current.toggleForceAvailable('X'));
+    expect(result.current.forceAvailableVideos['X']).toBe(true);
+    act(() => result.current.toggleForceAvailable('X'));
+    expect(result.current.forceAvailableVideos['X']).toBe(false);
+  });
+});

--- a/src/hooks/useWatchedState.ts
+++ b/src/hooks/useWatchedState.ts
@@ -1,0 +1,126 @@
+import { useState, useEffect } from 'react';
+import { VideoFile } from '../lib/types';
+import { safeSetItem } from '../lib/utils';
+
+const loadJson = <T,>(key: string, fallback: T): T => {
+  try {
+    const saved = localStorage.getItem(key);
+    return saved ? JSON.parse(saved) : fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+/**
+ * Gère l'état de visionnage : vu/non vu, progression, position de reprise,
+ * historique récent et disponibilité forcée. Logique extraite d'App.tsx (#17).
+ *
+ * `groupedVideos` est nécessaire à `toggleWatched` pour propager l'état
+ * vu entre une série et ses épisodes.
+ */
+export function useWatchedState(groupedVideos: VideoFile[]) {
+  const [watchedVideos, setWatchedVideos] = useState<Record<string, boolean>>(() => loadJson('watchedVideos', {}));
+  const [watchProgress, setWatchProgress] = useState<Record<string, number>>(() => loadJson('watchProgress', {}));
+  const [watchPositions, setWatchPositions] = useState<Record<string, number>>(() => loadJson('watchPositions', {}));
+  const [recentlyWatched, setRecentlyWatched] = useState<string[]>(() => loadJson('recentlyWatched', []));
+  const [forceAvailableVideos, setForceAvailableVideos] = useState<Record<string, boolean>>(() => loadJson('forceAvailableVideos', {}));
+
+  useEffect(() => {
+    safeSetItem('watchPositions', JSON.stringify(watchPositions));
+  }, [watchPositions]);
+
+  /** Bascule l'état vu d'un film/série, avec propagation série ↔ épisodes. */
+  const toggleWatched = (videoName: string) => {
+    setWatchedVideos(prev => {
+      // Trouver si c'est un groupe de vidéos (série ou collection)
+      const group = groupedVideos.find(v => (v.seriesName === videoName || v.name === videoName) && v.isSeriesGroup);
+
+      let isCurrentlyWatched;
+      if (group && group.episodes) {
+        // Pour un groupe, on considère qu'il est vu si TOUS les épisodes sont vus
+        isCurrentlyWatched = group.episodes.every(ep => !!prev[ep.name]);
+      } else {
+        isCurrentlyWatched = !!prev[videoName];
+      }
+
+      const newState = { ...prev };
+      const targetValue = !isCurrentlyWatched;
+
+      if (group && group.episodes) {
+        // On marque le nom du groupe ET tous ses épisodes
+        newState[videoName] = targetValue;
+        group.episodes.forEach(ep => {
+          newState[ep.name] = targetValue;
+        });
+      } else {
+        // C'est un épisode seul
+        newState[videoName] = targetValue;
+
+        // Propagation automatique vers le groupe de série s'il existe
+        const parentSeries = groupedVideos.find(g => g.isSeriesGroup && g.episodes?.some(ep => ep.name === videoName));
+        if (parentSeries) {
+          const seriesKey = parentSeries.seriesName || parentSeries.name;
+          const allEpsWatched = parentSeries.episodes!.every(ep => !!newState[ep.name]);
+          newState[seriesKey] = allEpsWatched;
+        }
+      }
+
+      safeSetItem('watchedVideos', JSON.stringify(newState));
+      return newState;
+    });
+  };
+
+  /** Efface la progression et la position de reprise d'une vidéo. */
+  const resetProgress = (videoName: string) => {
+    setWatchProgress(prev => {
+      const newState = { ...prev };
+      delete newState[videoName];
+      safeSetItem('watchProgress', JSON.stringify(newState));
+      return newState;
+    });
+    setWatchPositions(prev => {
+      const newState = { ...prev };
+      delete newState[videoName];
+      safeSetItem('watchPositions', JSON.stringify(newState));
+      return newState;
+    });
+  };
+
+  const toggleForceAvailable = (videoName: string) => {
+    setForceAvailableVideos(prev => {
+      const newState = { ...prev, [videoName]: !prev[videoName] };
+      safeSetItem('forceAvailableVideos', JSON.stringify(newState));
+      return newState;
+    });
+  };
+
+  /** Ajoute manuellement une entrée d'historique (marquée vue + disponible). */
+  const addManualHistoryItem = (rawName: string) => {
+    const name = rawName.trim();
+    if (!name) return;
+
+    setWatchedVideos(prev => {
+      const newState = { ...prev, [name]: true };
+      safeSetItem('watchedVideos', JSON.stringify(newState));
+      return newState;
+    });
+
+    setForceAvailableVideos(prev => {
+      const newState = { ...prev, [name]: true };
+      safeSetItem('forceAvailableVideos', JSON.stringify(newState));
+      return newState;
+    });
+  };
+
+  return {
+    watchedVideos,
+    watchProgress, setWatchProgress,
+    watchPositions, setWatchPositions,
+    recentlyWatched, setRecentlyWatched,
+    forceAvailableVideos,
+    toggleWatched,
+    resetProgress,
+    toggleForceAvailable,
+    addManualHistoryItem,
+  };
+}


### PR DESCRIPTION
## Contexte

Deuxième tranche du découpage d'`App.tsx` ([#17](https://github.com/DZTic/localstream/issues/17)), après `usePlaylists` (#28). Extraction de tout l'état de **visionnage**.

## Changements

- **`src/hooks/useWatchedState.ts`** : possède `watchedVideos`, `watchProgress`, `watchPositions`, `recentlyWatched`, `forceAvailableVideos` (chargement + persistance localStorage) et les actions `toggleWatched`, `resetProgress`, `toggleForceAvailable`, `addManualHistoryItem`. Reçoit `groupedVideos` en argument (nécessaire à `toggleWatched` pour la propagation série ↔ épisodes).
- **`App.tsx`** : consomme le hook, appelé **après** `useTmdbMetadata` pour disposer de `groupedVideos` ; les setters de lecture (`setWatchProgress/Positions/RecentlyWatched`) restent exposés pour les gestionnaires du lecteur. Un wrapper `handleAddHistory` relie le champ de saisie de l'historique.
- **Tests** : `useWatchedState.test.ts` — 7 tests (toggle film / série / épisode avec propagation, `resetProgress`, ajout manuel + nom vide ignoré, disponibilité forcée, chargement localStorage).

Logique déplacée verbatim (setters fonctionnels conservés) → comportement inchangé.

## Vérification
- ✅ `npm run lint`
- ✅ `npm test` — **65/65** (+7)
- ✅ `npm run build`
- ✅ **App lancée** (`npm run dev`) : montage sans erreur console ; effet de persistance exécuté (`watchPositions` écrit) ; relecture localStorage de données réelles (objet + tableau) sans erreur.

## Suite #17
Tranches restantes : `useScan` (scan natif), puis extraction des écrans (Playlists, Historique, Paramètres) et de la modale Info en composants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)