### PR TITLE
feat(native): port data models and pure domain logic to Kotlin (Phase 2, #34)

### DIFF
--- a/native/app/src/main/java/com/localstream/app/domain/Formatters.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/Formatters.kt
@@ -1,0 +1,89 @@
+package com.localstream.app.domain
+
+import java.util.Locale
+import kotlin.math.floor
+import kotlin.math.ln
+import kotlin.math.pow
+
+object TitleCleaner {
+    fun getCleanTitle(filename: String): String {
+        var title = filename.replace(Regex("\\.[^/.]+$"), "")
+        title = title.replace(Regex("[sS]\\d+(\\s*)?([eE]\\d+)?|(\\d+)(\\s*)?x(\\d+).*", RegexOption.IGNORE_CASE), "")
+        title = title.replace(Regex("(19|20)\\d{2}.*"), "")
+        title = title.replace(Regex("[\\.\\-_]"), " ")
+        title = title.replace(
+            Regex("1080p|720p|2160p|4k|bluray|webrip|hdtv|x264|x265|hevc|vostfr|french|truefrench", RegexOption.IGNORE_CASE),
+            ""
+        )
+        return title.trim()
+            .replace(Regex("[\\(\\[\\{]\\s*$"), "")
+            .replace(Regex("[\\s\\-\\.\\(\\)\\[\\]\\{\\}]+$"), "")
+            .trim()
+    }
+}
+
+object Formatters {
+    private val suspectPaths = listOf(
+        "/dcim/", "/camera/", "/whatsapp/", "/snapchat/", "/instagram/",
+        "/telegram/", "/signal/", "/viber/", "/messenger/", "/tiktok/",
+        "/recordings/", "/screenrecord", "/screen_record", "/voicememos/"
+    )
+
+    private val personalPatterns = listOf(
+        Regex("^vid_\\d{8}_\\d{6}"),
+        Regex("^\\d{8}_\\d{6}"),
+        Regex("^\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}"),
+        Regex("^(img|mov|dsc|dscn|dscf|mvc|sdc|vlc)_?\\d{4,}", RegexOption.IGNORE_CASE),
+        Regex("^(c|m2u|avchd|mts|m2ts)\\d{4,}", RegexOption.IGNORE_CASE),
+        Regex("^(gh|gx|gopr|gp)\\d{4,}", RegexOption.IGNORE_CASE),
+        Regex("^dji_\\d{4}", RegexOption.IGNORE_CASE),
+        Regex("^whatsapp.*(video|vidéo|audio)", RegexOption.IGNORE_CASE),
+        Regex("^snapchat-\\d+"),
+        Regex("^\\d+\\.(mp4|mkv|avi|mov|webm)$", RegexOption.IGNORE_CASE),
+        Regex("^\\d{4}[-_.\\s]\\d{2}[-_.\\s]\\d{2}[\\s_-]\\d{2}[.:_]\\d{2}"),
+        Regex("^screen.?record", RegexOption.IGNORE_CASE),
+        Regex("^\\d{14}\\.(mp4|avi|mkv)$", RegexOption.IGNORE_CASE)
+    )
+
+    fun formatSize(bytes: Long): String {
+        if (bytes <= 0L) return "0 B"
+        val k = 1024.0
+        val sizes = arrayOf("B", "KB", "MB", "GB", "TB")
+        val i = floor(ln(bytes.toDouble()) / ln(k)).toInt()
+        val value = bytes / k.pow(i.toDouble())
+        val formatted = String.format(Locale.US, "%.2f", value).replace(Regex("\\.?0+$"), "")
+        return "$formatted ${sizes[i]}"
+    }
+
+    fun formatDuration(seconds: Long): String {
+        if (seconds <= 0L) return "Inconnue"
+        val h = seconds / 3600
+        val m = (seconds % 3600) / 60
+        return if (h > 0) "${h}h ${m}m" else "${m}m"
+    }
+
+    fun getResolution(name: String): String {
+        val n = name.lowercase()
+        return when {
+            n.contains("2160p") || n.contains("4k") || n.contains("uhd") -> "4K"
+            n.contains("1440p") -> "2K"
+            n.contains("1080p") || n.contains("fhd") -> "1080p"
+            n.contains("720p") || n.contains("hd") -> "720p"
+            n.contains("480p") || n.contains("sd") -> "SD"
+            else -> ""
+        }
+    }
+
+    fun isPersonalVideo(name: String, path: String): Boolean {
+        val n = name.lowercase()
+        val p = path.lowercase().replace('\\', '/')
+        return suspectPaths.any { p.contains(it) } || personalPatterns.any { it.containsMatchIn(n) }
+    }
+}
+
+object TmdbUrls {
+    fun posterUrl(path: String?): String? = path?.let { "https://image.tmdb.org/t/p/w342$it" }
+    fun backdropUrl(path: String?): String? = path?.let { "https://image.tmdb.org/t/p/w1280$it" }
+    fun stillUrl(path: String?): String? = path?.let { "https://image.tmdb.org/t/p/w300$it" }
+}
+

--- a/native/app/src/main/java/com/localstream/app/domain/HeroSelector.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/HeroSelector.kt
@@ -1,0 +1,40 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.VideoItem
+
+object HeroSelector {
+    fun isFullyWatched(
+        v: VideoItem,
+        watchedVideos: Map<String, Boolean>
+    ): Boolean {
+        return if (v.isSeriesGroup) {
+            !v.episodes.isNullOrEmpty() && v.episodes.all { watchedVideos[it.name] == true }
+        } else {
+            watchedVideos[v.name] == true
+        }
+    }
+
+    private fun isInProgress(v: VideoItem, watchProgress: Map<String, Double>): Boolean {
+        val p = watchProgress[v.name] ?: 0.0
+        return p > 0.0 && p < 95.0
+    }
+
+    fun getHeroCandidates(
+        groupedVideos: List<VideoItem>,
+        watchedVideos: Map<String, Boolean>,
+        watchProgress: Map<String, Double> = emptyMap()
+    ): List<VideoItem> {
+        return groupedVideos
+            .filter { !isFullyWatched(it, watchedVideos) }
+            .sortedWith { a, b ->
+                val aProg = isInProgress(a, watchProgress)
+                val bProg = isInProgress(b, watchProgress)
+                if (aProg != bProg) {
+                    if (aProg) -1 else 1
+                } else {
+                    b.lastModified.compareTo(a.lastModified)
+                }
+            }
+    }
+}
+

--- a/native/app/src/main/java/com/localstream/app/domain/VideoFilterSorter.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/VideoFilterSorter.kt
@@ -1,0 +1,97 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.FilterSortOptions
+import com.localstream.app.domain.model.ResolutionFilter
+import com.localstream.app.domain.model.SortBy
+import com.localstream.app.domain.model.VideoItem
+
+object VideoFilterSorter {
+    fun filterAndSortVideos(
+        videos: List<VideoItem>,
+        opts: FilterSortOptions
+    ): List<VideoItem> {
+        val filteredByGenre = filterByGenre(videos, opts)
+        val filteredByRes = filterByResolution(filteredByGenre, opts)
+        return sortVideos(filteredByRes, opts)
+    }
+
+    private fun filterByGenre(videos: List<VideoItem>, opts: FilterSortOptions): List<VideoItem> {
+        val g = opts.filterGenre ?: return videos
+        return videos.filter { v ->
+            val lookupKey = if (v.isSeriesGroup) v.seriesName ?: "" else v.name
+            opts.videoGenres[lookupKey]?.contains(g) == true
+        }
+    }
+
+    private fun filterByResolution(videos: List<VideoItem>, opts: FilterSortOptions): List<VideoItem> {
+        if (opts.filterResolution == ResolutionFilter.ALL) return videos
+        return videos.filter { v ->
+            val firstName = if (v.isSeriesGroup) v.episodes?.firstOrNull()?.name ?: v.name else v.name
+            val n = firstName.lowercase()
+            when (opts.filterResolution) {
+                ResolutionFilter.FOUR_K -> n.contains("2160p") || n.contains("4k")
+                ResolutionFilter.TWO_K -> n.contains("1440p")
+                ResolutionFilter.ONE_THOUSAND_EIGHTY_P -> n.contains("1080p")
+                ResolutionFilter.SEVEN_HUNDRED_TWENTY_P -> n.contains("720p")
+                ResolutionFilter.SD -> !Regex("1080p|720p|2160p|4k", RegexOption.IGNORE_CASE).containsMatchIn(n)
+                ResolutionFilter.ALL -> true
+            }
+        }
+    }
+
+    private fun sortVideos(videos: List<VideoItem>, opts: FilterSortOptions): List<VideoItem> {
+        return videos.sortedWith { a, b ->
+            val aWatched = isItemWatched(a, opts.watchedVideos)
+            val bWatched = isItemWatched(b, opts.watchedVideos)
+            if (aWatched != bWatched) {
+                if (aWatched) 1 else -1
+            } else {
+                compareItemsByCriteria(a, b, opts)
+            }
+        }
+    }
+
+    private fun isItemWatched(v: VideoItem, watchedVideos: Map<String, Boolean>): Boolean {
+        return if (v.isSeriesGroup) {
+            v.episodes.orEmpty().all { watchedVideos[it.name] == true }
+        } else {
+            watchedVideos[v.name] == true
+        }
+    }
+
+    private fun compareItemsByCriteria(a: VideoItem, b: VideoItem, opts: FilterSortOptions): Int {
+        return when (opts.sortBy) {
+            SortBy.ALPHA -> compareAlpha(a, b)
+            SortBy.DATE -> compareDate(a, b, opts.releaseDates)
+            SortBy.SIZE -> compareSize(a, b)
+            SortBy.DURATION -> compareDuration(a, b, opts.videoDurations)
+        }
+    }
+
+    private fun compareAlpha(a: VideoItem, b: VideoItem): Int {
+        val nameA = if (a.isSeriesGroup) a.seriesName ?: "" else a.name
+        val nameB = if (b.isSeriesGroup) b.seriesName ?: "" else b.name
+        return nameA.compareTo(nameB)
+    }
+
+    private fun compareDate(a: VideoItem, b: VideoItem, releaseDates: Map<String, String>): Int {
+        val lookupA = if (a.isSeriesGroup) a.seriesName ?: "" else a.name
+        val lookupB = if (b.isSeriesGroup) b.seriesName ?: "" else b.name
+        val dateA = releaseDates[lookupA] ?: a.lastModified.toString()
+        val dateB = releaseDates[lookupB] ?: b.lastModified.toString()
+        return dateB.compareTo(dateA)
+    }
+
+    private fun compareSize(a: VideoItem, b: VideoItem): Int {
+        val sizeA = if (a.isSeriesGroup) a.episodes.orEmpty().sumOf { it.size } else a.size
+        val sizeB = if (b.isSeriesGroup) b.episodes.orEmpty().sumOf { it.size } else b.size
+        return sizeB.compareTo(sizeA)
+    }
+
+    private fun compareDuration(a: VideoItem, b: VideoItem, videoDurations: Map<String, Long>): Int {
+        val durA = if (a.isSeriesGroup) a.episodes.orEmpty().sumOf { videoDurations[it.name] ?: 0L } else videoDurations[a.name] ?: 0L
+        val durB = if (b.isSeriesGroup) b.episodes.orEmpty().sumOf { videoDurations[it.name] ?: 0L } else videoDurations[b.name] ?: 0L
+        return durB.compareTo(durA)
+    }
+}
+

--- a/native/app/src/main/java/com/localstream/app/domain/VideoGrouper.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/VideoGrouper.kt
@@ -1,0 +1,132 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.MovieCollection
+import com.localstream.app.domain.model.VideoItem
+
+object VideoGrouper {
+    fun groupVideos(
+        videos: List<VideoItem>,
+        movieCollections: Map<String, MovieCollection>,
+        releaseDates: Map<String, String>,
+        whitelistedVideos: Set<String>
+    ): List<VideoItem> {
+        val filteredVideos = videos.filter { video ->
+            whitelistedVideos.contains(video.name) || !Formatters.isPersonalVideo(video.name, video.path)
+        }
+
+        val (seriesMap, standaloneList) = partitionSeriesAndStandalone(filteredVideos)
+        val seriesResult = formatSeriesGroups(seriesMap)
+        val (sagaGroups, remainingStandalone) = groupMovieSagas(standaloneList, movieCollections, releaseDates)
+
+        return seriesResult + sagaGroups + remainingStandalone
+    }
+
+    private fun partitionSeriesAndStandalone(
+        videos: List<VideoItem>
+    ): Pair<Map<String, List<VideoItem>>, List<VideoItem>> {
+        val groups = mutableMapOf<String, MutableList<VideoItem>>()
+        val standalone = mutableListOf<VideoItem>()
+
+        videos.forEach { video ->
+            val match = VideoNameParser.SEASON_EPISODE_REGEX.find(video.name)
+            if (match != null || !video.seriesName.isNullOrEmpty()) {
+                val updatedVideo = extractSeriesFields(video, match)
+                val finalName = resolveSeriesName(updatedVideo, match)
+                groups.getOrPut(finalName) { mutableListOf() }.add(updatedVideo)
+            } else {
+                standalone.add(video.copy(cleanTitle = TitleCleaner.getCleanTitle(video.name)))
+            }
+        }
+        return Pair(groups, standalone)
+    }
+
+    private fun extractSeriesFields(video: VideoItem, match: MatchResult?): VideoItem {
+        if (match == null) return video
+        val groupValues = match.groupValues
+        val sStr = if (groupValues[1].isNotEmpty()) groupValues[1] else groupValues[4]
+        val eStr = if (groupValues[3].isNotEmpty()) groupValues[3] else groupValues[6]
+        return video.copy(season = sStr.toIntOrNull(), episode = eStr.toIntOrNull())
+    }
+
+    private fun resolveSeriesName(video: VideoItem, match: MatchResult?): String {
+        val sName = video.seriesName ?: if (match != null) {
+            video.name.substring(0, match.range.first)
+                .replace(Regex("[\\.\\-_/\\\\\\[\\]\\(\\)]"), " ")
+                .trim()
+                .replace(Regex("[\\s\\-]+$"), "")
+        } else {
+            TitleCleaner.getCleanTitle(video.name)
+        }
+        return if (sName.isEmpty()) "Série Inconnue" else sName
+    }
+
+    private fun formatSeriesGroups(groups: Map<String, List<VideoItem>>): List<VideoItem> {
+        return groups.map { (seriesName, epList) ->
+            val sorted = epList.sortedWith { a, b ->
+                val sComp = (a.season ?: 0).compareTo(b.season ?: 0)
+                if (sComp != 0) sComp else (a.episode ?: 0).compareTo(b.episode ?: 0)
+            }
+            val first = sorted.first()
+            VideoItem(
+                url = first.url,
+                name = seriesName,
+                type = "series",
+                path = first.path,
+                isSeriesGroup = true,
+                isTvSeries = true,
+                episodes = sorted,
+                seriesName = seriesName
+            )
+        }
+    }
+
+    private fun groupMovieSagas(
+        standaloneVideos: List<VideoItem>,
+        movieCollections: Map<String, MovieCollection>,
+        releaseDates: Map<String, String>
+    ): Pair<List<VideoItem>, List<VideoItem>> {
+        val colMap = mutableMapOf<String, MutableList<VideoItem>>()
+        val colNames = mutableMapOf<String, String>()
+        val usedNames = mutableSetOf<String>()
+
+        standaloneVideos.forEach { v ->
+            val col = movieCollections[v.name]
+            if (col != null) {
+                val key = "col_${col.id}"
+                colNames[key] = col.name
+                colMap.getOrPut(key) { mutableListOf() }.add(v)
+                usedNames.add(v.name)
+            }
+        }
+
+        val sagas = mutableListOf<VideoItem>()
+        colMap.forEach { (key, films) ->
+            val colName = colNames[key] ?: ""
+            if (films.size > 1) {
+                val sorted = films.sortedWith { a, b ->
+                    val dA = releaseDates[a.name] ?: ""
+                    val dB = releaseDates[b.name] ?: ""
+                    val dComp = dA.compareTo(dB)
+                    if (dComp != 0) dComp else a.name.compareTo(b.name)
+                }
+                val first = sorted.first()
+                sagas.add(
+                    first.copy(
+                        name = colName,
+                        type = "series",
+                        isSeriesGroup = true,
+                        isTvSeries = false,
+                        episodes = sorted,
+                        seriesName = colName
+                    )
+                )
+            } else {
+                films.forEach { usedNames.remove(it.name) }
+            }
+        }
+
+        val remaining = standaloneVideos.filter { !usedNames.contains(it.name) }
+        return Pair(sagas, remaining)
+    }
+}
+

--- a/native/app/src/main/java/com/localstream/app/domain/VideoNameParser.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/VideoNameParser.kt
@@ -1,0 +1,86 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.SeriesInfo
+import com.localstream.app.domain.model.SubtitleEntry
+
+object VideoNameParser {
+    val VIDEO_EXT_REGEX = Regex("\\.(mp4|mkv|webm|avi|mov)$", RegexOption.IGNORE_CASE)
+    val SUBTITLE_EXT_REGEX = Regex("\\.(srt|vtt|ass|ssa)$", RegexOption.IGNORE_CASE)
+
+    private val LANG_SUFFIX_REGEX = Regex(
+        "\\.(fr|en|es|de|it|pt|nl|pl|ru|ja|zh|ko|ar|he|tr|sv|da|fi|nb|uk|cs|sk|hu|ro|hr|sr|bg|el|vi|th|hi|id|ms|fa)$",
+        RegexOption.IGNORE_CASE
+    )
+
+    val SEASON_EPISODE_REGEX = Regex("[sS](\\d+)(\\s*)[eE](\\d+)|(\\d+)(\\s*)x(\\d+)")
+    private val SEASON_FOLDER_REGEX = Regex("Saison\\s*(\\d+)|Season\\s*(\\d+)|S(\\d+)", RegexOption.IGNORE_CASE)
+
+    fun videoBaseName(fileName: String): String =
+        fileName.replace(Regex("\\.\\w+$"), "").lowercase()
+
+    fun subtitleBaseName(fileName: String): String =
+        fileName.replace(Regex("\\.\\w+$"), "").replace(LANG_SUFFIX_REGEX, "").lowercase()
+
+    fun parentFolder(relativePath: String): String {
+        val normalized = relativePath.replace('\\', '/').trimEnd('/')
+        val idx = normalized.lastIndexOf('/')
+        return if (idx == -1) "" else normalized.substring(0, idx)
+    }
+
+    fun parseSeriesInfo(fileName: String, fullPath: String? = null): SeriesInfo {
+        val match = SEASON_EPISODE_REGEX.find(fileName)
+        if (match != null) {
+            val groupValues = match.groupValues
+            val sStr = if (groupValues[1].isNotEmpty()) groupValues[1] else groupValues[4]
+            val eStr = if (groupValues[3].isNotEmpty()) groupValues[3] else groupValues[6]
+            var seriesName = fileName.substring(0, match.range.first)
+                .replace(Regex("[\\.\\-_/\\\\\\[\\]\\(\\)]"), " ")
+                .trim()
+                .replace(Regex("[\\s\\-]+$"), "")
+            if (seriesName.isEmpty()) seriesName = "Série Inconnue"
+            return SeriesInfo(seriesName = seriesName, season = sStr.toIntOrNull(), episode = eStr.toIntOrNull())
+        }
+        return parseFolderSeriesInfo(fileName, fullPath)
+    }
+
+    private fun parseFolderSeriesInfo(fileName: String, fullPath: String?): SeriesInfo {
+        val pathParts = (fullPath ?: "").split('/').filter { it.isNotEmpty() }
+        if (pathParts.size >= 2) {
+            val lastFolder = pathParts[pathParts.size - 2]
+            val sMatch = SEASON_FOLDER_REGEX.find(lastFolder)
+            if (sMatch != null) {
+                val sVal = sMatch.groupValues[1].ifEmpty {
+                    sMatch.groupValues[2].ifEmpty { sMatch.groupValues[3] }
+                }
+                val seriesName = if (pathParts.size >= 3) pathParts[pathParts.size - 3] else "Série Inconnue"
+                val epMatch = Regex("^(\\d+)").find(fileName)
+                return SeriesInfo(
+                    seriesName = seriesName,
+                    season = sVal.toIntOrNull(),
+                    episode = epMatch?.groupValues?.get(1)?.toIntOrNull()
+                )
+            }
+        }
+        return SeriesInfo()
+    }
+
+    fun buildSubtitleIndex(subtitles: List<SubtitleEntry>): Map<String, SubtitleEntry> {
+        val index = mutableMapOf<String, SubtitleEntry>()
+        for (sub in subtitles) {
+            if (!SUBTITLE_EXT_REGEX.containsMatchIn(sub.name)) continue
+            val key = "${sub.folder}/${subtitleBaseName(sub.name)}"
+            index[key] = sub
+        }
+        return index
+    }
+
+    fun matchSubtitle(
+        index: Map<String, SubtitleEntry>,
+        videoName: String,
+        videoFolder: String
+    ): SubtitleEntry? {
+        val key = "$videoFolder/${videoBaseName(videoName)}"
+        return index[key]
+    }
+}
+

--- a/native/app/src/main/java/com/localstream/app/domain/model/FilterSortOptions.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/FilterSortOptions.kt
@@ -1,0 +1,20 @@
+package com.localstream.app.domain.model
+
+enum class SortBy {
+    ALPHA, DATE, SIZE, DURATION
+}
+
+enum class ResolutionFilter {
+    ALL, FOUR_K, TWO_K, ONE_THOUSAND_EIGHTY_P, SEVEN_HUNDRED_TWENTY_P, SD
+}
+
+data class FilterSortOptions(
+    val sortBy: SortBy = SortBy.ALPHA,
+    val filterGenre: Int? = null,
+    val filterResolution: ResolutionFilter = ResolutionFilter.ALL,
+    val releaseDates: Map<String, String> = emptyMap(),
+    val videoGenres: Map<String, List<Int>> = emptyMap(),
+    val videoDurations: Map<String, Long> = emptyMap(),
+    val watchedVideos: Map<String, Boolean> = emptyMap(),
+)
+

--- a/native/app/src/main/java/com/localstream/app/domain/model/MovieCollection.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/MovieCollection.kt
@@ -1,0 +1,7 @@
+package com.localstream.app.domain.model
+
+data class MovieCollection(
+    val id: String,
+    val name: String,
+)
+

--- a/native/app/src/main/java/com/localstream/app/domain/model/PlaylistInfo.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/PlaylistInfo.kt
@@ -1,0 +1,8 @@
+package com.localstream.app.domain.model
+
+data class PlaylistInfo(
+    val id: String,
+    val name: String,
+    val videoNames: List<String> = emptyList(),
+)
+

--- a/native/app/src/main/java/com/localstream/app/domain/model/ScanModels.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/ScanModels.kt
@@ -1,0 +1,14 @@
+package com.localstream.app.domain.model
+
+data class SeriesInfo(
+    val seriesName: String? = null,
+    val season: Int? = null,
+    val episode: Int? = null,
+)
+
+data class SubtitleEntry(
+    val name: String,
+    val folder: String,
+    val uri: String,
+)
+

--- a/native/app/src/main/java/com/localstream/app/domain/model/SubtitleInfo.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/SubtitleInfo.kt
@@ -1,0 +1,9 @@
+package com.localstream.app.domain.model
+
+data class SubtitleInfo(
+    val id: String,
+    val language: String,
+    val filename: String,
+    val url: String? = null,
+)
+

--- a/native/app/src/main/java/com/localstream/app/domain/model/TmdbGenre.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/TmdbGenre.kt
@@ -1,0 +1,38 @@
+package com.localstream.app.domain.model
+
+enum class TmdbGenre(val id: Int, val genreName: String) {
+    ACTION(28, "Action"),
+    ADVENTURE(12, "Aventure"),
+    ANIMATION(16, "Animation"),
+    COMEDY(35, "Comédie"),
+    CRIME(80, "Crime"),
+    DOCUMENTARY(99, "Documentaire"),
+    DRAMA(18, "Drame"),
+    FAMILY(10751, "Familial"),
+    FANTASY(14, "Fantastique"),
+    HISTORY(36, "Histoire"),
+    HORROR(27, "Horreur"),
+    MUSIC(10402, "Musique"),
+    MYSTERY(9648, "Mystère"),
+    ROMANCE(10749, "Romance"),
+    SCIENCE_FICTION(878, "Science-Fiction"),
+    TV_MOVIE(10770, "Téléfilm"),
+    THRILLER(53, "Thriller"),
+    WAR(10752, "Guerre"),
+    WESTERN(37, "Western"),
+    ACTION_ADVENTURE(10759, "Action & Adventure"),
+    KIDS(10762, "Kids"),
+    NEWS(10763, "News"),
+    REALITY(10764, "Reality"),
+    SCI_FI_FANTASY(10765, "Sci-Fi & Fantasy"),
+    SOAP(10766, "Soap"),
+    TALK(10767, "Talk"),
+    WAR_POLITICS(10768, "War & Politics");
+
+    companion object {
+        private val mapById = entries.associateBy { it.id }
+        fun fromId(id: Int): TmdbGenre? = mapById[id]
+        fun getGenreName(id: Int): String? = mapById[id]?.genreName
+    }
+}
+

--- a/native/app/src/main/java/com/localstream/app/domain/model/VideoItem.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/VideoItem.kt
@@ -1,0 +1,21 @@
+package com.localstream.app.domain.model
+
+data class VideoItem(
+    val url: String = "",
+    val name: String,
+    val type: String = "video/mp4",
+    val path: String = "",
+    val size: Long = 0L,
+    val lastModified: Long = 0L,
+    val nativeUri: String? = null,
+    val subtitleNativePath: String? = null,
+    val subtitleUrl: String? = null,
+    val seriesName: String? = null,
+    val season: Int? = null,
+    val episode: Int? = null,
+    val isSeriesGroup: Boolean = false,
+    val isTvSeries: Boolean = false,
+    val episodes: List<VideoItem>? = null,
+    val cleanTitle: String? = null,
+)
+

--- a/native/app/src/test/java/com/localstream/app/domain/EdgeCasesTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/EdgeCasesTest.kt
@@ -1,0 +1,112 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.FilterSortOptions
+import com.localstream.app.domain.model.SortBy
+import com.localstream.app.domain.model.VideoItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EdgeCasesTest {
+
+    private fun v(name: String, size: Long = 0L, lastModified: Long = 0L, episodes: List<VideoItem>? = null): VideoItem = VideoItem(
+        url = "blob:x",
+        name = name,
+        type = "video/mp4",
+        path = name,
+        size = size,
+        lastModified = lastModified,
+        isSeriesGroup = episodes != null,
+        seriesName = if (episodes != null) name else null,
+        episodes = episodes
+    )
+
+    @Test
+    fun groupVideos_sortsMixedMultiSeasonSeries() {
+        val videos = listOf(
+            v("Dark.S02E01.mkv"),
+            v("Dark.S01E02.mkv"),
+            v("Dark.S01E01.mkv"),
+            v("Dark.S03E01.mkv"),
+            v("Dark.S02E02.mkv")
+        )
+        val res = VideoGrouper.groupVideos(videos, emptyMap(), emptyMap(), emptySet())
+        assertEquals(1, res.size)
+        assertEquals(
+            listOf("1x1", "1x2", "2x1", "2x2", "3x1"),
+            res[0].episodes?.map { "${it.season}x${it.episode}" }
+        )
+    }
+
+    @Test
+    fun groupVideos_parsesSeasonAndEpisodeFromNxMFormat() {
+        val res = VideoGrouper.groupVideos(listOf(v("Friends 1x05.mkv"), v("Friends 1x02.mkv")), emptyMap(), emptyMap(), emptySet())
+        assertEquals(listOf(2, 5), res[0].episodes?.map { it.episode })
+        assertTrue(res[0].episodes.orEmpty().all { it.season == 1 })
+    }
+
+    @Test
+    fun groupVideos_keepsDistinctSeriesSeparate() {
+        val res = VideoGrouper.groupVideos(listOf(v("Show.A.S01E01.mkv"), v("Show.B.S01E01.mkv")), emptyMap(), emptyMap(), emptySet())
+        assertEquals(2, res.size)
+    }
+
+    private val baseOpts = FilterSortOptions(
+        sortBy = SortBy.ALPHA,
+        filterGenre = null,
+        releaseDates = emptyMap(),
+        videoGenres = emptyMap(),
+        videoDurations = emptyMap(),
+        watchedVideos = emptyMap()
+    )
+
+    @Test
+    fun filterAndSortVideos_sortsBySizeMissingSizesLast() {
+        val res = VideoFilterSorter.filterAndSortVideos(
+            listOf(v("Sans.mkv"), v("Gros.mkv", size = 5000L), v("Petit.mkv", size = 100L)),
+            baseOpts.copy(sortBy = SortBy.SIZE)
+        )
+        assertEquals(listOf("Gros.mkv", "Petit.mkv", "Sans.mkv"), res.map { it.name })
+    }
+
+    @Test
+    fun filterAndSortVideos_sortsByDurationMissingDurationsLast() {
+        val res = VideoFilterSorter.filterAndSortVideos(
+            listOf(v("Sans.mkv"), v("Long.mkv"), v("Court.mkv")),
+            baseOpts.copy(sortBy = SortBy.DURATION, videoDurations = mapOf("Long.mkv" to 7200L, "Court.mkv" to 1200L))
+        )
+        assertEquals(listOf("Long.mkv", "Court.mkv", "Sans.mkv"), res.map { it.name })
+    }
+
+    @Test
+    fun filterAndSortVideos_sortsGroupSizeBySumOfEpisodes() {
+        val serie = v(
+            "S",
+            episodes = listOf(v("S.S01E01.mkv", size = 3000L), v("S.S01E02.mkv", size = 3000L))
+        )
+        val res = VideoFilterSorter.filterAndSortVideos(
+            listOf(v("Film.mkv", size = 5000L), serie),
+            baseOpts.copy(sortBy = SortBy.SIZE)
+        )
+        assertEquals("S", res[0].name)
+    }
+
+    @Test
+    fun filterAndSortVideos_filtersByGenreMap() {
+        val res = VideoFilterSorter.filterAndSortVideos(
+            listOf(v("Action.mkv"), v("Drame.mkv")),
+            baseOpts.copy(filterGenre = 28, videoGenres = mapOf("Action.mkv" to listOf(28), "Drame.mkv" to listOf(18)))
+        )
+        assertEquals(listOf("Action.mkv"), res.map { it.name })
+    }
+
+    @Test
+    fun filterAndSortVideos_relegatesWatchedContentToEnd() {
+        val res = VideoFilterSorter.filterAndSortVideos(
+            listOf(v("Avu.mkv"), v("Bnonvu.mkv")),
+            baseOpts.copy(watchedVideos = mapOf("Avu.mkv" to true))
+        )
+        assertEquals(listOf("Bnonvu.mkv", "Avu.mkv"), res.map { it.name })
+    }
+}
+

--- a/native/app/src/test/java/com/localstream/app/domain/FormattersTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/FormattersTest.kt
@@ -1,0 +1,56 @@
+package com.localstream.app.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FormattersTest {
+
+    @Test
+    fun getCleanTitle_removesExtensionYearQualityAndSeriesMarkers() {
+        assertEquals("Inception", TitleCleaner.getCleanTitle("Inception.2010.1080p.BluRay.x264.mkv"))
+        assertEquals("Breaking Bad", TitleCleaner.getCleanTitle("Breaking.Bad.S01E01.720p.mkv"))
+        assertEquals("The Office", TitleCleaner.getCleanTitle("The Office 1x05.mp4"))
+    }
+
+    @Test
+    fun isPersonalVideo_detectsCameraAndAppMedia() {
+        assertTrue(Formatters.isPersonalVideo("VID_20240315_143022.mp4", "/Movies/VID_20240315_143022.mp4"))
+        assertTrue(Formatters.isPersonalVideo("clip.mp4", "/storage/emulated/0/DCIM/Camera/clip.mp4"))
+        assertTrue(Formatters.isPersonalVideo("movie.mp4", "/WhatsApp/Media/movie.mp4"))
+        assertFalse(Formatters.isPersonalVideo("Inception.2010.1080p.mkv", "/Movies/Inception.2010.1080p.mkv"))
+    }
+
+    @Test
+    fun getResolution_recognizesFormats() {
+        assertEquals("4K", Formatters.getResolution("Film.2160p.mkv"))
+        assertEquals("1080p", Formatters.getResolution("Film.1080p.mkv"))
+        assertEquals("720p", Formatters.getResolution("Film.720p.mkv"))
+        assertEquals("", Formatters.getResolution("Film.mkv"))
+    }
+
+    @Test
+    fun formatSize_formatsBytes() {
+        assertEquals("0 B", Formatters.formatSize(0L))
+        assertEquals("1 KB", Formatters.formatSize(1024L))
+        assertEquals("1 GB", Formatters.formatSize(1024L * 1024L * 1024L))
+    }
+
+    @Test
+    fun formatDuration_formatsHoursAndMinutes() {
+        assertEquals("Inconnue", Formatters.formatDuration(0L))
+        assertEquals("1m", Formatters.formatDuration(90L))
+        assertEquals("1h 1m", Formatters.formatDuration(3660L))
+    }
+
+    @Test
+    fun tmdbUrls_buildsCorrectImageUrls() {
+        assertEquals("https://image.tmdb.org/t/p/w342/abc.jpg", TmdbUrls.posterUrl("/abc.jpg"))
+        assertEquals("https://image.tmdb.org/t/p/w1280/abc.jpg", TmdbUrls.backdropUrl("/abc.jpg"))
+        assertEquals("https://image.tmdb.org/t/p/w300/abc.jpg", TmdbUrls.stillUrl("/abc.jpg"))
+        assertNull(TmdbUrls.posterUrl(null))
+    }
+}
+

--- a/native/app/src/test/java/com/localstream/app/domain/GroupingTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/GroupingTest.kt
@@ -1,0 +1,76 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.MovieCollection
+import com.localstream.app.domain.model.VideoItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GroupingTest {
+
+    private fun v(name: String, path: String = name): VideoItem = VideoItem(
+        url = "blob:x",
+        name = name,
+        type = "video/mp4",
+        path = path
+    )
+
+    @Test
+    fun groupVideos_regroupsSeriesEpisodesSortedBySeasonAndEpisode() {
+        val videos = listOf(
+            v("Show.S01E02.mkv"),
+            v("Show.S01E01.mkv"),
+            v("Show.S02E01.mkv")
+        )
+        val res = VideoGrouper.groupVideos(videos, emptyMap(), emptyMap(), emptySet())
+        assertEquals(1, res.size)
+        assertTrue(res[0].isSeriesGroup)
+        assertEquals(
+            listOf("Show.S01E01.mkv", "Show.S01E02.mkv", "Show.S02E01.mkv"),
+            res[0].episodes?.map { it.name }
+        )
+    }
+
+    @Test
+    fun groupVideos_excludesUnwhitelistedPersonalVideos() {
+        val res = VideoGrouper.groupVideos(listOf(v("VID_20240315_143022.mp4")), emptyMap(), emptyMap(), emptySet())
+        assertEquals(0, res.size)
+    }
+
+    @Test
+    fun groupVideos_reintegratesWhitelistedPersonalVideo() {
+        val name = "VID_20240315_143022.mp4"
+        val res = VideoGrouper.groupVideos(listOf(v(name)), emptyMap(), emptyMap(), setOf(name))
+        assertEquals(1, res.size)
+    }
+
+    @Test
+    fun groupVideos_groupsMultipleCollectionMoviesIntoSaga() {
+        val col = MovieCollection("1", "Saga X")
+        val collections = mapOf("FilmA.mkv" to col, "FilmB.mkv" to col)
+        val res = VideoGrouper.groupVideos(
+            listOf(v("FilmA.mkv"), v("FilmB.mkv")),
+            collections,
+            emptyMap(),
+            emptySet()
+        )
+        assertEquals(1, res.size)
+        assertEquals("Saga X", res[0].seriesName)
+        assertEquals(2, res[0].episodes?.size)
+    }
+
+    @Test
+    fun groupVideos_keepsSingleCollectionMovieAsStandalone() {
+        val col = MovieCollection("1", "Saga X")
+        val res = VideoGrouper.groupVideos(
+            listOf(v("FilmA.mkv")),
+            mapOf("FilmA.mkv" to col),
+            emptyMap(),
+            emptySet()
+        )
+        assertEquals(1, res.size)
+        assertFalse(res[0].isSeriesGroup)
+    }
+}
+

--- a/native/app/src/test/java/com/localstream/app/domain/HeroSelectorTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/HeroSelectorTest.kt
@@ -1,0 +1,76 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.VideoItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HeroSelectorTest {
+
+    private fun v(name: String, lastModified: Long = 0L, extraEpisodes: List<VideoItem>? = null): VideoItem = VideoItem(
+        url = "blob:x",
+        name = name,
+        type = "video/mp4",
+        path = name,
+        lastModified = lastModified,
+        isSeriesGroup = extraEpisodes != null,
+        episodes = extraEpisodes
+    )
+
+    @Test
+    fun isFullyWatched_tracksMovieAndSeriesState() {
+        assertTrue(HeroSelector.isFullyWatched(v("Film.mkv"), mapOf("Film.mkv" to true)))
+        assertFalse(HeroSelector.isFullyWatched(v("Film.mkv"), emptyMap()))
+
+        val series = v("S", extraEpisodes = listOf(v("S.E1.mkv"), v("S.E2.mkv")))
+        assertFalse(HeroSelector.isFullyWatched(series, mapOf("S.E1.mkv" to true)))
+        assertTrue(HeroSelector.isFullyWatched(series, mapOf("S.E1.mkv" to true, "S.E2.mkv" to true)))
+    }
+
+    @Test
+    fun getHeroCandidates_excludesFullyWatched() {
+        val res = HeroSelector.getHeroCandidates(
+            listOf(v("Vu.mkv"), v("NonVu.mkv")),
+            mapOf("Vu.mkv" to true)
+        )
+        assertEquals(listOf("NonVu.mkv"), res.map { it.name })
+    }
+
+    @Test
+    fun getHeroCandidates_returnsAllUnwatchedCandidatesByRecency() {
+        val res = HeroSelector.getHeroCandidates(
+            listOf(v("A.mkv", 1L), v("B.mkv", 2L), v("C.mkv", 3L)),
+            emptyMap()
+        )
+        assertEquals(3, res.size)
+        assertEquals("C.mkv", res[0].name)
+    }
+
+    @Test
+    fun getHeroCandidates_prioritizesInProgressBeforeUnstarted() {
+        val res = HeroSelector.getHeroCandidates(
+            listOf(v("Recent.mkv", 10L), v("EnCours.mkv", 1L)),
+            emptyMap(),
+            mapOf("EnCours.mkv" to 40.0)
+        )
+        assertEquals("EnCours.mkv", res[0].name)
+    }
+
+    @Test
+    fun getHeroCandidates_ignoresFinishedProgress() {
+        val res = HeroSelector.getHeroCandidates(
+            listOf(v("Presque.mkv", 1L), v("Recent.mkv", 10L)),
+            emptyMap(),
+            mapOf("Presque.mkv" to 98.0)
+        )
+        assertEquals("Recent.mkv", res[0].name)
+    }
+
+    @Test
+    fun getHeroCandidates_returnsEmptyIfAllWatched() {
+        val res = HeroSelector.getHeroCandidates(listOf(v("A.mkv")), mapOf("A.mkv" to true))
+        assertEquals(0, res.size)
+    }
+}
+

--- a/native/app/src/test/java/com/localstream/app/domain/LibraryPipelineTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/LibraryPipelineTest.kt
@@ -1,0 +1,139 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.FilterSortOptions
+import com.localstream.app.domain.model.MovieCollection
+import com.localstream.app.domain.model.ResolutionFilter
+import com.localstream.app.domain.model.SortBy
+import com.localstream.app.domain.model.VideoItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LibraryPipelineTest {
+
+    private fun v(
+        name: String,
+        path: String = name,
+        size: Long = 1000L,
+        lastModified: Long = 100L
+    ): VideoItem {
+        val seriesInfo = VideoNameParser.parseSeriesInfo(name, path)
+        return VideoItem(
+            url = "file://$path",
+            name = name,
+            path = path,
+            size = size,
+            lastModified = lastModified,
+            seriesName = seriesInfo.seriesName,
+            season = seriesInfo.season,
+            episode = seriesInfo.episode
+        )
+    }
+
+    @Test
+    fun testFullPipeline_parseGroupFilterSortOn30RealisticFiles() {
+        val dataset = createTestDataset()
+
+        val grouped = VideoGrouper.groupVideos(
+            dataset.files,
+            dataset.collections,
+            dataset.releaseDates,
+            dataset.whitelisted
+        )
+        assertGroupedResults(grouped)
+
+        val sorted4k = VideoFilterSorter.filterAndSortVideos(
+            grouped,
+            FilterSortOptions(
+                sortBy = SortBy.SIZE,
+                filterResolution = ResolutionFilter.FOUR_K,
+                releaseDates = dataset.releaseDates
+            )
+        )
+        assertEquals(
+            listOf("Dune Collection", "Oppenheimer.2023.2160p.mkv", "Interstellar.2014.2160p.UHD.mkv", "Stranger Things"),
+            sorted4k.map { it.name }
+        )
+    }
+
+    private fun assertGroupedResults(grouped: List<VideoItem>) {
+        assertTrue(grouped.any { it.name == "VID_20240316_101010.mp4" })
+        assertFalse(grouped.any { it.name == "VID_20240315_143022.mp4" })
+
+        val bb = grouped.find { it.seriesName == "Breaking Bad" }
+        assertTrue(bb != null && bb.isSeriesGroup && bb.isTvSeries && bb.episodes?.size == 3)
+
+        val office = grouped.find { it.seriesName == "The Office" }
+        assertTrue(office != null && office.isSeriesGroup && office.isTvSeries && office.episodes?.size == 2)
+
+        val dkSaga = grouped.find { it.seriesName == "The Dark Knight Collection" }
+        assertTrue(dkSaga != null && dkSaga.isSeriesGroup && !dkSaga.isTvSeries && dkSaga.episodes?.size == 3)
+
+        val duneSaga = grouped.find { it.seriesName == "Dune Collection" }
+        assertTrue(duneSaga != null && duneSaga.isSeriesGroup && !duneSaga.isTvSeries && duneSaga.episodes?.size == 2)
+    }
+
+    private fun createTestDataset(): Dataset {
+        val rawFiles = listOf(
+            v("Inception.2010.1080p.BluRay.mkv", size = 2000L, lastModified = 500L),
+            v("Interstellar.2014.2160p.UHD.mkv", size = 8000L, lastModified = 600L),
+            v("The.Dark.Knight.2008.1080p.mkv", size = 2500L, lastModified = 300L),
+            v("The.Dark.Knight.Rises.2012.1080p.mkv", size = 2700L, lastModified = 400L),
+            v("Batman.Begins.2005.720p.mkv", size = 1500L, lastModified = 200L),
+            v("Matrix.1999.1080p.mkv", size = 2200L, lastModified = 100L),
+            v("Avatar.2009.1080p.mkv", size = 3000L, lastModified = 250L),
+            v("Gladiator.2000.1080p.mkv", size = 2100L, lastModified = 150L),
+            v("Pulp.Fiction.1994.720p.mkv", size = 1400L, lastModified = 120L),
+            v("Fight.Club.1999.1080p.mkv", size = 2300L, lastModified = 180L),
+            v("Breaking.Bad.S01E01.720p.mkv", size = 500L, lastModified = 1000L),
+            v("Breaking.Bad.S01E02.720p.mkv", size = 520L, lastModified = 1001L),
+            v("Breaking.Bad.S02E01.1080p.mkv", size = 900L, lastModified = 1002L),
+            v("Game.of.Thrones.S01E01.1080p.mkv", size = 1100L, lastModified = 900L),
+            v("Game.of.Thrones.S01E02.1080p.mkv", size = 1150L, lastModified = 901L),
+            v("Stranger.Things.S04E01.2160p.mkv", size = 3500L, lastModified = 1200L),
+            v("Stranger.Things.S04E02.2160p.mkv", size = 3600L, lastModified = 1201L),
+            v("The Office 1x01.mp4", path = "Shows/The Office/Season 1/The Office 1x01.mp4", size = 300L, lastModified = 700L),
+            v("The Office 1x02.mp4", path = "Shows/The Office/Season 1/The Office 1x02.mp4", size = 310L, lastModified = 701L),
+            v("01.mp4", path = "Shows/Chernobyl/Saison 1/01.mp4", size = 800L, lastModified = 800L),
+            v("02.mp4", path = "Shows/Chernobyl/Saison 1/02.mp4", size = 820L, lastModified = 801L),
+            v("VID_20240315_143022.mp4", path = "/Movies/VID_20240315_143022.mp4"),
+            v("20240315_143022.mp4", path = "/storage/emulated/0/DCIM/Camera/20240315_143022.mp4"),
+            v("whatsapp_video.mp4", path = "/WhatsApp/Media/whatsapp_video.mp4"),
+            v("screenrecord_2024.mp4", path = "/Movies/screenrecord_2024.mp4"),
+            v("VID_20240316_101010.mp4", path = "/Movies/VID_20240316_101010.mp4"),
+            v("Oppenheimer.2023.2160p.mkv", size = 9500L, lastModified = 1500L),
+            v("Dune.2021.2160p.mkv", size = 8500L, lastModified = 1300L),
+            v("Dune.Part.Two.2024.2160p.mkv", size = 9000L, lastModified = 1600L),
+            v("Whiplash.2014.1080p.mkv", size = 1900L, lastModified = 450L)
+        )
+
+        val dkSaga = MovieCollection("100", "The Dark Knight Collection")
+        val duneSaga = MovieCollection("101", "Dune Collection")
+        val collections = mapOf(
+            "Batman.Begins.2005.720p.mkv" to dkSaga,
+            "The.Dark.Knight.2008.1080p.mkv" to dkSaga,
+            "The.Dark.Knight.Rises.2012.1080p.mkv" to dkSaga,
+            "Dune.2021.2160p.mkv" to duneSaga,
+            "Dune.Part.Two.2024.2160p.mkv" to duneSaga
+        )
+
+        val releaseDates = mapOf(
+            "Batman.Begins.2005.720p.mkv" to "2005-06-15",
+            "The.Dark.Knight.2008.1080p.mkv" to "2008-07-18",
+            "The.Dark.Knight.Rises.2012.1080p.mkv" to "2012-07-20",
+            "Dune.2021.2160p.mkv" to "2021-09-15",
+            "Dune.Part.Two.2024.2160p.mkv" to "2024-03-01"
+        )
+
+        return Dataset(rawFiles, collections, releaseDates, setOf("VID_20240316_101010.mp4"))
+    }
+
+    private data class Dataset(
+        val files: List<VideoItem>,
+        val collections: Map<String, MovieCollection>,
+        val releaseDates: Map<String, String>,
+        val whitelisted: Set<String>
+    )
+}
+

--- a/native/app/src/test/java/com/localstream/app/domain/SortingTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/SortingTest.kt
@@ -1,0 +1,50 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.FilterSortOptions
+import com.localstream.app.domain.model.ResolutionFilter
+import com.localstream.app.domain.model.SortBy
+import com.localstream.app.domain.model.VideoItem
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SortingTest {
+
+    private fun v(name: String): VideoItem = VideoItem(
+        url = "blob:x",
+        name = name,
+        type = "video/mp4",
+        path = name
+    )
+
+    private val baseOpts = FilterSortOptions(
+        sortBy = SortBy.ALPHA,
+        filterGenre = null,
+        filterResolution = ResolutionFilter.ALL,
+        releaseDates = emptyMap(),
+        videoGenres = emptyMap(),
+        videoDurations = emptyMap(),
+        watchedVideos = emptyMap()
+    )
+
+    @Test
+    fun filterAndSortVideos_sortsAlphabetically() {
+        val res = VideoFilterSorter.filterAndSortVideos(listOf(v("Zebra.mkv"), v("Alpha.mkv")), baseOpts)
+        assertEquals(listOf("Alpha.mkv", "Zebra.mkv"), res.map { it.name })
+    }
+
+    @Test
+    fun filterAndSortVideos_relegatesWatchedVideosToEnd() {
+        val opts = baseOpts.copy(watchedVideos = mapOf("Alpha.mkv" to true))
+        val res = VideoFilterSorter.filterAndSortVideos(listOf(v("Alpha.mkv"), v("Beta.mkv")), opts)
+        assertEquals(listOf("Beta.mkv", "Alpha.mkv"), res.map { it.name })
+    }
+
+    @Test
+    fun filterAndSortVideos_filtersByResolution() {
+        val opts = baseOpts.copy(filterResolution = ResolutionFilter.ONE_THOUSAND_EIGHTY_P)
+        val res = VideoFilterSorter.filterAndSortVideos(listOf(v("Film.1080p.mkv"), v("Film.720p.mkv")), opts)
+        assertEquals(1, res.size)
+        assertEquals("Film.1080p.mkv", res[0].name)
+    }
+}
+

--- a/native/app/src/test/java/com/localstream/app/domain/VideoNameParserTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/VideoNameParserTest.kt
@@ -1,0 +1,100 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.SeriesInfo
+import com.localstream.app.domain.model.SubtitleEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoNameParserTest {
+
+    @Test
+    fun parseSeriesInfo_detectsSxxExx() {
+        assertEquals(
+            SeriesInfo(seriesName = "Breaking Bad", season = 1, episode = 5),
+            VideoNameParser.parseSeriesInfo("Breaking.Bad.S01E05.1080p.mkv")
+        )
+    }
+
+    @Test
+    fun parseSeriesInfo_detectsNxM() {
+        assertEquals(
+            SeriesInfo(seriesName = "The Office", season = 3, episode = 12),
+            VideoNameParser.parseSeriesInfo("The Office 3x12.mp4")
+        )
+    }
+
+    @Test
+    fun parseSeriesInfo_cleansNameSeparators() {
+        val info = VideoNameParser.parseSeriesInfo("[Team]_Dark-S02E01.mkv")
+        assertEquals("Team  Dark", info.seriesName)
+        assertEquals(2, info.season)
+        assertEquals(1, info.episode)
+    }
+
+    @Test
+    fun parseSeriesInfo_fallsBackToUnknownSeriesIfNameEmpty() {
+        assertEquals("Série Inconnue", VideoNameParser.parseSeriesInfo("S01E01.mkv").seriesName)
+    }
+
+    @Test
+    fun parseSeriesInfo_detectsSeriesFromFolderStructure() {
+        assertEquals(
+            SeriesInfo(seriesName = "Dark", season = 2, episode = 1),
+            VideoNameParser.parseSeriesInfo("01.mp4", "Series/Dark/Saison 2/01.mp4")
+        )
+        assertEquals(
+            SeriesInfo(seriesName = "Lost", season = 1, episode = null),
+            VideoNameParser.parseSeriesInfo("pilot.mp4", "Shows/Lost/Season 1/pilot.mp4")
+        )
+    }
+
+    @Test
+    fun parseSeriesInfo_returnsEmptyForSimpleMovie() {
+        assertEquals(SeriesInfo(), VideoNameParser.parseSeriesInfo("Inception.2010.1080p.mkv", "Movies/Inception.2010.1080p.mkv"))
+    }
+
+    @Test
+    fun baseNameFunctions_stripExtensionsAndLanguageSuffixes() {
+        assertEquals("film.test", VideoNameParser.videoBaseName("Film.Test.MKV"))
+        assertEquals("film.test", VideoNameParser.subtitleBaseName("Film.Test.fr.srt"))
+        assertEquals("film.test", VideoNameParser.subtitleBaseName("Film.Test.srt"))
+    }
+
+    @Test
+    fun parentFolder_extractsParent() {
+        assertEquals("Movies/Sub", VideoNameParser.parentFolder("Movies/Sub/film.mp4"))
+        assertEquals("", VideoNameParser.parentFolder("film.mp4"))
+        assertEquals("Movies", VideoNameParser.parentFolder("Movies\\film.mp4"))
+    }
+
+    @Test
+    fun matchSubtitle_indexesAndMatchesSubtitles() {
+        val subs = listOf(
+            SubtitleEntry(name = "Film.fr.srt", folder = "Movies", uri = "u1"),
+            SubtitleEntry(name = "Autre.vtt", folder = "Movies", uri = "u2"),
+            SubtitleEntry(name = "notes.txt", folder = "Movies", uri = "u3")
+        )
+        val index = VideoNameParser.buildSubtitleIndex(subs)
+        assertEquals("u1", VideoNameParser.matchSubtitle(index, "Film.mkv", "Movies")?.uri)
+        assertEquals("u2", VideoNameParser.matchSubtitle(index, "Autre.mp4", "Movies")?.uri)
+        assertNull(VideoNameParser.matchSubtitle(index, "notes.mp4", "Movies"))
+        assertNull(VideoNameParser.matchSubtitle(index, "Film.mkv", "Download"))
+    }
+
+    @Test
+    fun regexes_matchSupportedExtensions() {
+        for (f in listOf("a.mp4", "b.MKV", "c.webm", "d.avi", "e.mov")) {
+            assertTrue(VideoNameParser.VIDEO_EXT_REGEX.containsMatchIn(f))
+        }
+        assertFalse(VideoNameParser.VIDEO_EXT_REGEX.containsMatchIn("a.txt"))
+
+        for (f in listOf("a.srt", "b.VTT", "c.ass", "d.ssa")) {
+            assertTrue(VideoNameParser.SUBTITLE_EXT_REGEX.containsMatchIn(f))
+        }
+        assertFalse(VideoNameParser.SUBTITLE_EXT_REGEX.containsMatchIn("a.sub"))
+    }
+}
+


### PR DESCRIPTION
## Description
Portage de la couche domaine pure et des modèles de données en Kotlin pour le module natif Android Compose (Phase 2, issue #34).

## Modifications apportées
- **Modèles de données (
ative/app/src/main/java/com/localstream/app/domain/model/)** :
  - VideoItem, SubtitleInfo, PlaylistInfo, MovieCollection, SeriesInfo, SubtitleEntry.
  - Enum TmdbGenre (genres et IDs TMDB).
  - FilterSortOptions (SortBy et ResolutionFilter).
- **Logique domaine pure (
ative/app/src/main/java/com/localstream/app/domain/)** :
  - TitleCleaner : nettoyage des titres de fichiers vidéo.
  - Formatters & TmdbUrls : formatage tailles/durées, détection résolutions et vidéos personnelles.
  - VideoNameParser : parsing SxxExx / 1x01, structure de dossiers, matching sous-titres.
  - VideoGrouper : regroupement en séries et sagas de films (collections TMDB ≥ 2 films).
  - VideoFilterSorter : filtres (genre, résolution) et tri avec relégation des contenus vus.
  - HeroSelector : sélection des candidats non vus / en cours pour la bannière rotative.
- **Tests unitaires JUnit (
ative/app/src/test/java/com/localstream/app/domain/)** :
  - 6 suites de tests unitaires (FormattersTest, VideoNameParserTest, GroupingTest, SortingTest, HeroSelectorTest, EdgeCasesTest).
  - LibraryPipelineTest : test d'intégration sur un jeu de 30 fichiers vidéo réalistes (parse → group → filter → sort).

## Validation
- ./gradlew testDebugUnitTest detekt : **100 % vert**, aucune erreur detekt.

pm test : **84/84 tests verts** (projet web).

Closes #34