### PR TITLE
feat(native): client TMDB natif avec Retrofit, cache Room et tests MockWebServer (Phase 5, #37)

### DIFF
--- a/native/app/build.gradle.kts
+++ b/native/app/build.gradle.kts
@@ -3,7 +3,8 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.detekt)
-    alias(libs.plugins.ksp) // Phase 4 : g\u00e9n\u00e9ration Room
+    alias(libs.plugins.ksp) // Phase 4 : génération Room
+    alias(libs.plugins.kotlin.serialization) // Phase 5 : kotlinx.serialization
 }
 
 android {
@@ -12,7 +13,7 @@ android {
 
     defaultConfig {
         // applicationId PROVISOIRE : le vrai id (com.localstream.app) sera repris en
-        // Phase 10 pour h\u00e9riter des installations de l'app Capacitor existante.
+        // Phase 10 pour hériter des installations de l'app Capacitor existante.
         applicationId = "com.localstream.app.native"
         minSdk = 24
         targetSdk = 36
@@ -22,6 +23,15 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        getByName("debug") {
+            storeFile = file("C:/tmp/.android/debug.keystore")
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -29,6 +39,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+        }
+        debug {
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
 
@@ -48,7 +61,7 @@ android {
 
 detekt {
     // Analyse statique du code Kotlin. La config de base est enrichie par les
-    // r\u00e9glages adapt\u00e9s \u00e0 Compose dans config/detekt/detekt.yml.
+    // réglages adaptés à Compose dans config/detekt/detekt.yml.
     buildUponDefaultConfig = true
     config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
 }
@@ -80,9 +93,18 @@ dependencies {
     // Phase 4 — Coroutines
     implementation(libs.kotlinx.coroutines.android)
 
+    // Phase 5 — API TMDB, Retrofit, Serialization, OkHttp, Coil
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.converter.kotlinx.serialization)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging.interceptor)
+    implementation(libs.coil.compose)
+
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.json)
+    testImplementation(libs.mockwebserver)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/native/app/build.gradle.kts
+++ b/native/app/build.gradle.kts
@@ -23,15 +23,6 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    signingConfigs {
-        getByName("debug") {
-            storeFile = file("C:/tmp/.android/debug.keystore")
-            storePassword = "android"
-            keyAlias = "androiddebugkey"
-            keyPassword = "android"
-        }
-    }
-
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -39,9 +30,6 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
-        }
-        debug {
-            signingConfig = signingConfigs.getByName("debug")
         }
     }
 

--- a/native/app/src/main/java/com/localstream/app/data/db/AppDatabase.kt
+++ b/native/app/src/main/java/com/localstream/app/data/db/AppDatabase.kt
@@ -1,4 +1,4 @@
-﻿package com.localstream.app.data.db
+package com.localstream.app.data.db
 
 import android.content.Context
 import androidx.room.Database
@@ -6,17 +6,19 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.localstream.app.data.db.dao.PlaybackStateDao
 import com.localstream.app.data.db.dao.PlaylistDao
+import com.localstream.app.data.db.dao.TmdbMetadataDao
 import com.localstream.app.data.db.dao.WatchedItemDao
 import com.localstream.app.data.db.entity.PlaybackStateEntity
 import com.localstream.app.data.db.entity.PlaylistEntity
 import com.localstream.app.data.db.entity.PlaylistItemEntity
+import com.localstream.app.data.db.entity.TmdbMetadataEntity
 import com.localstream.app.data.db.entity.WatchedItemEntity
 
 /**
- * Base de donn\u00e9es Room principale de LocalStream (Phase 4).
+ * Base de données Room principale de LocalStream (Phase 4, Phase 5).
  *
  * Version 1 : tables watched_items, playback_state, playlist, playlist_item.
- * Les migrations futures incr\u00e9menteront [version].
+ * Version 2 : ajout de la table tmdb_metadata (Phase 5).
  */
 @Database(
     entities = [
@@ -24,8 +26,9 @@ import com.localstream.app.data.db.entity.WatchedItemEntity
         PlaybackStateEntity::class,
         PlaylistEntity::class,
         PlaylistItemEntity::class,
+        TmdbMetadataEntity::class,
     ],
-    version = 1,
+    version = 2,
     exportSchema = false,
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -33,6 +36,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun watchedItemDao(): WatchedItemDao
     abstract fun playbackStateDao(): PlaybackStateDao
     abstract fun playlistDao(): PlaylistDao
+    abstract fun tmdbMetadataDao(): TmdbMetadataDao
 
     companion object {
         private const val DB_NAME = "localstream.db"
@@ -53,7 +57,7 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
-        /** Uniquement pour les tests instrumentaux : base en m\u00e9moire sans passer par le singleton. */
+        /** Uniquement pour les tests instrumentaux : base en mémoire sans passer par le singleton. */
         fun createInMemory(context: Context): AppDatabase =
             Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
                 .allowMainThreadQueries()

--- a/native/app/src/main/java/com/localstream/app/data/db/dao/TmdbMetadataDao.kt
+++ b/native/app/src/main/java/com/localstream/app/data/db/dao/TmdbMetadataDao.kt
@@ -1,0 +1,26 @@
+package com.localstream.app.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.localstream.app.data.db.entity.TmdbMetadataEntity
+
+@Dao
+interface TmdbMetadataDao {
+
+    @Query("SELECT * FROM tmdb_metadata WHERE query_key = :queryKey")
+    suspend fun getMetadata(queryKey: String): TmdbMetadataEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMetadata(entity: TmdbMetadataEntity)
+
+    @Query("DELETE FROM tmdb_metadata WHERE query_key = :queryKey")
+    suspend fun deleteMetadata(queryKey: String)
+
+    @Query("DELETE FROM tmdb_metadata")
+    suspend fun clearAll()
+
+    @Query("SELECT * FROM tmdb_metadata")
+    suspend fun getAll(): List<TmdbMetadataEntity>
+}

--- a/native/app/src/main/java/com/localstream/app/data/db/entity/TmdbMetadataEntity.kt
+++ b/native/app/src/main/java/com/localstream/app/data/db/entity/TmdbMetadataEntity.kt
@@ -1,0 +1,16 @@
+package com.localstream.app.data.db.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "tmdb_metadata")
+data class TmdbMetadataEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "query_key")
+    val queryKey: String,
+    @ColumnInfo(name = "json")
+    val json: String,
+    @ColumnInfo(name = "fetched_at")
+    val fetchedAt: Long,
+)

--- a/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbApi.kt
+++ b/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbApi.kt
@@ -1,0 +1,60 @@
+package com.localstream.app.data.remote.tmdb
+
+import com.localstream.app.data.remote.tmdb.dto.TmdbCollectionDetailsDto
+import com.localstream.app.data.remote.tmdb.dto.TmdbMovieDetailsDto
+import com.localstream.app.data.remote.tmdb.dto.TmdbSearchResponse
+import com.localstream.app.data.remote.tmdb.dto.TmdbSeasonDetailsDto
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface TmdbApi {
+
+    @GET("search/multi")
+    suspend fun searchMulti(
+        @Query("api_key") apiKey: String,
+        @Query("query") query: String,
+        @Query("language") language: String = DEFAULT_LANGUAGE,
+    ): TmdbSearchResponse
+
+    @GET("search/movie")
+    suspend fun searchMovie(
+        @Query("api_key") apiKey: String,
+        @Query("query") query: String,
+        @Query("language") language: String = DEFAULT_LANGUAGE,
+    ): TmdbSearchResponse
+
+    @GET("movie/{id}")
+    suspend fun getMovieDetails(
+        @Path("id") movieId: Long,
+        @Query("api_key") apiKey: String,
+        @Query("language") language: String = DEFAULT_LANGUAGE,
+    ): TmdbMovieDetailsDto
+
+    @GET("collection/{id}")
+    suspend fun getCollection(
+        @Path("id") collectionId: Long,
+        @Query("api_key") apiKey: String,
+        @Query("language") language: String = DEFAULT_LANGUAGE,
+    ): TmdbCollectionDetailsDto
+
+    @GET("tv/{tv_id}/season/{season_number}")
+    suspend fun getSeason(
+        @Path("tv_id") tvId: Long,
+        @Path("season_number") seasonNumber: Int,
+        @Query("api_key") apiKey: String,
+        @Query("language") language: String = DEFAULT_LANGUAGE,
+    ): TmdbSeasonDetailsDto
+
+    @GET("movie/popular")
+    suspend fun getPopular(
+        @Query("api_key") apiKey: String,
+        @Query("language") language: String = DEFAULT_LANGUAGE,
+    ): Response<TmdbSearchResponse>
+
+    companion object {
+        const val BASE_URL = "https://api.themoviedb.org/3/"
+        const val DEFAULT_LANGUAGE = "fr-FR"
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/data/remote/tmdb/dto/TmdbDtos.kt
+++ b/native/app/src/main/java/com/localstream/app/data/remote/tmdb/dto/TmdbDtos.kt
@@ -1,0 +1,76 @@
+package com.localstream.app.data.remote.tmdb.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TmdbSearchResponse(
+    @SerialName("results") val results: List<TmdbSearchResultDto> = emptyList(),
+)
+
+@Serializable
+data class TmdbSearchResultDto(
+    val id: Long,
+    val title: String? = null,
+    val name: String? = null,
+    @SerialName("poster_path") val posterPath: String? = null,
+    @SerialName("backdrop_path") val backdropPath: String? = null,
+    @SerialName("overview") val overview: String? = null,
+    @SerialName("release_date") val releaseDate: String? = null,
+    @SerialName("first_air_date") val firstAirDate: String? = null,
+    @SerialName("genre_ids") val genreIds: List<Int>? = null,
+    @SerialName("media_type") val mediaType: String? = null,
+)
+
+@Serializable
+data class TmdbMovieDetailsDto(
+    val id: Long,
+    val title: String? = null,
+    @SerialName("poster_path") val posterPath: String? = null,
+    @SerialName("backdrop_path") val backdropPath: String? = null,
+    @SerialName("overview") val overview: String? = null,
+    @SerialName("release_date") val releaseDate: String? = null,
+    @SerialName("genres") val genres: List<TmdbGenreDto>? = null,
+    @SerialName("belongs_to_collection") val belongsToCollection: TmdbBelongsToCollectionDto? = null,
+)
+
+@Serializable
+data class TmdbBelongsToCollectionDto(
+    val id: Long,
+    val name: String,
+    @SerialName("poster_path") val posterPath: String? = null,
+    @SerialName("backdrop_path") val backdropPath: String? = null,
+)
+
+@Serializable
+data class TmdbCollectionDetailsDto(
+    val id: Long,
+    val name: String,
+    @SerialName("overview") val overview: String? = null,
+    @SerialName("poster_path") val posterPath: String? = null,
+    @SerialName("backdrop_path") val backdropPath: String? = null,
+    @SerialName("parts") val parts: List<TmdbSearchResultDto>? = null,
+)
+
+@Serializable
+data class TmdbSeasonDetailsDto(
+    val id: Long? = null,
+    @SerialName("season_number") val seasonNumber: Int = 1,
+    @SerialName("episodes") val episodes: List<TmdbEpisodeDto> = emptyList(),
+)
+
+@Serializable
+data class TmdbEpisodeDto(
+    val id: Long,
+    val name: String? = null,
+    @SerialName("overview") val overview: String? = null,
+    @SerialName("still_path") val stillPath: String? = null,
+    @SerialName("season_number") val seasonNumber: Int = 1,
+    @SerialName("episode_number") val episodeNumber: Int = 1,
+)
+
+@Serializable
+data class TmdbGenreDto(
+    val id: Int,
+    val name: String,
+)

--- a/native/app/src/main/java/com/localstream/app/data/repository/SettingsRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/SettingsRepository.kt
@@ -3,48 +3,50 @@ package com.localstream.app.data.repository
 import com.localstream.app.data.local.EncryptedPreferencesManager
 import com.localstream.app.data.local.UserPreferencesDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 
 /**
- * Repository des param\u00e8tres applicatifs (Phase 4).
+ * Repository des paramètres applicatifs (Phase 4, Phase 5).
  *
- * - Credentials sensibles  \u2192 [EncryptedPreferencesManager] (chiffrement AES-256-GCM)
- * - Pr\u00e9f\u00e9rences l\u00e9g\u00e8res     \u2192 [UserPreferencesDataStore] (DataStore/Preferences)
+ * - Credentials sensibles  -> [EncryptedPreferencesManager] (chiffrement AES-256-GCM)
+ * - Préférences légères     -> [UserPreferencesDataStore] (DataStore/Preferences)
  */
 @Suppress("TooManyFunctions")
-class SettingsRepository(
-    private val encryptedPrefs: EncryptedPreferencesManager,
-    private val dataStore: UserPreferencesDataStore,
+open class SettingsRepository(
+    private val encryptedPrefs: EncryptedPreferencesManager? = null,
+    private val dataStore: UserPreferencesDataStore? = null,
 ) {
 
-    // -------- Credentials chiffr\u00e9s --------
+    // -------- Credentials chiffrés --------
 
-    fun getTmdbApiKey(): String = encryptedPrefs.tmdbApiKey
-    fun saveTmdbApiKey(key: String) { encryptedPrefs.tmdbApiKey = key }
+    open fun getTmdbApiKey(): String = encryptedPrefs?.tmdbApiKey ?: ""
+    open fun saveTmdbApiKey(key: String) { encryptedPrefs?.tmdbApiKey = key }
 
-    fun getOpenSubtitlesApiKey(): String = encryptedPrefs.openSubtitlesApiKey
-    fun saveOpenSubtitlesApiKey(key: String) { encryptedPrefs.openSubtitlesApiKey = key }
+    open fun getOpenSubtitlesApiKey(): String = encryptedPrefs?.openSubtitlesApiKey ?: ""
+    open fun saveOpenSubtitlesApiKey(key: String) { encryptedPrefs?.openSubtitlesApiKey = key }
 
-    fun getOpenSubtitlesUsername(): String = encryptedPrefs.openSubtitlesUsername
-    fun saveOpenSubtitlesUsername(username: String) { encryptedPrefs.openSubtitlesUsername = username }
+    open fun getOpenSubtitlesUsername(): String = encryptedPrefs?.openSubtitlesUsername ?: ""
+    open fun saveOpenSubtitlesUsername(username: String) { encryptedPrefs?.openSubtitlesUsername = username }
 
-    fun getOpenSubtitlesPassword(): String = encryptedPrefs.openSubtitlesPassword
-    fun saveOpenSubtitlesPassword(password: String) { encryptedPrefs.openSubtitlesPassword = password }
+    open fun getOpenSubtitlesPassword(): String = encryptedPrefs?.openSubtitlesPassword ?: ""
+    open fun saveOpenSubtitlesPassword(password: String) { encryptedPrefs?.openSubtitlesPassword = password }
 
-    // -------- Pr\u00e9f\u00e9rences DataStore --------
+    // -------- Préférences DataStore --------
 
-    val videoPlayerMode: Flow<String> = dataStore.videoPlayerMode
-    suspend fun saveVideoPlayerMode(mode: String) = dataStore.saveVideoPlayerMode(mode)
+    open val videoPlayerMode: Flow<String> get() = dataStore?.videoPlayerMode ?: emptyFlow()
+    open suspend fun saveVideoPlayerMode(mode: String) { dataStore?.saveVideoPlayerMode(mode) }
 
-    val externalPlayerPackage: Flow<String> = dataStore.externalPlayerPackage
-    suspend fun saveExternalPlayerPackage(pkg: String) = dataStore.saveExternalPlayerPackage(pkg)
+    open val externalPlayerPackage: Flow<String> get() = dataStore?.externalPlayerPackage ?: emptyFlow()
+    open suspend fun saveExternalPlayerPackage(pkg: String) { dataStore?.saveExternalPlayerPackage(pkg) }
 
-    val whitelistedVideos: Flow<Set<String>> = dataStore.whitelistedVideos
-    suspend fun saveWhitelistedVideos(whitelist: Set<String>) =
-        dataStore.saveWhitelistedVideos(whitelist)
+    open val whitelistedVideos: Flow<Set<String>> get() = dataStore?.whitelistedVideos ?: emptyFlow()
+    open suspend fun saveWhitelistedVideos(whitelist: Set<String>) {
+        dataStore?.saveWhitelistedVideos(whitelist)
+    }
 
-    val forceAvailableJson: Flow<String> = dataStore.forceAvailableJson
-    suspend fun saveForceAvailableJson(json: String) = dataStore.saveForceAvailableJson(json)
+    open val forceAvailableJson: Flow<String> get() = dataStore?.forceAvailableJson ?: emptyFlow()
+    open suspend fun saveForceAvailableJson(json: String) { dataStore?.saveForceAvailableJson(json) }
 
-    val legacyImportDone: Flow<Boolean> = dataStore.legacyImportDone
-    suspend fun markLegacyImportDone() = dataStore.markLegacyImportDone()
+    open val legacyImportDone: Flow<Boolean> get() = dataStore?.legacyImportDone ?: emptyFlow()
+    open suspend fun markLegacyImportDone() { dataStore?.markLegacyImportDone() }
 }

--- a/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
@@ -1,0 +1,355 @@
+package com.localstream.app.data.repository
+
+import com.localstream.app.data.db.dao.TmdbMetadataDao
+import com.localstream.app.data.db.entity.TmdbMetadataEntity
+import com.localstream.app.data.remote.tmdb.TmdbApi
+import com.localstream.app.data.remote.tmdb.dto.TmdbMovieDetailsDto
+import com.localstream.app.data.remote.tmdb.dto.TmdbSearchResultDto
+import com.localstream.app.domain.TitleCleaner
+import com.localstream.app.domain.model.TmdbEpisode
+import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoItem
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import retrofit2.HttpException
+
+class TmdbAuthException(message: String = "Clé API TMDB invalide") : Exception(message)
+
+@Suppress(
+    "TooManyFunctions",
+    "LargeClass",
+    "LongMethod",
+    "CyclomaticComplexMethod",
+    "TooGenericExceptionCaught",
+    "SwallowedException",
+    "ReturnCount"
+)
+class TmdbRepository(
+    private val tmdbApi: TmdbApi,
+    private val tmdbMetadataDao: TmdbMetadataDao,
+    private val settingsRepository: SettingsRepository,
+    private val json: Json = Json { ignoreUnknownKeys = true; isLenient = true },
+    maxConcurrentRequests: Int = DEFAULT_CONCURRENCY,
+) {
+
+    private val semaphore = Semaphore(maxConcurrentRequests)
+    private val activeRequests = AtomicInteger(0)
+    private val peakConcurrentRequests = AtomicInteger(0)
+
+    val currentActiveRequests: Int get() = activeRequests.get()
+    val maxObservedConcurrentRequests: Int get() = peakConcurrentRequests.get()
+
+    fun resetMetrics() {
+        activeRequests.set(0)
+        peakConcurrentRequests.set(0)
+    }
+
+    suspend fun testApiKey(apiKeyOverride: String? = null): Result<Boolean> {
+        val apiKey = apiKeyOverride ?: settingsRepository.getTmdbApiKey()
+        if (apiKey.isBlank()) return Result.success(false)
+        return try {
+            val response = executeWithRetryAndThrottling {
+                tmdbApi.getPopular(apiKey)
+            }
+            if (response.isSuccessful) {
+                Result.success(true)
+            } else if (response.code() == HTTP_UNAUTHORIZED) {
+                Result.failure(TmdbAuthException())
+            } else {
+                Result.success(false)
+            }
+        } catch (e: TmdbAuthException) {
+            Result.failure(e)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getCachedMetadata(queryKey: String): TmdbMetadata? {
+        val entity = tmdbMetadataDao.getMetadata(queryKey) ?: return null
+        if (entity.json == NOT_FOUND_JSON) return null
+        return try {
+            json.decodeFromString<TmdbMetadata>(entity.json)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    suspend fun getCachedEpisode(lookupName: String, season: Int, episode: Int): TmdbEpisode? {
+        val epKey = "${lookupName}_s${season}_e${episode}"
+        val entity = tmdbMetadataDao.getMetadata(epKey) ?: return null
+        return try {
+            json.decodeFromString<TmdbEpisode>(entity.json)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    suspend fun fetchMetadataForVideo(
+        video: VideoItem,
+        forceRefresh: Boolean = false,
+    ): Result<TmdbMetadata> {
+        val lookupName = if (video.isSeriesGroup && !video.seriesName.isNullOrEmpty()) {
+            video.seriesName
+        } else {
+            video.name
+        }
+
+        val cleanTitle = if (video.isSeriesGroup && !video.seriesName.isNullOrEmpty()) {
+            video.seriesName
+        } else {
+            TitleCleaner.getCleanTitle(video.name)
+        }
+
+        val cachedEntity = tmdbMetadataDao.getMetadata(lookupName)
+        val now = System.currentTimeMillis()
+
+        if (!forceRefresh && cachedEntity != null) {
+            if (cachedEntity.json == NOT_FOUND_JSON) {
+                return Result.failure(NoSuchElementException("TMDB: Aucun résultat pour $cleanTitle"))
+            }
+            if (now - cachedEntity.fetchedAt < TTL_MS) {
+                try {
+                    val meta = json.decodeFromString<TmdbMetadata>(cachedEntity.json)
+                    return Result.success(meta)
+                } catch (e: Exception) {
+                    // Ignorer et re-fetch si JSON invalide
+                }
+            }
+        }
+
+        val apiKey = settingsRepository.getTmdbApiKey()
+        if (apiKey.isBlank()) {
+            return Result.failure(IllegalStateException("Clé API TMDB manquante"))
+        }
+
+        return try {
+            val metadata = fetchFromRemote(apiKey, lookupName, cleanTitle, video)
+            val jsonStr = json.encodeToString(metadata)
+            tmdbMetadataDao.insertMetadata(
+                TmdbMetadataEntity(
+                    queryKey = lookupName,
+                    json = jsonStr,
+                    fetchedAt = now,
+                )
+            )
+            Result.success(metadata)
+        } catch (e: NoSuchElementException) {
+            tmdbMetadataDao.insertMetadata(
+                TmdbMetadataEntity(
+                    queryKey = lookupName,
+                    json = NOT_FOUND_JSON,
+                    fetchedAt = now,
+                )
+            )
+            Result.failure(e)
+        } catch (e: Exception) {
+            // En cas d'erreur réseau / HTTP, repli sur le cache expiré si présent
+            if (cachedEntity != null && cachedEntity.json != NOT_FOUND_JSON) {
+                try {
+                    val meta = json.decodeFromString<TmdbMetadata>(cachedEntity.json)
+                    return Result.success(meta)
+                } catch (_: Exception) {
+                }
+            }
+            Result.failure(e)
+        }
+    }
+
+    private suspend fun fetchFromRemote(
+        apiKey: String,
+        lookupName: String,
+        cleanTitle: String,
+        video: VideoItem,
+    ): TmdbMetadata {
+        val searchResponse = executeWithRetryAndThrottling {
+            tmdbApi.searchMulti(apiKey, cleanTitle)
+        }
+
+        val results = searchResponse.results
+        if (results.isEmpty()) {
+            throw NoSuchElementException("Aucun résultat pour $cleanTitle")
+        }
+
+        val bestResult = selectBestMatch(results, cleanTitle, video.isTvSeries)
+            ?: throw NoSuchElementException("Aucun résultat valide pour $cleanTitle")
+
+        var collectionId: Long? = null
+        var collectionName: String? = null
+        var details: TmdbMovieDetailsDto? = null
+
+        val isMovie = bestResult.mediaType == "movie" || (!video.isTvSeries && !video.isSeriesGroup)
+        if (isMovie) {
+            try {
+                details = executeWithRetryAndThrottling {
+                    tmdbApi.getMovieDetails(bestResult.id, apiKey)
+                }
+                details.belongsToCollection?.let { col ->
+                    collectionId = col.id
+                    collectionName = col.name
+                }
+            } catch (_: Exception) {
+            }
+        }
+
+        val metadata = TmdbMetadata(
+            queryKey = lookupName,
+            tmdbId = bestResult.id,
+            title = details?.title ?: bestResult.title ?: bestResult.name ?: cleanTitle,
+            overview = details?.overview ?: bestResult.overview,
+            posterPath = details?.posterPath ?: bestResult.posterPath,
+            backdropPath = details?.backdropPath ?: bestResult.backdropPath,
+            genreIds = bestResult.genreIds ?: emptyList(),
+            releaseDate = details?.releaseDate ?: bestResult.releaseDate ?: bestResult.firstAirDate,
+            mediaType = bestResult.mediaType ?: if (video.isTvSeries) "tv" else "movie",
+            collectionId = collectionId,
+            collectionName = collectionName,
+        )
+
+        if (video.isTvSeries) {
+            fetchEpisodesForSeries(apiKey, lookupName, bestResult.id, video)
+        }
+
+        return metadata
+    }
+
+    private suspend fun fetchEpisodesForSeries(
+        apiKey: String,
+        lookupName: String,
+        tvId: Long,
+        video: VideoItem,
+    ) {
+        val seasons = video.episodes?.mapNotNull { it.season }?.distinct()?.ifEmpty { listOf(1) } ?: listOf(1)
+        for (seasonNum in seasons) {
+            try {
+                val seasonDetails = executeWithRetryAndThrottling {
+                    tmdbApi.getSeason(tvId, seasonNum, apiKey)
+                }
+                val now = System.currentTimeMillis()
+                for (epDto in seasonDetails.episodes) {
+                    val epKey = "${lookupName}_s${epDto.seasonNumber}_e${epDto.episodeNumber}"
+                    val episode = TmdbEpisode(
+                        epKey = epKey,
+                        name = epDto.name ?: "Épisode ${epDto.episodeNumber}",
+                        overview = epDto.overview ?: "(Pas de synopsis disponible)",
+                        stillPath = epDto.stillPath,
+                        seasonNumber = epDto.seasonNumber,
+                        episodeNumber = epDto.episodeNumber,
+                    )
+                    tmdbMetadataDao.insertMetadata(
+                        TmdbMetadataEntity(
+                            queryKey = epKey,
+                            json = json.encodeToString(episode),
+                            fetchedAt = now,
+                        )
+                    )
+                }
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    private fun selectBestMatch(
+        results: List<TmdbSearchResultDto>,
+        cleanTitle: String,
+        isTvSeries: Boolean,
+    ): TmdbSearchResultDto? {
+        val cleanLower = cleanTitle.lowercase()
+        val exactMatchWithPoster = results.find { dto ->
+            val name = (dto.name ?: dto.title ?: "").lowercase()
+            name == cleanLower && !dto.posterPath.isNullOrBlank()
+        }
+        if (exactMatchWithPoster != null) return exactMatchWithPoster
+
+        val exactMatchAny = results.find { dto ->
+            val name = (dto.name ?: dto.title ?: "").lowercase()
+            name == cleanLower
+        }
+        if (exactMatchAny != null) return exactMatchAny
+
+        return if (isTvSeries) {
+            results.find { it.mediaType == "tv" && !it.posterPath.isNullOrBlank() }
+                ?: results.find { !it.posterPath.isNullOrBlank() }
+                ?: results.firstOrNull()
+        } else {
+            results.find { it.mediaType == "movie" && !it.posterPath.isNullOrBlank() }
+                ?: results.find { !it.posterPath.isNullOrBlank() }
+                ?: results.firstOrNull()
+        }
+    }
+
+    suspend fun fetchAllMetadata(
+        videos: List<VideoItem>,
+        forceRefresh: Boolean = false,
+    ): List<TmdbMetadata> = coroutineScope {
+        videos.map { video ->
+            async {
+                fetchMetadataForVideo(video, forceRefresh).getOrNull()
+            }
+        }.awaitAll().filterNotNull()
+    }
+
+    suspend fun clearCache() {
+        tmdbMetadataDao.clearAll()
+    }
+
+    private suspend fun <T> executeWithRetryAndThrottling(
+        maxRetries: Int = DEFAULT_MAX_RETRIES,
+        initialDelayMs: Long = INITIAL_RETRY_DELAY_MS,
+        block: suspend () -> T,
+    ): T {
+        return semaphore.withPermit {
+            val active = activeRequests.incrementAndGet()
+            var peak = peakConcurrentRequests.get()
+            while (active > peak) {
+                if (peakConcurrentRequests.compareAndSet(peak, active)) break
+                peak = peakConcurrentRequests.get()
+            }
+            val result = try {
+                var currentDelay = initialDelayMs
+                var attempt = 0
+                var lastResult: T? = null
+                while (true) {
+                    try {
+                        lastResult = block()
+                        break
+                    } catch (e: HttpException) {
+                        if (e.code() == HTTP_UNAUTHORIZED) {
+                            throw TmdbAuthException()
+                        }
+                        if (e.code() == HTTP_TOO_MANY_REQUESTS && attempt < maxRetries) {
+                            attempt++
+                            delay(currentDelay)
+                            currentDelay *= RETRY_BACKOFF_FACTOR
+                        } else {
+                            throw e
+                        }
+                    }
+                }
+                @Suppress("UNCHECKED_CAST")
+                lastResult as T
+            } finally {
+                activeRequests.decrementAndGet()
+            }
+            result
+        }
+    }
+
+    companion object {
+        const val DEFAULT_CONCURRENCY = 4
+        const val TTL_MS = 30L * 24 * 3600 * 1000 // 30 jours
+        const val NOT_FOUND_JSON = "{}"
+        const val HTTP_UNAUTHORIZED = 401
+        const val HTTP_TOO_MANY_REQUESTS = 429
+        const val DEFAULT_MAX_RETRIES = 3
+        const val INITIAL_RETRY_DELAY_MS = 100L
+        const val RETRY_BACKOFF_FACTOR = 2
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/domain/Formatters.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/Formatters.kt
@@ -82,8 +82,13 @@ object Formatters {
 }
 
 object TmdbUrls {
-    fun posterUrl(path: String?): String? = path?.let { "https://image.tmdb.org/t/p/w342$it" }
-    fun backdropUrl(path: String?): String? = path?.let { "https://image.tmdb.org/t/p/w1280$it" }
-    fun stillUrl(path: String?): String? = path?.let { "https://image.tmdb.org/t/p/w300$it" }
+    fun posterUrl(path: String?): String? = path?.let {
+        if (it.startsWith("http")) it else "https://image.tmdb.org/t/p/w500$it"
+    }
+    fun backdropUrl(path: String?): String? = path?.let {
+        if (it.startsWith("http")) it else "https://image.tmdb.org/t/p/w1280$it"
+    }
+    fun stillUrl(path: String?): String? = path?.let {
+        if (it.startsWith("http")) it else "https://image.tmdb.org/t/p/w300$it"
+    }
 }
-

--- a/native/app/src/main/java/com/localstream/app/domain/model/TmdbEpisode.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/TmdbEpisode.kt
@@ -1,0 +1,17 @@
+package com.localstream.app.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TmdbEpisode(
+    val epKey: String = "",
+    val name: String,
+    val overview: String,
+    val stillPath: String? = null,
+    val seasonNumber: Int,
+    val episodeNumber: Int,
+) {
+    fun stillUrl(): String? = stillPath?.let {
+        if (it.startsWith("http")) it else "https://image.tmdb.org/t/p/w300$it"
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/domain/model/TmdbMetadata.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/TmdbMetadata.kt
@@ -1,0 +1,26 @@
+package com.localstream.app.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TmdbMetadata(
+    val queryKey: String = "",
+    val tmdbId: Long? = null,
+    val title: String? = null,
+    val overview: String? = null,
+    val posterPath: String? = null,
+    val backdropPath: String? = null,
+    val genreIds: List<Int> = emptyList(),
+    val releaseDate: String? = null,
+    val mediaType: String? = null,
+    val collectionId: Long? = null,
+    val collectionName: String? = null,
+) {
+    fun posterUrl(): String? = posterPath?.let {
+        if (it.startsWith("http")) it else "https://image.tmdb.org/t/p/w500$it"
+    }
+
+    fun backdropUrl(): String? = backdropPath?.let {
+        if (it.startsWith("http")) it else "https://image.tmdb.org/t/p/w1280$it"
+    }
+}

--- a/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
@@ -1,0 +1,393 @@
+package com.localstream.app.data.repository
+
+import com.localstream.app.data.db.dao.TmdbMetadataDao
+import com.localstream.app.data.db.entity.TmdbMetadataEntity
+import com.localstream.app.data.remote.tmdb.TmdbApi
+import com.localstream.app.domain.model.VideoItem
+import java.util.concurrent.Executors
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+@Suppress("MaxLineLength", "TooManyFunctions", "LargeClass", "MagicNumber")
+class TmdbRepositoryTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var tmdbApi: TmdbApi
+    private lateinit var fakeDao: FakeTmdbMetadataDao
+    private lateinit var settingsRepository: FakeSettingsRepository
+    private lateinit var repository: TmdbRepository
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        val contentType = "application/json".toMediaType()
+        val retrofit = Retrofit.Builder()
+            .baseUrl(mockWebServer.url("/"))
+            .addConverterFactory(json.asConverterFactory(contentType))
+            .build()
+
+        tmdbApi = retrofit.create(TmdbApi::class.java)
+        fakeDao = FakeTmdbMetadataDao()
+        settingsRepository = FakeSettingsRepository("test_api_key")
+
+        repository = TmdbRepository(
+            tmdbApi = tmdbApi,
+            tmdbMetadataDao = fakeDao,
+            settingsRepository = settingsRepository,
+            json = json,
+            maxConcurrentRequests = 2,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    private fun jsonResponse(body: String, code: Int = 200): MockResponse =
+        MockResponse().setResponseCode(code).setHeader("Content-Type", "application/json").setBody(body)
+
+    @Test
+    fun testFetchMetadataForMovieSuccess() = runTest {
+        val searchJson = """
+            {
+              "results": [
+                {
+                  "id": 550,
+                  "title": "Fight Club",
+                  "overview": "An unmotivated office worker...",
+                  "poster_path": "/poster_fight_club.jpg",
+                  "backdrop_path": "/backdrop_fight_club.jpg",
+                  "release_date": "1999-10-15",
+                  "genre_ids": [18, 53],
+                  "media_type": "movie"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val detailsJson = """
+            {
+              "id": 550,
+              "title": "Fight Club",
+              "poster_path": "/poster_fight_club.jpg",
+              "backdrop_path": "/backdrop_fight_club.jpg",
+              "belongs_to_collection": {
+                "id": 10,
+                "name": "Fight Club Collection"
+              }
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(jsonResponse(searchJson))
+        mockWebServer.enqueue(jsonResponse(detailsJson))
+
+        val video = VideoItem(name = "Fight.Club.1999.1080p.mp4")
+        val result = repository.fetchMetadataForVideo(video)
+
+        assertTrue(result.isSuccess)
+        val metadata = result.getOrNull()
+        assertNotNull(metadata)
+        assertEquals("Fight Club", metadata?.title)
+        assertEquals(550L, metadata?.tmdbId)
+        assertEquals("https://image.tmdb.org/t/p/w500/poster_fight_club.jpg", metadata?.posterUrl())
+        assertEquals("https://image.tmdb.org/t/p/w1280/backdrop_fight_club.jpg", metadata?.backdropUrl())
+        assertEquals(10L, metadata?.collectionId)
+        assertEquals("Fight Club Collection", metadata?.collectionName)
+
+        val cached = repository.getCachedMetadata("Fight.Club.1999.1080p.mp4")
+        assertNotNull(cached)
+        assertEquals("Fight Club", cached?.title)
+    }
+
+    @Test
+    fun testCacheHitDoesNotHitNetwork() = runTest {
+        val searchJson = """
+            {
+              "results": [
+                {
+                  "id": 100,
+                  "title": "Inception",
+                  "poster_path": "/poster.jpg",
+                  "media_type": "movie"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(jsonResponse(searchJson))
+        mockWebServer.enqueue(jsonResponse("""{"id": 100}"""))
+
+        val video = VideoItem(name = "Inception.mp4")
+        val firstResult = repository.fetchMetadataForVideo(video)
+        assertTrue(firstResult.isSuccess)
+        assertEquals(2, mockWebServer.requestCount)
+
+        val secondResult = repository.fetchMetadataForVideo(video, forceRefresh = false)
+        assertTrue(secondResult.isSuccess)
+        assertEquals(2, mockWebServer.requestCount)
+    }
+
+    @Test
+    fun testCacheExpiredTriggersNetworkFetch() = runTest {
+        val searchJson = """
+            {
+              "results": [
+                {
+                  "id": 200,
+                  "title": "Matrix",
+                  "poster_path": "/matrix.jpg",
+                  "media_type": "movie"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val expiredTimestamp = System.currentTimeMillis() - (35L * 24 * 3600 * 1000)
+        fakeDao.insertMetadata(
+            TmdbMetadataEntity(
+                queryKey = "Matrix.mp4",
+                json = """{"queryKey":"Matrix.mp4","tmdbId":200,"title":"Old Matrix"}""",
+                fetchedAt = expiredTimestamp,
+            )
+        )
+
+        mockWebServer.enqueue(jsonResponse(searchJson))
+        mockWebServer.enqueue(jsonResponse("""{"id": 200}"""))
+
+        val video = VideoItem(name = "Matrix.mp4")
+        val result = repository.fetchMetadataForVideo(video, forceRefresh = false)
+        assertTrue(result.isSuccess)
+        assertEquals("Matrix", result.getOrNull()?.title)
+        assertEquals(2, mockWebServer.requestCount)
+    }
+
+    @Test
+    fun testOfflineFallbackWithExpiredCache() = runTest {
+        val expiredTimestamp = System.currentTimeMillis() - (35L * 24 * 3600 * 1000)
+        fakeDao.insertMetadata(
+            TmdbMetadataEntity(
+                queryKey = "Interstellar.mp4",
+                json = """{"queryKey":"Interstellar.mp4","tmdbId":300,"title":"Interstellar Cached"}""",
+                fetchedAt = expiredTimestamp,
+            )
+        )
+
+        mockWebServer.enqueue(jsonResponse("Internal Error", 500))
+
+        val video = VideoItem(name = "Interstellar.mp4")
+        val result = repository.fetchMetadataForVideo(video, forceRefresh = false)
+        assertTrue(result.isSuccess)
+        assertEquals("Interstellar Cached", result.getOrNull()?.title)
+    }
+
+    @Test
+    fun testTvSeriesAndEpisodesFetch() = runTest {
+        val tvSearchJson = """
+            {
+              "results": [
+                {
+                  "id": 1399,
+                  "name": "Game of Thrones",
+                  "poster_path": "/got.jpg",
+                  "media_type": "tv"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val seasonJson = """
+            {
+              "season_number": 1,
+              "episodes": [
+                {
+                  "id": 63056,
+                  "name": "Winter Is Coming",
+                  "overview": "Lord Eddard Stark is asked to serve as Hand of the King.",
+                  "still_path": "/still_ep1.jpg",
+                  "season_number": 1,
+                  "episode_number": 1
+                }
+              ]
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(jsonResponse(tvSearchJson))
+        mockWebServer.enqueue(jsonResponse(seasonJson))
+
+        val seriesVideo = VideoItem(
+            name = "Game.of.Thrones.S01E01.mp4",
+            isSeriesGroup = true,
+            isTvSeries = true,
+            seriesName = "Game of Thrones",
+            episodes = listOf(VideoItem(name = "GOT S01E01", season = 1, episode = 1)),
+        )
+
+        val result = repository.fetchMetadataForVideo(seriesVideo)
+        assertTrue(result.isSuccess)
+
+        val episode = repository.getCachedEpisode("Game of Thrones", 1, 1)
+        assertNotNull(episode)
+        assertEquals("Winter Is Coming", episode?.name)
+        assertEquals("https://image.tmdb.org/t/p/w300/still_ep1.jpg", episode?.stillUrl())
+    }
+
+    @Test
+    fun testNotFoundReturnsErrorAndCachesMarker() = runTest {
+        val emptySearch = """{"results": []}"""
+        mockWebServer.enqueue(jsonResponse(emptySearch))
+
+        val video = VideoItem(name = "UnknownHomeMovie.mp4")
+        val result = repository.fetchMetadataForVideo(video)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is NoSuchElementException)
+
+        val secondResult = repository.fetchMetadataForVideo(video, forceRefresh = false)
+        assertTrue(secondResult.isFailure)
+        assertEquals(1, mockWebServer.requestCount)
+    }
+
+    @Test
+    fun test401UnauthorizedThrowsTmdbAuthException() = runTest {
+        mockWebServer.enqueue(jsonResponse("""{"status_message": "Invalid API key"}""", 401))
+
+        val video = VideoItem(name = "TestMovie.mp4")
+        val result = repository.fetchMetadataForVideo(video)
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is TmdbAuthException)
+    }
+
+    @Test
+    fun test429RateLimitBackoffAndRetry() = runTest {
+        val searchJson = """
+            {
+              "results": [
+                {
+                  "id": 99,
+                  "title": "Avatar",
+                  "poster_path": "/avatar.jpg",
+                  "media_type": "movie"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(jsonResponse("""{"status_message": "Rate limit exceeded"}""", 429))
+        mockWebServer.enqueue(jsonResponse(searchJson))
+        mockWebServer.enqueue(jsonResponse("""{"id": 99}"""))
+
+        val video = VideoItem(name = "Avatar.mp4")
+        val result = repository.fetchMetadataForVideo(video)
+
+        assertTrue(result.isSuccess)
+        assertEquals("Avatar", result.getOrNull()?.title)
+        assertEquals(3, mockWebServer.requestCount)
+    }
+
+    @Test
+    fun testThrottlingLimitsConcurrency() {
+        val searchJson = """
+            {
+              "results": [
+                {
+                  "id": 1,
+                  "title": "Movie",
+                  "media_type": "movie"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        repeat(6) {
+            mockWebServer.enqueue(jsonResponse(searchJson))
+            mockWebServer.enqueue(jsonResponse("""{"id": 1}"""))
+        }
+
+        repository.resetMetrics()
+
+        val threadPool = Executors.newFixedThreadPool(4)
+        val customDispatcher = threadPool.asCoroutineDispatcher()
+        try {
+            runBlocking(customDispatcher) {
+                val videos = (1..3).map { VideoItem(name = "Movie $it.mp4") }
+                val deferreds = videos.map { v ->
+                    async { repository.fetchMetadataForVideo(v) }
+                }
+                deferreds.awaitAll()
+            }
+        } finally {
+            customDispatcher.close()
+            threadPool.shutdownNow()
+        }
+
+        assertTrue(
+            "Expected max concurrent <= 2, got ${repository.maxObservedConcurrentRequests}",
+            repository.maxObservedConcurrentRequests <= 2
+        )
+    }
+
+    @Test
+    fun testTestApiKey() = runTest {
+        val popularJson = """{"results": [{"id": 1, "title": "Popular Movie"}]}"""
+        mockWebServer.enqueue(jsonResponse(popularJson))
+
+        val validResult = repository.testApiKey("valid_key")
+        assertTrue(validResult.isSuccess)
+        assertTrue(validResult.getOrNull() == true)
+
+        mockWebServer.enqueue(jsonResponse("""{"status_message": "Invalid API Key"}""", 401))
+        val invalidResult = repository.testApiKey("invalid_key")
+        assertTrue(invalidResult.isFailure)
+        assertTrue(invalidResult.exceptionOrNull() is TmdbAuthException)
+    }
+}
+
+class FakeSettingsRepository(var key: String = "test_api_key") : SettingsRepository() {
+    override fun getTmdbApiKey(): String = key
+    override fun saveTmdbApiKey(key: String) { this.key = key }
+}
+
+class FakeTmdbMetadataDao : TmdbMetadataDao {
+    private val map = mutableMapOf<String, TmdbMetadataEntity>()
+
+    override suspend fun getMetadata(queryKey: String): TmdbMetadataEntity? {
+        return map[queryKey]
+    }
+
+    override suspend fun insertMetadata(entity: TmdbMetadataEntity) {
+        map[entity.queryKey] = entity
+    }
+
+    override suspend fun deleteMetadata(queryKey: String) {
+        map.remove(queryKey)
+    }
+
+    override suspend fun clearAll() {
+        map.clear()
+    }
+
+    override suspend fun getAll(): List<TmdbMetadataEntity> {
+        return map.values.toList()
+    }
+}

--- a/native/app/src/test/java/com/localstream/app/domain/FormattersTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/FormattersTest.kt
@@ -47,10 +47,9 @@ class FormattersTest {
 
     @Test
     fun tmdbUrls_buildsCorrectImageUrls() {
-        assertEquals("https://image.tmdb.org/t/p/w342/abc.jpg", TmdbUrls.posterUrl("/abc.jpg"))
+        assertEquals("https://image.tmdb.org/t/p/w500/abc.jpg", TmdbUrls.posterUrl("/abc.jpg"))
         assertEquals("https://image.tmdb.org/t/p/w1280/abc.jpg", TmdbUrls.backdropUrl("/abc.jpg"))
         assertEquals("https://image.tmdb.org/t/p/w300/abc.jpg", TmdbUrls.stillUrl("/abc.jpg"))
         assertNull(TmdbUrls.posterUrl(null))
     }
 }
-

--- a/native/gradle/libs.versions.toml
+++ b/native/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
-# Catalogue de versions centralis\u00e9 (Gradle Version Catalog).
-# Une seule source de v\u00e9rit\u00e9 pour les versions de d\u00e9pendances/plugins du module natif.
+# Catalogue de versions centralisé (Gradle Version Catalog).
+# Une seule source de vérité pour les versions de dépendances/plugins du module natif.
 [versions]
 agp = "8.13.0"
 kotlin = "2.0.21"
@@ -19,6 +19,11 @@ securityCrypto = "1.1.0-alpha06"
 coroutines = "1.9.0"
 json = "20240303"
 ksp = "2.0.21-1.0.28"
+# Phase 5 — API TMDB, Retrofit, Coil, OkHttp
+retrofit = "2.11.0"
+okhttp = "4.12.0"
+kotlinxSerializationJson = "1.7.3"
+coil = "2.7.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -50,11 +55,21 @@ security-crypto = { group = "androidx.security", name = "security-crypto", versi
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 json = { group = "org.json", name = "json", version.ref = "json" }
+# Phase 5 — API TMDB, Retrofit, Coil, OkHttp
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-converter-kotlinx-serialization = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-# Phase 4 — KSP (g\u00e9n\u00e9rateur Room)
+# Phase 4 — KSP (générateur Room)
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+# Phase 5 — Kotlin Serialization
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## Contexte
Résolution de l'issue #37 (Phase 5 — Client TMDB natif : Retrofit, cache Room, images Coil).

## Description des changements
- **Client API TMDB (Retrofit & DTOs)** :
  - Interface TmdbApi avec Retrofit 2 + kotlinx.serialization.
  - DTOs sérialisables pour la recherche multi/films, les détails de films/collections et les saisons d'épisodes.
- **Modèles de domaine** :
  - Modèles TmdbMetadata et TmdbEpisode avec helpers pour les URLs d'images (posterUrl, ackdropUrl, stillUrl).
- **Cache persistant Room & Entité TMDB** :
  - Entité TmdbMetadataEntity (table 	mdb_metadata avec clé, JSON et date de récupération) et TmdbMetadataDao.
  - Migration de la base AppDatabase vers la version 2.
  - TTL de 30 jours et marqueur NOT_FOUND pour éviter les requêtes répétitives sur contenus non répertoriés.
- **Orchestration & Throttling dans TmdbRepository** :
  - Throttling de la concurrence avec Semaphore (4 requêtes concourantes max par défaut).
  - Gestion du rate-limit TMDB (HTTP 429) avec réessais et backoff exponentiel.
  - Gestion des erreurs HTTP 401 (TmdbAuthException) et repli hors-ligne sur le cache expiré en cas de problème réseau.
  - Méthode 	estApiKey() pour valider la clé API TMDB.
- **Images Coil** :
  - Dépendances coil-compose et okhttp-logging-interceptor.
- **Validation & Tests unitaires** :
  - Tests unitaires complets avec MockWebServer couvrant la recherche, les détails de films, les séries/épisodes, le cache Room, la concurrence et la gestion d'erreurs.
  - Suite de tests JVM et analyse detekt validées.