### PR TITLE
feat(native): client OpenSubtitles natif et pipeline sous-titres (Phase 6, #38)

### DIFF
--- a/native/app/src/main/java/com/localstream/app/data/local/EncryptedPreferencesManager.kt
+++ b/native/app/src/main/java/com/localstream/app/data/local/EncryptedPreferencesManager.kt
@@ -1,4 +1,4 @@
-﻿package com.localstream.app.data.local
+package com.localstream.app.data.local
 
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
@@ -46,6 +46,11 @@ class EncryptedPreferencesManager(context: Context) {
         get() = prefs.getString(KEY_OPENSUB_PASS, "") ?: ""
         set(value) = prefs.edit().putString(KEY_OPENSUB_PASS, value).apply()
 
+    /** Jeton de session OpenSubtitles (Phase 6) — effacé sur 401 définitif. */
+    var openSubtitlesToken: String
+        get() = prefs.getString(KEY_OPENSUB_TOKEN, "") ?: ""
+        set(value) = prefs.edit().putString(KEY_OPENSUB_TOKEN, value).apply()
+
     /** Efface tous les credentials chiffr\u00e9s (utilis\u00e9 lors de la d\u00e9connexion). */
     fun clearAll() = prefs.edit().clear().apply()
 
@@ -55,5 +60,6 @@ class EncryptedPreferencesManager(context: Context) {
         private const val KEY_OPENSUB_API_KEY = "opensub_api_key"
         private const val KEY_OPENSUB_USER = "opensub_username"
         private const val KEY_OPENSUB_PASS = "opensub_password"
+        private const val KEY_OPENSUB_TOKEN = "opensub_token"
     }
 }

--- a/native/app/src/main/java/com/localstream/app/data/local/SubtitleCache.kt
+++ b/native/app/src/main/java/com/localstream/app/data/local/SubtitleCache.kt
@@ -1,0 +1,54 @@
+package com.localstream.app.data.local
+
+import java.io.File
+
+/**
+ * Cache disque des sous-titres téléchargés : `cacheDir/subtitles/{file_id}.srt`.
+ *
+ * Nettoyage LRU : au-delà de [MAX_SIZE_BYTES] (50 Mo), les fichiers les moins
+ * récemment utilisés sont supprimés en premier.
+ */
+class SubtitleCache(
+    private val cacheDir: File,
+    private val maxSizeBytes: Long = MAX_SIZE_BYTES,
+) {
+
+    private val subtitlesDir: File get() = File(cacheDir, SUBTITLES_DIR)
+
+    fun get(fileId: String): File? {
+        val file = File(subtitlesDir, fileName(fileId))
+        return if (file.isFile) file else null
+    }
+
+    /** Écrit le .srt sur disque puis déclenche le nettoyage LRU. */
+    fun store(fileId: String, bytes: ByteArray): File {
+        val dir = subtitlesDir.apply { mkdirs() }
+        val file = File(dir, fileName(fileId))
+        file.writeBytes(bytes)
+        file.setLastModified(System.currentTimeMillis())
+        evictIfNeeded()
+        return file
+    }
+
+    fun clear() {
+        subtitlesDir.deleteRecursively()
+    }
+
+    private fun evictIfNeeded() {
+        val files = subtitlesDir.listFiles()?.filter { it.isFile } ?: return
+        var total = files.sumOf { it.length() }
+        if (total <= maxSizeBytes) return
+        for (file in files.sortedBy { it.lastModified() }) {
+            if (total <= maxSizeBytes) break
+            val size = file.length()
+            if (file.delete()) total -= size
+        }
+    }
+
+    private fun fileName(fileId: String) = "$fileId.srt"
+
+    companion object {
+        const val SUBTITLES_DIR = "subtitles"
+        const val MAX_SIZE_BYTES = 50L * 1024 * 1024 // 50 Mo
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/data/remote/opensubtitles/OpenSubtitlesApi.kt
+++ b/native/app/src/main/java/com/localstream/app/data/remote/opensubtitles/OpenSubtitlesApi.kt
@@ -1,0 +1,50 @@
+package com.localstream.app.data.remote.opensubtitles
+
+import com.localstream.app.data.remote.opensubtitles.dto.OsDownloadRequest
+import com.localstream.app.data.remote.opensubtitles.dto.OsDownloadResponse
+import com.localstream.app.data.remote.opensubtitles.dto.OsLoginRequest
+import com.localstream.app.data.remote.opensubtitles.dto.OsLoginResponse
+import com.localstream.app.data.remote.opensubtitles.dto.OsSearchResponse
+import okhttp3.ResponseBody
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.Query
+import retrofit2.http.Url
+
+/**
+ * API Retrofit OpenSubtitles (Phase 6).
+ *
+ * Remplace `src/lib/opensubtitles.ts` : appels directs, sans proxy Express ni
+ * CapacitorHttp. Les en-têtes `Api-Key` / `User-Agent` sont ajoutés par
+ * [OpenSubtitlesInterceptor] ; seul le `Authorization: Bearer` (jeton de
+ * téléchargement) est passé en paramètre.
+ */
+interface OpenSubtitlesApi {
+
+    @POST("login")
+    suspend fun login(@Body body: OsLoginRequest): OsLoginResponse
+
+    @GET("subtitles")
+    suspend fun search(
+        @Query("query") query: String,
+        @Query("languages") languages: String = DEFAULT_LANGUAGES,
+    ): OsSearchResponse
+
+    @POST("download")
+    suspend fun requestDownload(
+        @Body body: OsDownloadRequest,
+        @Header("Authorization") authorization: String,
+    ): Response<OsDownloadResponse>
+
+    /** Téléchargement du fichier .srt depuis le lien direct renvoyé par [requestDownload]. */
+    @GET
+    suspend fun downloadFile(@Url url: String): Response<ResponseBody>
+
+    companion object {
+        const val BASE_URL = "https://api.opensubtitles.com/api/v1/"
+        const val DEFAULT_LANGUAGES = "fr,en"
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/data/remote/opensubtitles/OpenSubtitlesInterceptor.kt
+++ b/native/app/src/main/java/com/localstream/app/data/remote/opensubtitles/OpenSubtitlesInterceptor.kt
@@ -1,0 +1,27 @@
+package com.localstream.app.data.remote.opensubtitles
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Interceptor OkHttp centralisant les en-têtes exigés par OpenSubtitles :
+ * `Api-Key` (obligatoire sur toutes les routes) et `User-Agent` (identifiant
+ * applicatif requis par leur politique d'usage).
+ */
+class OpenSubtitlesInterceptor(
+    private val apiKeyProvider: () -> String,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+            .header("Api-Key", apiKeyProvider())
+            .header("User-Agent", USER_AGENT)
+            .header("Accept", "application/json")
+            .build()
+        return chain.proceed(request)
+    }
+
+    companion object {
+        const val USER_AGENT = "LocalStream v0.1"
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/data/remote/opensubtitles/dto/OpenSubtitlesDtos.kt
+++ b/native/app/src/main/java/com/localstream/app/data/remote/opensubtitles/dto/OpenSubtitlesDtos.kt
@@ -1,0 +1,49 @@
+package com.localstream.app.data.remote.opensubtitles.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** DTOs de l'API OpenSubtitles v1 (https://api.opensubtitles.com/api/v1/). */
+
+@Serializable
+data class OsLoginRequest(
+    val username: String,
+    val password: String,
+)
+
+@Serializable
+data class OsLoginResponse(
+    val token: String? = null,
+)
+
+@Serializable
+data class OsSearchResponse(
+    val data: List<OsSubtitleDto> = emptyList(),
+)
+
+@Serializable
+data class OsSubtitleDto(
+    val attributes: OsSubtitleAttributesDto? = null,
+)
+
+@Serializable
+data class OsSubtitleAttributesDto(
+    val language: String = "",
+    val files: List<OsSubtitleFileDto> = emptyList(),
+)
+
+@Serializable
+data class OsSubtitleFileDto(
+    @SerialName("file_id") val fileId: Long = 0,
+    @SerialName("file_name") val fileName: String = "",
+)
+
+@Serializable
+data class OsDownloadRequest(
+    @SerialName("file_id") val fileId: Long,
+)
+
+@Serializable
+data class OsDownloadResponse(
+    val link: String? = null,
+)

--- a/native/app/src/main/java/com/localstream/app/data/repository/OpenSubtitlesRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/OpenSubtitlesRepository.kt
@@ -1,0 +1,131 @@
+package com.localstream.app.data.repository
+
+import com.localstream.app.data.local.SubtitleCache
+import com.localstream.app.data.remote.opensubtitles.OpenSubtitlesApi
+import com.localstream.app.data.remote.opensubtitles.dto.OsDownloadRequest
+import com.localstream.app.data.remote.opensubtitles.dto.OsLoginRequest
+import com.localstream.app.domain.TitleCleaner
+import com.localstream.app.domain.model.SubtitleInfo
+import java.io.File
+import java.io.IOException
+import retrofit2.HttpException
+
+/** Échec d'authentification OpenSubtitles — l'utilisateur doit se reconnecter. */
+class OpenSubtitlesAuthException(
+    message: String = "Session OpenSubtitles expirée — reconnectez-vous",
+) : Exception(message)
+
+/**
+ * Repository OpenSubtitles natif (Phase 6) : login, recherche, téléchargement.
+ *
+ * - Jeton stocké chiffré via [SettingsRepository] (Phase 4).
+ * - Sur 401 : re-login silencieux une fois, puis [OpenSubtitlesAuthException].
+ * - Les .srt sont écrits dans [SubtitleCache] — pas de conversion VTT, ExoPlayer
+ *   lit le SRT directement (MimeTypes.APPLICATION_SUBRIP).
+ */
+@Suppress("TooGenericExceptionCaught", "ReturnCount", "ThrowsCount")
+class OpenSubtitlesRepository(
+    private val api: OpenSubtitlesApi,
+    private val settingsRepository: SettingsRepository,
+    private val subtitleCache: SubtitleCache,
+) {
+
+    /** Authentifie l'utilisateur et mémorise le jeton (chiffré). */
+    suspend fun login(): Result<String> = loginInternal()
+
+    /** Recherche des sous-titres FR/EN pour un titre (nettoyé via [TitleCleaner]). */
+    suspend fun search(rawQuery: String): Result<List<SubtitleInfo>> {
+        if (settingsRepository.getOpenSubtitlesApiKey().isBlank()) {
+            return Result.failure(IllegalStateException("Clé API OpenSubtitles manquante"))
+        }
+        return try {
+            val query = TitleCleaner.getCleanTitle(rawQuery)
+            val response = api.search(query)
+            val subtitles = response.data.mapNotNull { dto ->
+                val attributes = dto.attributes ?: return@mapNotNull null
+                val file = attributes.files.firstOrNull() ?: return@mapNotNull null
+                SubtitleInfo(
+                    id = file.fileId.toString(),
+                    language = attributes.language,
+                    filename = file.fileName,
+                )
+            }
+            Result.success(subtitles)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /** Télécharge le .srt dans le cache (ou renvoie le fichier déjà en cache). */
+    suspend fun downloadSubtitle(fileId: String): Result<File> {
+        subtitleCache.get(fileId)?.let { return Result.success(it) }
+
+        var token = settingsRepository.getOpenSubtitlesToken()
+        if (token.isBlank()) {
+            token = loginInternal().getOrElse { return Result.failure(it) }
+        }
+
+        return try {
+            Result.success(downloadWithToken(fileId, token, allowRelogin = true))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private suspend fun downloadWithToken(fileId: String, token: String, allowRelogin: Boolean): File {
+        val response = api.requestDownload(
+            OsDownloadRequest(fileId.toLong()),
+            bearer(token),
+        )
+        if (response.code() == HTTP_UNAUTHORIZED) {
+            if (!allowRelogin) {
+                settingsRepository.saveOpenSubtitlesToken("")
+                throw OpenSubtitlesAuthException()
+            }
+            // Jeton expiré : re-login silencieux une seule fois.
+            val newToken = loginInternal().getOrThrow()
+            return downloadWithToken(fileId, newToken, allowRelogin = false)
+        }
+        if (!response.isSuccessful) throw HttpException(response)
+
+        val link = response.body()?.link
+            ?: throw IOException("Lien de téléchargement OpenSubtitles indisponible")
+
+        val fileResponse = api.downloadFile(link)
+        if (!fileResponse.isSuccessful) throw HttpException(fileResponse)
+        val bytes = fileResponse.body()?.bytes()
+            ?: throw IOException("Fichier de sous-titres vide")
+        return subtitleCache.store(fileId, bytes)
+    }
+
+    private suspend fun loginInternal(): Result<String> {
+        val username = settingsRepository.getOpenSubtitlesUsername()
+        val password = settingsRepository.getOpenSubtitlesPassword()
+        if (username.isBlank() || password.isBlank()) {
+            return Result.failure(IllegalStateException("Identifiants OpenSubtitles manquants"))
+        }
+        return try {
+            val token = api.login(OsLoginRequest(username, password)).token
+            if (token.isNullOrBlank()) {
+                Result.failure(OpenSubtitlesAuthException("Connexion OpenSubtitles refusée"))
+            } else {
+                settingsRepository.saveOpenSubtitlesToken(token)
+                Result.success(token)
+            }
+        } catch (e: HttpException) {
+            if (e.code() == HTTP_UNAUTHORIZED) {
+                Result.failure(OpenSubtitlesAuthException("Identifiants OpenSubtitles invalides"))
+            } else {
+                Result.failure(e)
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private fun bearer(token: String) = "Bearer $token"
+
+    companion object {
+        const val HTTP_UNAUTHORIZED = 401
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/data/repository/SettingsRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/SettingsRepository.kt
@@ -31,6 +31,9 @@ open class SettingsRepository(
     open fun getOpenSubtitlesPassword(): String = encryptedPrefs?.openSubtitlesPassword ?: ""
     open fun saveOpenSubtitlesPassword(password: String) { encryptedPrefs?.openSubtitlesPassword = password }
 
+    open fun getOpenSubtitlesToken(): String = encryptedPrefs?.openSubtitlesToken ?: ""
+    open fun saveOpenSubtitlesToken(token: String) { encryptedPrefs?.openSubtitlesToken = token }
+
     // -------- Préférences DataStore --------
 
     open val videoPlayerMode: Flow<String> get() = dataStore?.videoPlayerMode ?: emptyFlow()

--- a/native/app/src/main/java/com/localstream/app/domain/SubtitleSelector.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/SubtitleSelector.kt
@@ -1,0 +1,14 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.SubtitleEntry
+
+/**
+ * Priorité de sélection des sous-titres (Phase 6, étape 5) :
+ * sous-titre choisi manuellement > sous-titre auto-détecté (matching MediaStore, Phase 3).
+ */
+object SubtitleSelector {
+
+    /** Renvoie l'uri du sous-titre à utiliser : [manualUri] si présent, sinon l'auto-détecté. */
+    fun select(manualUri: String?, autoDetected: SubtitleEntry?): String? =
+        manualUri ?: autoDetected?.uri
+}

--- a/native/app/src/main/java/com/localstream/app/ui/subtitles/SubtitlePicker.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/subtitles/SubtitlePicker.kt
@@ -1,0 +1,60 @@
+package com.localstream.app.ui.subtitles
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+
+/**
+ * Sélection locale d'un fichier de sous-titres via SAF (port Kotlin de
+ * `VideoLauncherPlugin.pickSubtitle`, Phase 6 étape 4).
+ *
+ * La permission de lecture persistée est prise pour pouvoir rejouer le fichier
+ * après redémarrage de l'app.
+ */
+class SubtitlePicker(
+    private val activity: ComponentActivity,
+    private val onSubtitlePicked: (uri: Uri, displayName: String) -> Unit,
+) {
+
+    private val launcher = activity.registerForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        if (uri == null) return@registerForActivityResult
+        try {
+            activity.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION,
+            )
+        } catch (_: SecurityException) {
+            // Provider sans permission persistable : l'uri reste utilisable pour la session.
+        }
+        onSubtitlePicked(uri, queryDisplayName(activity, uri))
+    }
+
+    /** Ouvre le sélecteur de documents filtré sur les formats de sous-titres. */
+    fun launch() = launcher.launch(MIME_TYPES)
+
+    private fun queryDisplayName(context: Context, uri: Uri): String {
+        val fallback = uri.lastPathSegment ?: DEFAULT_NAME
+        return runCatching {
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index >= 0 && cursor.moveToFirst()) cursor.getString(index) else fallback
+            } ?: fallback
+        }.getOrDefault(fallback)
+    }
+
+    companion object {
+        // srt/vtt/ass sont souvent exposés comme text/plain ou octet-stream.
+        val MIME_TYPES = arrayOf(
+            "application/x-subrip",
+            "text/vtt",
+            "text/plain",
+            "application/octet-stream",
+        )
+        const val DEFAULT_NAME = "subtitle.srt"
+    }
+}

--- a/native/app/src/test/java/com/localstream/app/data/local/SubtitleCacheTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/local/SubtitleCacheTest.kt
@@ -1,0 +1,79 @@
+package com.localstream.app.data.local
+
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SubtitleCacheTest {
+
+    private lateinit var cacheDir: java.io.File
+
+    @Before
+    fun setUp() {
+        cacheDir = Files.createTempDirectory("subtitle_cache_test").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun storeThenGetReturnsFile() {
+        val cache = SubtitleCache(cacheDir)
+
+        val file = cache.store("42", "contenu".toByteArray())
+
+        assertEquals("42.srt", file.name)
+        assertEquals(SubtitleCache.SUBTITLES_DIR, file.parentFile?.name)
+        assertNotNull(cache.get("42"))
+        assertEquals("contenu", cache.get("42")!!.readText())
+    }
+
+    @Test
+    fun getReturnsNullForUnknownFile() {
+        val cache = SubtitleCache(cacheDir)
+
+        assertNull(cache.get("unknown"))
+    }
+
+    @Test
+    fun lruEvictionRemovesOldestFilesAboveMaxSize() {
+        val maxSize = 100L
+        val cache = SubtitleCache(cacheDir, maxSize)
+
+        val old = cache.store("old", ByteArray(60))
+        old.setLastModified(1_000L)
+        cache.store("new", ByteArray(60))
+
+        assertNull("Le plus ancien fichier doit être évincé", cache.get("old"))
+        assertNotNull(cache.get("new"))
+    }
+
+    @Test
+    fun noEvictionBelowMaxSize() {
+        val cache = SubtitleCache(cacheDir, 1_000L)
+
+        cache.store("a", ByteArray(40))
+        cache.store("b", ByteArray(40))
+
+        assertNotNull(cache.get("a"))
+        assertNotNull(cache.get("b"))
+    }
+
+    @Test
+    fun clearEmptiesCache() {
+        val cache = SubtitleCache(cacheDir)
+        cache.store("a", ByteArray(10))
+
+        cache.clear()
+
+        assertNull(cache.get("a"))
+        assertTrue(true)
+    }
+}

--- a/native/app/src/test/java/com/localstream/app/data/repository/OpenSubtitlesRepositoryTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/repository/OpenSubtitlesRepositoryTest.kt
@@ -1,0 +1,233 @@
+package com.localstream.app.data.repository
+
+import com.localstream.app.data.local.SubtitleCache
+import com.localstream.app.data.remote.opensubtitles.OpenSubtitlesApi
+import com.localstream.app.data.remote.opensubtitles.OpenSubtitlesInterceptor
+import java.io.File
+import java.nio.file.Files
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+@Suppress("MaxLineLength", "TooManyFunctions")
+class OpenSubtitlesRepositoryTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var api: OpenSubtitlesApi
+    private lateinit var settings: FakeOsSettingsRepository
+    private lateinit var cacheDir: File
+    private lateinit var repository: OpenSubtitlesRepository
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        val json = Json { ignoreUnknownKeys = true; isLenient = true }
+        val contentType = "application/json".toMediaType()
+        val client = OkHttpClient.Builder()
+            .addInterceptor(OpenSubtitlesInterceptor { "os_test_key" })
+            .build()
+        val retrofit = Retrofit.Builder()
+            .baseUrl(mockWebServer.url("/"))
+            .client(client)
+            .addConverterFactory(json.asConverterFactory(contentType))
+            .build()
+
+        api = retrofit.create(OpenSubtitlesApi::class.java)
+        settings = FakeOsSettingsRepository()
+        cacheDir = Files.createTempDirectory("os_cache_test").toFile()
+        repository = OpenSubtitlesRepository(api, settings, SubtitleCache(cacheDir))
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+        cacheDir.deleteRecursively()
+    }
+
+    private fun jsonResponse(body: String, code: Int = 200): MockResponse =
+        MockResponse().setResponseCode(code).setHeader("Content-Type", "application/json").setBody(body)
+
+    @Test
+    fun loginSuccessSavesEncryptedToken() = runTest {
+        mockWebServer.enqueue(jsonResponse("""{"token":"tok123"}"""))
+
+        val result = repository.login()
+
+        assertTrue(result.isSuccess)
+        assertEquals("tok123", result.getOrNull())
+        assertEquals("tok123", settings.token)
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("/login", request.path)
+        assertEquals("os_test_key", request.getHeader("Api-Key"))
+        assertEquals(OpenSubtitlesInterceptor.USER_AGENT, request.getHeader("User-Agent"))
+    }
+
+    @Test
+    fun loginUnauthorizedReturnsAuthException() = runTest {
+        mockWebServer.enqueue(jsonResponse("""{"message":"Unauthorized"}""", code = 401))
+
+        val result = repository.login()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is OpenSubtitlesAuthException)
+        assertEquals("", settings.token)
+    }
+
+    @Test
+    fun loginFailsWithoutCredentials() = runTest {
+        settings.username = ""
+        settings.password = ""
+
+        val result = repository.login()
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalStateException)
+    }
+
+    @Test
+    fun searchMapsResultsLikeOsSearch() = runTest {
+        val body = """
+            {"data":[
+              {"id":"1","type":"subtitle","attributes":{"language":"fr","files":[{"file_id":456,"file_name":"fight.club.fr.srt"}]}},
+              {"id":"2","type":"subtitle","attributes":{"language":"en","files":[{"file_id":457,"file_name":"fight.club.en.srt"}]}},
+              {"id":"3","type":"subtitle","attributes":{"language":"fr","files":[]}}
+            ]}
+        """.trimIndent()
+        mockWebServer.enqueue(jsonResponse(body))
+
+        val result = repository.search("Fight Club (1999) 1080p")
+
+        assertTrue(result.isSuccess)
+        val subtitles = result.getOrThrow()
+        assertEquals(2, subtitles.size)
+        assertEquals("456", subtitles[0].id)
+        assertEquals("fr", subtitles[0].language)
+        assertEquals("fight.club.fr.srt", subtitles[0].filename)
+
+        val request = mockWebServer.takeRequest()
+        assertTrue(request.path!!.startsWith("/subtitles?"))
+        assertTrue(request.path!!.contains("languages=fr%2Cen"))
+    }
+
+    @Test
+    fun searchFailsWithoutApiKey() = runTest {
+        settings.apiKey = ""
+
+        val result = repository.search("Fight Club")
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalStateException)
+    }
+
+    @Test
+    fun downloadSavesSrtInCache() = runTest {
+        settings.token = "valid_token"
+        val link = mockWebServer.url("/file/456.srt").toString()
+        mockWebServer.enqueue(jsonResponse("""{"link":"$link"}"""))
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("1\n00:00:01,000 --> 00:00:02,000\nBonjour\n"))
+
+        val result = repository.downloadSubtitle("456")
+
+        assertTrue(result.isSuccess)
+        val file = result.getOrThrow()
+        assertEquals("456.srt", file.name)
+        assertEquals("subtitles", file.parentFile?.name)
+        assertTrue(file.readText().contains("Bonjour"))
+
+        val downloadRequest = mockWebServer.takeRequest()
+        assertEquals("/download", downloadRequest.path)
+        assertEquals("Bearer valid_token", downloadRequest.getHeader("Authorization"))
+        assertTrue(downloadRequest.body.readUtf8().contains("456"))
+    }
+
+    @Test
+    fun downloadReturnsCachedFileWithoutNetwork() = runTest {
+        val cache = SubtitleCache(cacheDir)
+        val cached = cache.store("789", "cached".toByteArray())
+
+        val result = repository.downloadSubtitle("789")
+
+        assertTrue(result.isSuccess)
+        assertEquals(cached.absolutePath, result.getOrThrow().absolutePath)
+        assertEquals(0, mockWebServer.requestCount)
+    }
+
+    @Test
+    fun downloadRelogsInSilentlyOn401ThenSucceeds() = runTest {
+        settings.token = "expired"
+        mockWebServer.enqueue(jsonResponse("""{"message":"Unauthorized"}""", code = 401))
+        mockWebServer.enqueue(jsonResponse("""{"token":"fresh"}"""))
+        val link = mockWebServer.url("/file/456.srt").toString()
+        mockWebServer.enqueue(jsonResponse("""{"link":"$link"}"""))
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("srt-content"))
+
+        val result = repository.downloadSubtitle("456")
+
+        assertTrue(result.isSuccess)
+        assertEquals("fresh", settings.token)
+
+        mockWebServer.takeRequest() // 401 download
+        mockWebServer.takeRequest() // login
+        val retryRequest = mockWebServer.takeRequest()
+        assertEquals("Bearer fresh", retryRequest.getHeader("Authorization"))
+    }
+
+    @Test
+    fun downloadFailsWithClearAuthErrorAfterRelogin() = runTest {
+        settings.token = "expired"
+        mockWebServer.enqueue(jsonResponse("""{"message":"Unauthorized"}""", code = 401))
+        mockWebServer.enqueue(jsonResponse("""{"token":"fresh"}"""))
+        mockWebServer.enqueue(jsonResponse("""{"message":"Unauthorized"}""", code = 401))
+
+        val result = repository.downloadSubtitle("456")
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is OpenSubtitlesAuthException)
+        assertEquals("", settings.token)
+    }
+
+    @Test
+    fun downloadLogsInWhenNoTokenStored() = runTest {
+        settings.token = ""
+        mockWebServer.enqueue(jsonResponse("""{"token":"fresh"}"""))
+        val link = mockWebServer.url("/file/456.srt").toString()
+        mockWebServer.enqueue(jsonResponse("""{"link":"$link"}"""))
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("srt-content"))
+
+        val result = repository.downloadSubtitle("456")
+
+        assertTrue(result.isSuccess)
+        assertEquals("fresh", settings.token)
+        assertNotNull(result.getOrThrow())
+    }
+}
+
+class FakeOsSettingsRepository : SettingsRepository() {
+    var apiKey = "os_test_key"
+    var username = "user"
+    var password = "pass"
+    var token = ""
+
+    override fun getOpenSubtitlesApiKey(): String = apiKey
+    override fun saveOpenSubtitlesApiKey(key: String) { apiKey = key }
+    override fun getOpenSubtitlesUsername(): String = username
+    override fun saveOpenSubtitlesUsername(username: String) { this.username = username }
+    override fun getOpenSubtitlesPassword(): String = password
+    override fun saveOpenSubtitlesPassword(password: String) { this.password = password }
+    override fun getOpenSubtitlesToken(): String = token
+    override fun saveOpenSubtitlesToken(token: String) { this.token = token }
+}

--- a/native/app/src/test/java/com/localstream/app/domain/SubtitleSelectorTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/SubtitleSelectorTest.kt
@@ -1,0 +1,30 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.SubtitleEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SubtitleSelectorTest {
+
+    private val auto = SubtitleEntry(name = "film.srt", folder = "/movies", uri = "content://auto/film.srt")
+
+    @Test
+    fun manualSubtitleWinsOverAutoDetected() {
+        val selected = SubtitleSelector.select("content://manual/picked.srt", auto)
+
+        assertEquals("content://manual/picked.srt", selected)
+    }
+
+    @Test
+    fun fallsBackToAutoDetected() {
+        val selected = SubtitleSelector.select(null, auto)
+
+        assertEquals("content://auto/film.srt", selected)
+    }
+
+    @Test
+    fun returnsNullWhenNothingAvailable() {
+        assertNull(SubtitleSelector.select(null, null))
+    }
+}


### PR DESCRIPTION
## Objet

Implémente l'issue #38 (Phase 6) : client OpenSubtitles natif Kotlin, sans proxy Express ni conversion VTT.

Closes #38

## Changements

- **API Retrofit** \OpenSubtitlesApi\ (login / search / download) — DTOs kotlinx.serialization, même mapping que \osSearch\ (id, language, filename).
- **\OpenSubtitlesInterceptor\** OkHttp centralisant les en-têtes \Api-Key\ et \User-Agent\ exigés par OpenSubtitles.
- **\OpenSubtitlesRepository\** : login, recherche (titre nettoyé via \TitleCleaner\), téléchargement. Jeton stocké chiffré (Phase 4, \EncryptedPreferencesManager\ + \SettingsRepository\). Sur 401 → re-login silencieux **une fois**, puis \OpenSubtitlesAuthException\ (« reconnectez-vous ») sans crash, jeton effacé.
- **\SubtitleCache\** : \.srt\ écrits dans \cacheDir/subtitles/{file_id}.srt\, nettoyage LRU au-delà de 50 Mo. Pas de \srt2vtt\ : ExoPlayer lit le SRT via \MimeTypes.APPLICATION_SUBRIP\.
- **\SubtitlePicker\** : port Kotlin du SAF \ACTION_OPEN_DOCUMENT\ de \VideoLauncherPlugin.pickSubtitle\ (srt/vtt/ass, permission persistée, display name).
- **\SubtitleSelector\** : priorité sous-titre manuel > auto-détecté (matching MediaStore Phase 3).

## Notes de migration

- \server.ts\ (proxy \/api/os/proxy\) et \http.ts#externalRequest\ n'ont **pas d'équivalent natif** — plus nécessaires sans CORS.
- \srt2vtt\ non porté (utile uniquement pour \<track>\ HTML).

## Tests

- 18 nouveaux tests (\MockWebServer\ + unitaires) : login OK/401/credentials manquants, search mapping + clé absente, download OK/cache-hit sans réseau/401→re-login→succès/401 définitif→erreur propre/login auto si pas de jeton, LRU éviction, sélecteur de priorité.
- \./gradlew assembleDebug testDebugUnitTest detekt\ : **BUILD SUCCESSFUL** en local.
- Reste à faire (non automatisable) : test manuel sur compte réel + affichage du .srt dans PlayerActivity (Phase 9).