### PR TITLE
feat(native): UI Compose Accueil (Hero + rows), Recherche, Bibliothèque (Phase 7, #39)

### DIFF
--- a/native/README.md
+++ b/native/README.md
@@ -68,11 +68,11 @@ Correspondance entre l'UI web actuelle (`../src/`) et les écrans natifs cibles.
 
 | Écran natif (route)      | Source web (`src/`)                         | Onglet       | Statut socle |
 | ------------------------ | ------------------------------------------- | ------------ | ------------ |
-| `home`                   | `components/screens/HomeScreen.tsx`         | Accueil      | Placeholder  |
-| `library`                | `components/screens/LibraryScreen.tsx`      | Bibliothèque | Placeholder  |
+| `home`                   | `components/screens/HomeScreen.tsx`         | Accueil      | Phase 7 ✅   |
+| `library`                | `components/screens/LibraryScreen.tsx`      | Bibliothèque | Phase 7 ✅   |
 | `playlists`              | `components/screens/PlaylistsScreen.tsx`    | Listes       | Placeholder  |
 | `history`                | `components/screens/HistoryScreen.tsx`      | Historique   | Placeholder  |
-| `search`                 | `components/screens/SearchScreen.tsx`       | —            | Placeholder  |
+| `search`                 | `components/screens/SearchScreen.tsx`       | —            | Phase 7 ✅   |
 | `settings`               | `components/SettingsModal.tsx`              | —            | Placeholder  |
 | `details/{id}`           | vue Héro / détails (`HomeScreen` + modales) | —            | Placeholder  |
 

--- a/native/app/build.gradle.kts
+++ b/native/app/build.gradle.kts
@@ -57,6 +57,8 @@ detekt {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.compose) // Phase 7
+    implementation(libs.androidx.lifecycle.runtime.compose) // Phase 7
     implementation(libs.androidx.activity.compose)
 
     implementation(platform(libs.androidx.compose.bom))

--- a/native/app/src/main/AndroidManifest.xml
+++ b/native/app/src/main/AndroidManifest.xml
@@ -1,7 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Accès réseau : métadonnées TMDB / OpenSubtitles -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <!-- Scan MediaStore (Phase 3) : lecture des vidéos du stockage partagé.
+         READ_MEDIA_VIDEO à partir d'Android 13, READ_EXTERNAL_STORAGE avant. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
     <application
+        android:name=".LocalStreamApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/native/app/src/main/java/com/localstream/app/LocalStreamApplication.kt
+++ b/native/app/src/main/java/com/localstream/app/LocalStreamApplication.kt
@@ -1,0 +1,20 @@
+package com.localstream.app
+
+import android.app.Application
+import com.localstream.app.di.AppContainer
+
+/**
+ * Application de l'app native : héberge le [AppContainer] (injection manuelle).
+ * Instanciée avant toute activité ; le conteneur est accessible via
+ * `(context.applicationContext as LocalStreamApplication).container`.
+ */
+class LocalStreamApplication : Application() {
+
+    lateinit var container: AppContainer
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        container = AppContainer(this)
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/data/local/UserPreferencesDataStore.kt
+++ b/native/app/src/main/java/com/localstream/app/data/local/UserPreferencesDataStore.kt
@@ -78,11 +78,23 @@ class UserPreferencesDataStore(private val context: Context) {
         ds.edit { it[Keys.LEGACY_IMPORT_DONE] = true }
     }
 
+    // -------- Bannière onboarding TMDB --------
+
+    /** true si l'utilisateur a masqué la bannière "Configurer TMDB" de l'accueil. */
+    val tmdbBannerDismissed: Flow<Boolean> = ds.data.map { prefs ->
+        prefs[Keys.TMDB_BANNER_DISMISSED] ?: false
+    }
+
+    suspend fun dismissTmdbBanner() {
+        ds.edit { it[Keys.TMDB_BANNER_DISMISSED] = true }
+    }
+
     private object Keys {
         val WHITELISTED_VIDEOS = stringSetPreferencesKey("whitelisted_videos")
         val FORCE_AVAILABLE_JSON = stringPreferencesKey("force_available_json")
         val VIDEO_PLAYER_MODE = stringPreferencesKey("video_player_mode")
         val EXTERNAL_PLAYER_PACKAGE = stringPreferencesKey("external_player_package")
         val LEGACY_IMPORT_DONE = booleanPreferencesKey("legacy_import_done")
+        val TMDB_BANNER_DISMISSED = booleanPreferencesKey("tmdb_banner_dismissed")
     }
 }

--- a/native/app/src/main/java/com/localstream/app/data/repository/SettingsRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/SettingsRepository.kt
@@ -52,4 +52,7 @@ open class SettingsRepository(
 
     open val legacyImportDone: Flow<Boolean> get() = dataStore?.legacyImportDone ?: emptyFlow()
     open suspend fun markLegacyImportDone() { dataStore?.markLegacyImportDone() }
+
+    open val tmdbBannerDismissed: Flow<Boolean> get() = dataStore?.tmdbBannerDismissed ?: emptyFlow()
+    open suspend fun dismissTmdbBanner() { dataStore?.dismissTmdbBanner() }
 }

--- a/native/app/src/main/java/com/localstream/app/data/repository/VideoRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/VideoRepository.kt
@@ -2,6 +2,7 @@
 
 import com.localstream.app.data.scanner.MediaScanner
 import com.localstream.app.domain.HeroSelector
+import com.localstream.app.domain.VideoGrouper
 import com.localstream.app.domain.VideoFilterSorter
 import com.localstream.app.domain.model.FilterSortOptions
 import com.localstream.app.domain.model.MovieCollection
@@ -36,6 +37,26 @@ class VideoRepository(
 
     fun getGroupedVideos(): List<VideoItem> = groupedVideos
     fun getRawVideos(): List<VideoItem> = rawVideos
+
+    /**
+     * Regroupe les vidéos déjà scannées (Phase 7) : re-applique [VideoGrouper] sur
+     * le dernier scan brut avec les collections TMDB / dates de sortie fraîchement
+     * récupérées, sans relancer une requête MediaStore. Permet le regroupement en
+     * sagas après enrichissement des métadonnées.
+     */
+    fun regroup(
+        movieCollections: Map<String, MovieCollection> = emptyMap(),
+        releaseDates: Map<String, String> = emptyMap(),
+        whitelistedVideos: Set<String> = emptySet(),
+    ): List<VideoItem> {
+        groupedVideos = VideoGrouper.groupVideos(
+            videos = rawVideos,
+            movieCollections = movieCollections,
+            releaseDates = releaseDates,
+            whitelistedVideos = whitelistedVideos,
+        )
+        return groupedVideos
+    }
 
     fun getFilteredAndSortedVideos(
         opts: FilterSortOptions,

--- a/native/app/src/main/java/com/localstream/app/di/AppContainer.kt
+++ b/native/app/src/main/java/com/localstream/app/di/AppContainer.kt
@@ -1,0 +1,69 @@
+package com.localstream.app.di
+
+import android.content.Context
+import com.localstream.app.data.db.AppDatabase
+import com.localstream.app.data.local.EncryptedPreferencesManager
+import com.localstream.app.data.local.UserPreferencesDataStore
+import com.localstream.app.data.remote.tmdb.TmdbApi
+import com.localstream.app.data.repository.SettingsRepository
+import com.localstream.app.data.repository.TmdbRepository
+import com.localstream.app.data.repository.VideoRepository
+import com.localstream.app.data.repository.WatchStateRepository
+import com.localstream.app.data.scanner.MediaStoreScanner
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+/**
+ * Conteneur d'injection manuelle (pas de Hilt, cf. README du module).
+ * Construit le graphe de dépendances une fois au démarrage de l'application :
+ * Room, DataStore, Retrofit/TMDB, repositories partagés par les ViewModels.
+ */
+class AppContainer(context: Context) {
+
+    private val appContext: Context = context.applicationContext
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    private val database: AppDatabase by lazy { AppDatabase.getInstance(appContext) }
+
+    private val okHttpClient: OkHttpClient by lazy { OkHttpClient.Builder().build() }
+
+    private val tmdbApi: TmdbApi by lazy {
+        Retrofit.Builder()
+            .baseUrl(TmdbApi.BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(TmdbApi::class.java)
+    }
+
+    val settingsRepository: SettingsRepository by lazy {
+        SettingsRepository(
+            encryptedPrefs = EncryptedPreferencesManager(appContext),
+            dataStore = UserPreferencesDataStore(appContext),
+        )
+    }
+
+    val videoRepository: VideoRepository by lazy {
+        VideoRepository(mediaScanner = MediaStoreScanner(appContext))
+    }
+
+    val watchStateRepository: WatchStateRepository by lazy {
+        WatchStateRepository(
+            watchedItemDao = database.watchedItemDao(),
+            playbackStateDao = database.playbackStateDao(),
+        )
+    }
+
+    val tmdbRepository: TmdbRepository by lazy {
+        TmdbRepository(
+            tmdbApi = tmdbApi,
+            tmdbMetadataDao = database.tmdbMetadataDao(),
+            settingsRepository = settingsRepository,
+            json = json,
+        )
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/domain/HomeRowsDeriver.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/HomeRowsDeriver.kt
@@ -1,0 +1,108 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.VideoItem
+import java.io.File
+
+/** Une row "Dossier : X" de la page d'accueil. */
+data class FolderRow(
+    val title: String,
+    val items: List<VideoItem>,
+)
+
+/** Ensemble des rows de la page d'accueil, dans l'ordre d'affichage exact. */
+data class HomeRows(
+    val heroCandidates: List<VideoItem>,
+    val continueWatching: List<VideoItem>,
+    val recentAdditions: List<VideoItem>,
+    val recommendations: List<VideoItem>,
+    val series: List<VideoItem>,
+    val movies: List<VideoItem>,
+    val folderRows: List<FolderRow>,
+    val alphabetical: List<VideoItem>,
+)
+
+/**
+ * Dérivation pure des rows de l'accueil (réf. `HomeScreen.tsx` + `App.tsx`).
+ *
+ * Ordre exact : "Continuer la lecture" (si non vide), "Nouveautés" (15),
+ * "Recommandations" (15), "Séries", "Films", une row par dossier non-système,
+ * "De A à Z".
+ */
+object HomeRowsDeriver {
+
+    const val ROW_LIMIT = 15
+    const val CONTINUE_MAX_PROGRESS = 95.0
+
+    /**
+     * Dossiers considérés "système" (caméra, réseaux sociaux, dossiers internes
+     * Android) : exclus des rows par dossier, comme le filtrage des vidéos
+     * personnelles côté web.
+     */
+    private val SYSTEM_FOLDERS = setOf(
+        "dcim", "camera", "pictures", "screenshots", "recordings",
+        "whatsapp", "telegram", "snapchat", "instagram", "tiktok",
+        "messenger", "signal", "viber", "android", ".thumbnails", "lost.dir",
+    )
+
+    fun derive(
+        grouped: List<VideoItem>,
+        filteredSorted: List<VideoItem>,
+        watched: Map<String, Boolean>,
+        progress: Map<String, Double>,
+    ): HomeRows {
+        val heroCandidates = HeroSelector.getHeroCandidates(grouped, watched, progress)
+            .ifEmpty { listOfNotNull(filteredSorted.firstOrNull() ?: grouped.firstOrNull()) }
+
+        return HomeRows(
+            heroCandidates = heroCandidates,
+            continueWatching = filteredSorted.filter { v ->
+                val p = progress[v.name] ?: 0.0
+                p > 0.0 && p < CONTINUE_MAX_PROGRESS
+            },
+            // Ordre du scan (MediaStore : plus récent d'abord), inversé comme le web.
+            recentAdditions = grouped.asReversed().take(ROW_LIMIT),
+            recommendations = grouped.take(ROW_LIMIT),
+            series = grouped.filter { it.isSeriesGroup },
+            movies = grouped.filter { !it.isSeriesGroup },
+            folderRows = deriveFolderRows(grouped),
+            alphabetical = filteredSorted.sortedWith(
+                compareBy<VideoItem, String>(String.CASE_INSENSITIVE_ORDER) { it.name }
+                    .thenBy { it.name },
+            ),
+        )
+    }
+
+    /**
+     * Regroupe par dossier parent (basename du chemin), exclut les dossiers
+     * système et la racine, tri alphabétique, items dans l'ordre du scan.
+     */
+    private fun deriveFolderRows(grouped: List<VideoItem>): List<FolderRow> {
+        val byFolder = linkedMapOf<String, MutableList<VideoItem>>()
+        grouped.forEach { video ->
+            val folder = folderNameOf(video) ?: return@forEach
+            byFolder.getOrPut(folder) { mutableListOf() }.add(video)
+        }
+        return byFolder.entries
+            .sortedBy { it.key.lowercase() }
+            .map { (folder, items) -> FolderRow(title = "Dossier : $folder", items = items.toList()) }
+    }
+
+    private fun folderNameOf(video: VideoItem): String? {
+        val path = if (video.isSeriesGroup) {
+            video.episodes?.firstOrNull()?.path ?: video.path
+        } else {
+            video.path
+        }
+        var dir = path.takeIf { it.isNotBlank() }?.let { File(it).parent }
+        if (dir != null && video.isSeriesGroup && video.isTvSeries) {
+            // Les épisodes vivent dans un dossier dédié à la série
+            // (".../Series/Show/S01E01.mkv") : on remonte d'un niveau pour
+            // retrouver le dossier "bibliothèque" ("Series") et éviter une
+            // row par série.
+            dir = File(dir).parent
+        }
+        return dir
+            ?.let { File(it).name.trim() }
+            ?.takeIf { it.isNotEmpty() && it.lowercase() !in SYSTEM_FOLDERS }
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/domain/VideoUiSelectors.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/VideoUiSelectors.kt
@@ -1,0 +1,56 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.VideoItem
+
+/**
+ * Sélecteurs purs partagés par les écrans (Accueil, Recherche, Bibliothèque).
+ * Portage exact de la logique de `VideoRow.tsx` / `VideoCard.tsx` (Phase 0).
+ */
+object VideoUiSelectors {
+
+    /**
+     * "Vu" d'un item : pour un groupe (série/saga), tous les épisodes doivent
+     * être marqués vus ; pour un film, l'entrée du nom dans la map.
+     */
+    fun isWatched(video: VideoItem, watched: Map<String, Boolean>): Boolean =
+        if (video.isSeriesGroup) {
+            !video.episodes.isNullOrEmpty() && video.episodes.all { watched[it.name] == true }
+        } else {
+            watched[video.name] == true
+        }
+
+    /**
+     * Progression affichée (0-100) : pour un groupe, la progression est stockée
+     * par épisode — on retient celle du premier épisode en cours (0 < p < 100).
+     */
+    fun progressOf(video: VideoItem, progress: Map<String, Double>): Double =
+        if (video.isSeriesGroup && video.episodes != null) {
+            video.episodes
+                .map { progress[it.name] ?: 0.0 }
+                .firstOrNull { it > 0.0 && it < 100.0 } ?: 0.0
+        } else {
+            progress[video.name] ?: 0.0
+        }
+
+    /**
+     * Clé de recherche des métadonnées TMDB (affiche, backdrop, synopsis) :
+     * le nom de série pour les groupes, sinon le nom du fichier
+     * (équivalent du `posterKey` web).
+     */
+    fun metadataKey(video: VideoItem): String = video.seriesName ?: video.name
+
+    /** Titre affiché sous la vignette (équivalent du `title` de VideoCard.tsx). */
+    fun displayTitle(video: VideoItem): String =
+        if (video.isSeriesGroup) {
+            video.seriesName ?: video.name
+        } else {
+            video.seriesName ?: TitleCleaner.getCleanTitle(video.name)
+        }
+
+    /** Filtrage de recherche insensible à la casse (équivalent App.tsx). */
+    fun filterByQuery(videos: List<VideoItem>, query: String): List<VideoItem> {
+        val q = query.trim()
+        if (q.isEmpty()) return emptyList()
+        return videos.filter { it.name.contains(q, ignoreCase = true) }
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/ui/components/FilterBar.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/FilterBar.kt
@@ -1,0 +1,156 @@
+package com.localstream.app.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.localstream.app.domain.model.ResolutionFilter
+import com.localstream.app.domain.model.SortBy
+import com.localstream.app.domain.model.TmdbGenre
+import com.localstream.app.ui.theme.White
+import com.localstream.app.ui.theme.Zinc500
+import com.localstream.app.ui.theme.Zinc900
+
+/**
+ * Barre de tri et de filtres de la bibliothèque (équivalent Compose de
+ * `FilterBar.tsx`) : tri (A-Z, date, taille, durée), genre TMDB et qualité
+ * en chips Material 3 avec menus déroulants.
+ */
+@Composable
+fun LibraryFilterBar(
+    sortBy: SortBy,
+    filterGenre: Int?,
+    filterResolution: ResolutionFilter,
+    onSortBy: (SortBy) -> Unit,
+    onFilterGenre: (Int?) -> Unit,
+    onFilterResolution: (ResolutionFilter) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        FilterMenuChip(
+            label = "Trier",
+            value = sortByLabel(sortBy),
+            items = listOf(SortBy.ALPHA, SortBy.DATE, SortBy.SIZE, SortBy.DURATION),
+            itemLabel = { sortByLabel(it) },
+            onSelect = onSortBy,
+        )
+        FilterMenuChip(
+            label = "Genre",
+            value = filterGenre?.let { TmdbGenre.getGenreName(it) } ?: "Tous les genres",
+            items = listOf<Int?>(null) + TmdbGenre.entries.map { it.id as Int? },
+            itemLabel = { it?.let(TmdbGenre::getGenreName) ?: "Tous les genres" },
+            onSelect = onFilterGenre,
+        )
+        FilterMenuChip(
+            label = "Qualité",
+            value = resolutionLabel(filterResolution),
+            items = listOf(
+                ResolutionFilter.ALL,
+                ResolutionFilter.FOUR_K,
+                ResolutionFilter.ONE_THOUSAND_EIGHTY_P,
+                ResolutionFilter.SEVEN_HUNDRED_TWENTY_P,
+                ResolutionFilter.SD,
+            ),
+            itemLabel = { resolutionLabel(it) },
+            onSelect = onFilterResolution,
+        )
+    }
+}
+
+@Composable
+private fun <T> FilterMenuChip(
+    label: String,
+    value: String,
+    items: List<T>,
+    itemLabel: (T) -> String,
+    onSelect: (T) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Surface(
+        shape = CircleShape,
+        color = Zinc900.copy(alpha = 0.9f),
+        border = BorderStroke(1.dp, Zinc500.copy(alpha = 0.4f)),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .clickable { expanded = true }
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+        ) {
+            Text(
+                text = "$label : ",
+                color = Zinc500,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = value,
+                color = White,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+            )
+            Icon(
+                imageVector = Icons.Filled.ArrowDropDown,
+                contentDescription = null,
+                tint = Zinc500,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            items.forEach { item ->
+                DropdownMenuItem(
+                    text = { Text(itemLabel(item)) },
+                    onClick = {
+                        expanded = false
+                        onSelect(item)
+                    },
+                )
+            }
+        }
+    }
+}
+
+private fun sortByLabel(sortBy: SortBy): String = when (sortBy) {
+    SortBy.ALPHA -> "A-Z"
+    SortBy.DATE -> "Date d'ajout"
+    SortBy.SIZE -> "Taille"
+    SortBy.DURATION -> "Durée"
+}
+
+private fun resolutionLabel(filter: ResolutionFilter): String = when (filter) {
+    ResolutionFilter.ALL -> "Toutes"
+    ResolutionFilter.FOUR_K -> "4K / 2160p"
+    ResolutionFilter.TWO_K -> "2K / 1440p"
+    ResolutionFilter.ONE_THOUSAND_EIGHTY_P -> "1080p"
+    ResolutionFilter.SEVEN_HUNDRED_TWENTY_P -> "720p"
+    ResolutionFilter.SD -> "SD"
+}

--- a/native/app/src/main/java/com/localstream/app/ui/components/HeroSection.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/HeroSection.kt
@@ -1,0 +1,209 @@
+package com.localstream.app.ui.components
+
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.localstream.app.domain.TitleCleaner
+import com.localstream.app.domain.VideoUiSelectors
+import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoItem
+import com.localstream.app.ui.theme.White
+import com.localstream.app.ui.theme.Zinc300
+import com.localstream.app.ui.theme.Zinc500
+import com.localstream.app.ui.theme.Zinc800
+import kotlinx.coroutines.delay
+
+/** Rotation du hero toutes les 10 s (comme le web). */
+private const val HERO_ROTATION_MS = 10_000L
+private const val HERO_HEIGHT_FRACTION = 0.62f
+private const val HERO_FADE_MS = 700
+
+/**
+ * Hero plein écran de l'accueil (réf. `HomeScreen.tsx` + `hero.ts`) : backdrop
+ * TMDB, dégradés noirs (bas + gauche), titre nettoyé, synopsis, boutons
+ * "Lecture" et "Plus d'infos".
+ *
+ * La rotation automatique est interne au composable : son état est local, donc
+ * le tick des 10 s ne recompose ni les rows ni le reste de l'écran.
+ */
+@Composable
+fun HeroSection(
+    candidates: List<VideoItem>,
+    metadata: Map<String, TmdbMetadata>,
+    onPlay: (VideoItem) -> Unit,
+    onOpenDetails: (VideoItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (candidates.isEmpty()) return
+
+    var heroIndex by rememberSaveable { mutableIntStateOf(0) }
+    LaunchedEffect(candidates.size) {
+        if (candidates.size <= 1) return@LaunchedEffect
+        while (true) {
+            delay(HERO_ROTATION_MS)
+            heroIndex += 1
+        }
+    }
+
+    val hero = candidates[heroIndex % candidates.size]
+    val heroHeight = LocalConfiguration.current.screenHeightDp.dp * HERO_HEIGHT_FRACTION
+
+    Crossfade(
+        targetState = hero,
+        animationSpec = tween(durationMillis = HERO_FADE_MS),
+        modifier = modifier
+            .fillMaxWidth()
+            .height(heroHeight),
+        label = "hero-crossfade",
+    ) { current ->
+        HeroContent(
+            hero = current,
+            metadata = metadata[VideoUiSelectors.metadataKey(current)],
+            onPlay = { onPlay(current) },
+            onOpenDetails = { onOpenDetails(current) },
+        )
+    }
+}
+
+@Composable
+private fun HeroContent(
+    hero: VideoItem,
+    metadata: TmdbMetadata?,
+    onPlay: () -> Unit,
+    onOpenDetails: () -> Unit,
+) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        val imageUrl = metadata?.backdropUrl() ?: metadata?.posterUrl()
+        if (imageUrl != null) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = hero.name,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Zinc800),
+            )
+        }
+
+        // Dégradés noirs : bas (vertical) + gauche (horizontal), comme le web.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(Color.Transparent, Color.Black),
+                    ),
+                ),
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.horizontalGradient(
+                        colors = listOf(Color.Black, Color.Black.copy(alpha = 0.6f), Color.Transparent),
+                    ),
+                ),
+        )
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(start = 16.dp, end = 16.dp, bottom = 48.dp)
+                .widthIn(max = 560.dp),
+        ) {
+            Text(
+                text = TitleCleaner.getCleanTitle(hero.name),
+                color = White,
+                style = MaterialTheme.typography.displaySmall,
+                fontWeight = FontWeight.Bold,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            metadata?.overview?.takeIf { it.isNotBlank() }?.let { overview ->
+                Text(
+                    text = overview,
+                    color = Zinc300,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+            }
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(top = 16.dp),
+            ) {
+                Button(
+                    onClick = onPlay,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = White,
+                        contentColor = Color.Black,
+                    ),
+                    shape = RoundedCornerShape(4.dp),
+                ) {
+                    Icon(Icons.Filled.PlayArrow, contentDescription = null)
+                    Text(
+                        text = "Lecture",
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(start = 4.dp),
+                    )
+                }
+                Button(
+                    onClick = onOpenDetails,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Zinc500.copy(alpha = 0.7f),
+                        contentColor = White,
+                    ),
+                    shape = RoundedCornerShape(4.dp),
+                ) {
+                    Icon(Icons.Filled.Info, contentDescription = null)
+                    Text(
+                        text = "Plus d'infos",
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(start = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/ui/components/TopBar.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/TopBar.kt
@@ -1,0 +1,127 @@
+package com.localstream.app.ui.components
+
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.localstream.app.ui.theme.Red600
+import com.localstream.app.ui.theme.White
+
+/**
+ * Barre supérieure (équivalent Compose de `AppHeader.tsx`) : logo "LOCALSTREAM"
+ * rouge (retour accueil + reset des filtres), indicateur de chargement TMDB,
+ * recherche, réglages.
+ *
+ * [solid] : fond noir opaque (écrans Recherche/Bibliothèque) ; sinon dégradé
+ * noir → transparent au-dessus du hero, qui devient opaque au scroll (géré par
+ * l'appelant via [solid] dérivé du LazyListState).
+ */
+@Composable
+fun TopBar(
+    solid: Boolean,
+    showSearch: Boolean,
+    isFetchingMetadata: Boolean,
+    onLogoClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val background = if (solid) {
+        Modifier.background(Color.Black)
+    } else {
+        Modifier.background(
+            Brush.verticalGradient(
+                colors = listOf(Color.Black.copy(alpha = 0.8f), Color.Transparent),
+            ),
+        )
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(background)
+            .statusBarsPadding()
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "LOCALSTREAM",
+            color = Red600,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Black,
+            letterSpacing = (-0.5).sp,
+            modifier = Modifier.clickable(onClick = onLogoClick),
+        )
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (isFetchingMetadata) {
+                SpinningRefreshIcon()
+            }
+            if (showSearch) {
+                IconButton(onClick = onSearchClick) {
+                    Icon(
+                        imageVector = Icons.Filled.Search,
+                        contentDescription = "Rechercher",
+                        tint = White,
+                    )
+                }
+            }
+            IconButton(onClick = onSettingsClick) {
+                Icon(
+                    imageVector = Icons.Filled.Settings,
+                    contentDescription = "Paramètres",
+                    tint = White,
+                )
+            }
+        }
+    }
+}
+
+/** Indicateur de récupération TMDB en cours (RefreshCw animé du web). */
+@Composable
+private fun SpinningRefreshIcon() {
+    val transition = rememberInfiniteTransition(label = "tmdb-refresh")
+    val angle by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(animation = tween(durationMillis = 1000)),
+        label = "rotation",
+    )
+    Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+        Icon(
+            imageVector = Icons.Filled.Refresh,
+            contentDescription = "Récupération des métadonnées TMDB en cours",
+            tint = Red600,
+            modifier = Modifier
+                .size(18.dp)
+                .rotate(angle),
+        )
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoCard.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoCard.kt
@@ -1,0 +1,236 @@
+package com.localstream.app.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Replay
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.localstream.app.domain.Formatters
+import com.localstream.app.domain.VideoUiSelectors
+import com.localstream.app.domain.model.VideoItem
+import com.localstream.app.ui.theme.Red600
+import com.localstream.app.ui.theme.Zinc500
+import com.localstream.app.ui.theme.Zinc800
+
+private val WatchedGreen = Color(0xFF16A34A) // green-600 Tailwind
+private val ProgressTrack = Color(0xFF52525B) // zinc-600 Tailwind
+
+/**
+ * Carte d'affiche vidéo (équivalent Compose de `VideoCard.tsx`) :
+ * vignette 2/3, badge résolution, badge Série/Saga, coche verte "vu",
+ * barre de progression rouge, bouton reset de progression optionnel.
+ *
+ * Les contenus vus sont atténués (opacité + désaturation), comme sur le web.
+ */
+@Composable
+fun VideoCard(
+    video: VideoItem,
+    posterUrl: String?,
+    isWatched: Boolean,
+    progress: Double,
+    showResetProgress: Boolean,
+    onClick: () -> Unit,
+    onResetProgress: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val title = VideoUiSelectors.displayTitle(video)
+    // Comme le web (VideoCard.tsx) : la résolution est déduite du nom de l'item
+    // affiché — pas de badge sur un groupe dont le nom est un titre de série.
+    val resolution = Formatters.getResolution(video.name)
+
+    Column(modifier = modifier) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(2f / 3f)
+                .clip(RoundedCornerShape(6.dp))
+                .background(Zinc800)
+                .clickable(onClick = onClick),
+        ) {
+            PosterImage(
+                posterUrl = posterUrl,
+                title = title,
+                isWatched = isWatched,
+            )
+
+            // Badge type (Série / Saga) — coin haut gauche.
+            if (video.isSeriesGroup) {
+                Badge(
+                    text = if (video.isTvSeries) "Série" else "Saga",
+                    background = Red600,
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(8.dp),
+                )
+            }
+
+            // Coche "vu" — coin haut droit.
+            if (isWatched) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(8.dp)
+                        .size(18.dp)
+                        .background(WatchedGreen, CircleShape),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = "Vu",
+                        tint = Color.White,
+                        modifier = Modifier.size(12.dp),
+                    )
+                }
+            }
+
+            // Badge résolution — coin bas gauche.
+            if (resolution.isNotEmpty()) {
+                Badge(
+                    text = resolution,
+                    background = Color.Black.copy(alpha = 0.7f),
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(8.dp),
+                )
+            }
+
+            // Bouton reset progression — coin bas droit (row "Continuer la lecture").
+            if (showResetProgress && progress > 0.0) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(6.dp)
+                        .size(28.dp)
+                        .clip(CircleShape)
+                        .background(Color.Black.copy(alpha = 0.6f))
+                        .clickable(onClick = onResetProgress),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Replay,
+                        contentDescription = "Reprendre à zéro",
+                        tint = Color.White,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            }
+
+            // Barre de progression rouge — bas de la vignette.
+            if (progress > 0.0 && progress < 100.0) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .fillMaxWidth()
+                        .height(4.dp)
+                        .background(ProgressTrack),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth((progress / 100.0).toFloat().coerceIn(0f, 1f))
+                            .height(4.dp)
+                            .background(Red600),
+                    )
+                }
+            }
+        }
+
+        // Titre sous la vignette.
+        Text(
+            text = title,
+            color = Zinc500,
+            style = MaterialTheme.typography.labelSmall,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(start = 4.dp, top = 6.dp),
+        )
+    }
+}
+
+/** Affiche Coil, ou placeholder zinc-800 avec le titre nettoyé (comme le web). */
+@Composable
+private fun PosterImage(
+    posterUrl: String?,
+    title: String,
+    isWatched: Boolean,
+) {
+    val dimmed = if (isWatched) Modifier.alpha(0.5f) else Modifier
+    if (posterUrl != null) {
+        AsyncImage(
+            model = posterUrl,
+            contentDescription = title,
+            contentScale = ContentScale.Crop,
+            colorFilter = if (isWatched) {
+                ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0.25f) })
+            } else {
+                null
+            },
+            modifier = Modifier
+                .fillMaxSize()
+                .then(dimmed),
+        )
+    } else {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .then(dimmed)
+                .padding(12.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = title,
+                color = Zinc500,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium,
+                textAlign = TextAlign.Center,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun Badge(
+    text: String,
+    background: Color,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text.uppercase(),
+        color = Color.White,
+        fontSize = 9.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = modifier
+            .background(background, RoundedCornerShape(4.dp))
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+    )
+}

--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoGrid.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoGrid.kt
@@ -1,0 +1,53 @@
+package com.localstream.app.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.localstream.app.domain.VideoUiSelectors
+import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoItem
+
+/**
+ * Grille adaptative d'affiches (réf. grilles de `SearchScreen.tsx` /
+ * `LibraryScreen.tsx` : 2 à 6 colonnes selon la largeur, minSize ~110 dp).
+ * Clés stables pour limiter les recompositions.
+ */
+@Composable
+fun VideoGrid(
+    videos: List<VideoItem>,
+    metadata: Map<String, TmdbMetadata>,
+    watched: Map<String, Boolean>,
+    progress: Map<String, Double>,
+    onOpenDetails: (VideoItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(minSize = 110.dp),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 24.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier.fillMaxSize(),
+    ) {
+        items(
+            items = videos,
+            key = { it.nativeUri?.takeIf(String::isNotEmpty) ?: it.path.ifEmpty { it.name } },
+        ) { video ->
+            val meta = metadata[VideoUiSelectors.metadataKey(video)]
+            VideoCard(
+                video = video,
+                posterUrl = meta?.posterUrl(),
+                isWatched = VideoUiSelectors.isWatched(video, watched),
+                progress = VideoUiSelectors.progressOf(video, progress),
+                showResetProgress = false,
+                onClick = { onOpenDetails(video) },
+                onResetProgress = {},
+            )
+        }
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoRow.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoRow.kt
@@ -1,0 +1,69 @@
+package com.localstream.app.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.localstream.app.domain.VideoUiSelectors
+import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoItem
+import com.localstream.app.ui.theme.White
+
+/**
+ * Carrousel horizontal d'affiches (équivalent Compose de `VideoRow.tsx`).
+ * Clés stables pour éviter les recompositions inutiles au fil des mises à jour.
+ */
+@Composable
+fun VideoRow(
+    title: String,
+    items: List<VideoItem>,
+    metadata: Map<String, TmdbMetadata>,
+    watched: Map<String, Boolean>,
+    progress: Map<String, Double>,
+    showResetProgress: Boolean,
+    onOpenDetails: (VideoItem) -> Unit,
+    onResetProgress: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (items.isEmpty()) return
+
+    Column(modifier = modifier.padding(bottom = 24.dp)) {
+        Text(
+            text = title,
+            color = White,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        )
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(
+                items = items,
+                key = { it.nativeUri?.takeIf(String::isNotEmpty) ?: it.path.ifEmpty { it.name } },
+            ) { video ->
+                val meta = metadata[VideoUiSelectors.metadataKey(video)]
+                VideoCard(
+                    video = video,
+                    posterUrl = meta?.posterUrl(),
+                    isWatched = VideoUiSelectors.isWatched(video, watched),
+                    progress = VideoUiSelectors.progressOf(video, progress),
+                    showResetProgress = showResetProgress,
+                    onClick = { onOpenDetails(video) },
+                    onResetProgress = { onResetProgress(video.name) },
+                    modifier = Modifier.width(112.dp),
+                )
+            }
+        }
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/ui/home/HomeViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/home/HomeViewModel.kt
@@ -1,0 +1,95 @@
+package com.localstream.app.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.localstream.app.domain.FolderRow
+import com.localstream.app.domain.HomeRowsDeriver
+import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoItem
+import com.localstream.app.ui.library.LibraryUiState
+import com.localstream.app.ui.library.LibraryViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * État de l'écran d'accueil : les rows dans l'ordre exact du web plus les
+ * données d'affichage (métadonnées, vu/progression, bannière TMDB).
+ */
+data class HomeUiState(
+    val isLoading: Boolean = true,
+    val isFetchingMetadata: Boolean = false,
+    val hasContent: Boolean = false,
+    val heroCandidates: List<VideoItem> = emptyList(),
+    val continueWatching: List<VideoItem> = emptyList(),
+    val recentAdditions: List<VideoItem> = emptyList(),
+    val recommendations: List<VideoItem> = emptyList(),
+    val series: List<VideoItem> = emptyList(),
+    val movies: List<VideoItem> = emptyList(),
+    val folderRows: List<FolderRow> = emptyList(),
+    val alphabetical: List<VideoItem> = emptyList(),
+    val metadata: Map<String, TmdbMetadata> = emptyMap(),
+    val watched: Map<String, Boolean> = emptyMap(),
+    val progress: Map<String, Double> = emptyMap(),
+    val showTmdbBanner: Boolean = false,
+)
+
+/**
+ * ViewModel de l'accueil (Phase 7) : dérive les rows de l'état bibliothèque
+ * via [HomeRowsDeriver] (pur). Aucune E/S propre — le scan et l'enrichissement
+ * restent la responsabilité du [LibraryViewModel] partagé.
+ */
+class HomeViewModel(
+    libraryUiState: StateFlow<LibraryUiState>,
+) : ViewModel() {
+
+    val uiState: StateFlow<HomeUiState> = libraryUiState
+        .map { deriveHomeUiState(it) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS),
+            initialValue = HomeUiState(),
+        )
+
+    companion object {
+        private const val STOP_TIMEOUT_MS = 5_000L
+
+        /** Projection pure LibraryUiState → HomeUiState (testable sans Android). */
+        fun deriveHomeUiState(state: LibraryUiState): HomeUiState {
+            val rows = HomeRowsDeriver.derive(
+                grouped = state.videos,
+                filteredSorted = state.filteredSorted,
+                watched = state.watched,
+                progress = state.progress,
+            )
+            return HomeUiState(
+                isLoading = state.isScanning && state.videos.isEmpty(),
+                isFetchingMetadata = state.isFetchingMetadata,
+                hasContent = state.videos.isNotEmpty(),
+                heroCandidates = rows.heroCandidates,
+                continueWatching = rows.continueWatching,
+                recentAdditions = rows.recentAdditions,
+                recommendations = rows.recommendations,
+                series = rows.series,
+                movies = rows.movies,
+                folderRows = rows.folderRows,
+                alphabetical = rows.alphabetical,
+                metadata = state.metadata,
+                watched = state.watched,
+                progress = state.progress,
+                showTmdbBanner = state.videos.isNotEmpty() &&
+                    !state.hasTmdbKey &&
+                    !state.tmdbBannerDismissed,
+            )
+        }
+
+        fun factory(libraryViewModel: LibraryViewModel): ViewModelProvider.Factory =
+            viewModelFactory {
+                initializer { HomeViewModel(libraryViewModel.uiState) }
+            }
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
@@ -1,0 +1,315 @@
+package com.localstream.app.ui.library
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.localstream.app.data.repository.SettingsRepository
+import com.localstream.app.data.repository.TmdbRepository
+import com.localstream.app.data.repository.VideoRepository
+import com.localstream.app.data.repository.WatchStateRepository
+import com.localstream.app.di.AppContainer
+import com.localstream.app.domain.VideoFilterSorter
+import com.localstream.app.domain.VideoUiSelectors
+import com.localstream.app.domain.model.FilterSortOptions
+import com.localstream.app.domain.model.MovieCollection
+import com.localstream.app.domain.model.ResolutionFilter
+import com.localstream.app.domain.model.SortBy
+import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoItem
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * État de la bibliothèque partagé par les écrans Accueil / Recherche / Bibliothèque.
+ * [videos] = groupé (séries + sagas) ; [filteredSorted] = après tri/filtres
+ * (VideoFilterSorter, Phase 2) ; [metadata] = métadonnées TMDB indexées par clé
+ * de lookup (nom de série pour les groupes, nom de fichier sinon).
+ */
+data class LibraryUiState(
+    val isScanning: Boolean = false,
+    val hasScanned: Boolean = false,
+    val isFetchingMetadata: Boolean = false,
+    val videos: List<VideoItem> = emptyList(),
+    val filteredSorted: List<VideoItem> = emptyList(),
+    val metadata: Map<String, TmdbMetadata> = emptyMap(),
+    val videoDurations: Map<String, Long> = emptyMap(),
+    val watched: Map<String, Boolean> = emptyMap(),
+    val progress: Map<String, Double> = emptyMap(),
+    val sortBy: SortBy = SortBy.ALPHA,
+    val filterGenre: Int? = null,
+    val filterResolution: ResolutionFilter = ResolutionFilter.ALL,
+    val searchResults: List<VideoItem> = emptyList(),
+    val hasTmdbKey: Boolean = false,
+    val tmdbBannerDismissed: Boolean = false,
+) {
+    /** Dates de sortie par clé de lookup (tri par date). */
+    val releaseDates: Map<String, String>
+        get() = metadata.mapNotNull { (key, meta) ->
+            meta.releaseDate?.takeIf { it.isNotBlank() }?.let { key to it }
+        }.toMap()
+
+    /** Genres TMDB par clé de lookup (filtre par genre). */
+    val videoGenres: Map<String, List<Int>>
+        get() = metadata.mapValues { it.value.genreIds }
+}
+
+/**
+ * ViewModel maître de la bibliothèque (Phase 7) : pilote le scan MediaStore
+ * (Phase 3), l'enrichissement TMDB (Phase 5) et observe l'état de visionnage
+ * (Phase 4). Partagé entre les écrans via le scope de l'activité.
+ */
+@Suppress("TooManyFunctions")
+class LibraryViewModel(
+    private val videoRepository: VideoRepository,
+    private val watchStateRepository: WatchStateRepository,
+    private val tmdbRepository: TmdbRepository,
+    private val settingsRepository: SettingsRepository,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(LibraryUiState())
+    val uiState: StateFlow<LibraryUiState> = _uiState.asStateFlow()
+
+    /** Requête de recherche immédiate (champ texte) ; les résultats sont débouncés. */
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    private var scanJob: Job? = null
+
+    init {
+        observeWatchState()
+        observePreferences()
+        observeSearchQuery()
+    }
+
+    // -------- Pipeline scan + métadonnées --------
+
+    /** Lance le scan complet si aucun n'est en cours (appelé une fois la permission accordée). */
+    fun refreshLibrary() {
+        if (scanJob?.isActive == true) return
+        scanJob = viewModelScope.launch {
+            _uiState.update { it.copy(isScanning = true) }
+            try {
+                val whitelist = settingsRepository.whitelistedVideos.firstOrNull() ?: emptySet()
+                val hasKey = settingsRepository.getTmdbApiKey().isNotBlank()
+                _uiState.update { it.copy(hasTmdbKey = hasKey) }
+
+                val grouped = withContext(ioDispatcher) {
+                    videoRepository.scanAndLoad(whitelistedVideos = whitelist)
+                }
+                publishVideos(grouped)
+
+                // Cache Room d'abord : les affiches s'affichent immédiatement.
+                val cached = loadCachedMetadata(grouped)
+                if (cached.isNotEmpty()) {
+                    _uiState.update { it.copy(metadata = it.metadata + cached).withDerived() }
+                }
+
+                if (hasKey) {
+                    _uiState.update { it.copy(isFetchingMetadata = true) }
+                    enrichAndRegroup(grouped, whitelist)
+                }
+            } finally {
+                _uiState.update {
+                    it.copy(isScanning = false, hasScanned = true, isFetchingMetadata = false)
+                }
+            }
+        }
+    }
+
+    private fun publishVideos(grouped: List<VideoItem>) {
+        val durations = videoRepository.getRawVideos().associate { it.name to it.duration }
+        _uiState.update {
+            it.copy(videos = grouped, videoDurations = durations).withDerived()
+        }
+    }
+
+    private suspend fun loadCachedMetadata(videos: List<VideoItem>): Map<String, TmdbMetadata> =
+        withContext(ioDispatcher) {
+            videos.mapNotNull { video ->
+                val key = VideoUiSelectors.metadataKey(video)
+                tmdbRepository.getCachedMetadata(key)?.let { key to it }
+            }.toMap()
+        }
+
+    /**
+     * Enrichit via le réseau (par paquets, mises à jour progressives), puis
+     * regroupe les films en sagas grâce aux collections TMDB (2ᵉ passe de
+     * regroupement, comme le web qui groupe après récupération des métadonnées).
+     */
+    private suspend fun enrichAndRegroup(grouped: List<VideoItem>, whitelist: Set<String>) {
+        fetchMetadataIntoState(grouped)
+
+        val meta = _uiState.value.metadata
+        val collections = meta.values
+            .filter { it.collectionId != null && !it.collectionName.isNullOrBlank() }
+            .associate {
+                it.queryKey to MovieCollection(
+                    id = it.collectionId.toString(),
+                    name = it.collectionName.orEmpty(),
+                )
+            }
+
+        if (collections.isEmpty()) return
+
+        val regrouped = withContext(ioDispatcher) {
+            videoRepository.regroup(
+                movieCollections = collections,
+                releaseDates = _uiState.value.releaseDates,
+                whitelistedVideos = whitelist,
+            )
+        }
+        if (regrouped.map { it.name } != _uiState.value.videos.map { it.name }) {
+            publishVideos(regrouped)
+            // Enrichit les nouveaux groupes (sagas) absents de la map.
+            val missing = regrouped.filter {
+                VideoUiSelectors.metadataKey(it) !in _uiState.value.metadata
+            }
+            fetchMetadataIntoState(missing)
+        }
+    }
+
+    /** Récupère les métadonnées par paquets et publie chaque paquet dès réception. */
+    private suspend fun fetchMetadataIntoState(videos: List<VideoItem>) {
+        for (chunk in videos.chunked(METADATA_CHUNK_SIZE)) {
+            val results = coroutineScope {
+                chunk.map { video ->
+                    async(ioDispatcher) {
+                        tmdbRepository.fetchMetadataForVideo(video).getOrNull()
+                    }
+                }.awaitAll()
+            }.filterNotNull()
+            if (results.isNotEmpty()) {
+                val additions = results.associate { it.queryKey to it }
+                _uiState.update { it.copy(metadata = it.metadata + additions).withDerived() }
+            }
+        }
+    }
+
+    // -------- Observation des états persistés --------
+
+    private fun observeWatchState() {
+        viewModelScope.launch {
+            watchStateRepository.watchedItems.collect { watched ->
+                _uiState.update { it.copy(watched = watched).withDerived() }
+            }
+        }
+        viewModelScope.launch {
+            watchStateRepository.activePlaybackStates.collect { progress ->
+                _uiState.update { it.copy(progress = progress).withDerived() }
+            }
+        }
+    }
+
+    private fun observePreferences() {
+        viewModelScope.launch {
+            settingsRepository.tmdbBannerDismissed.collect { dismissed ->
+                _uiState.update { it.copy(tmdbBannerDismissed = dismissed) }
+            }
+        }
+    }
+
+    /** Résultats de recherche débouncés (250 ms comme le web) sur la liste filtrée/triée. */
+    @OptIn(FlowPreview::class)
+    private fun observeSearchQuery() {
+        viewModelScope.launch {
+            _searchQuery.debounce(SEARCH_DEBOUNCE_MS).collectLatest { query ->
+                _uiState.update {
+                    it.copy(searchResults = VideoUiSelectors.filterByQuery(it.filteredSorted, query))
+                }
+            }
+        }
+    }
+
+    // -------- Actions utilisateur --------
+
+    fun onSearchChange(query: String) {
+        _searchQuery.value = query
+    }
+
+    fun setSortBy(sortBy: SortBy) {
+        _uiState.update { it.copy(sortBy = sortBy).withDerived() }
+    }
+
+    fun setFilterGenre(genreId: Int?) {
+        _uiState.update { it.copy(filterGenre = genreId).withDerived() }
+    }
+
+    fun setFilterResolution(resolution: ResolutionFilter) {
+        _uiState.update { it.copy(filterResolution = resolution).withDerived() }
+    }
+
+    /** Clic sur le logo : retour à l'état d'accueil (filtres et recherche réinitialisés). */
+    fun resetFilters() {
+        _searchQuery.value = ""
+        _uiState.update {
+            it.copy(
+                sortBy = SortBy.ALPHA,
+                filterGenre = null,
+                filterResolution = ResolutionFilter.ALL,
+                searchResults = emptyList(),
+            ).withDerived()
+        }
+    }
+
+    fun resetProgress(videoName: String) {
+        viewModelScope.launch { watchStateRepository.clearProgress(videoName) }
+    }
+
+    fun dismissTmdbBanner() {
+        viewModelScope.launch { settingsRepository.dismissTmdbBanner() }
+    }
+
+    // -------- Dérivation filtre/tri --------
+
+    private fun LibraryUiState.withDerived(): LibraryUiState {
+        val filtered = VideoFilterSorter.filterAndSortVideos(
+            videos,
+            FilterSortOptions(
+                sortBy = sortBy,
+                filterGenre = filterGenre,
+                filterResolution = filterResolution,
+                releaseDates = releaseDates,
+                videoGenres = videoGenres,
+                videoDurations = videoDurations,
+                watchedVideos = watched,
+            ),
+        )
+        return copy(
+            filteredSorted = filtered,
+            searchResults = VideoUiSelectors.filterByQuery(filtered, _searchQuery.value),
+        )
+    }
+
+    companion object {
+        private const val METADATA_CHUNK_SIZE = 8
+        private const val SEARCH_DEBOUNCE_MS = 250L
+
+        fun factory(container: AppContainer): ViewModelProvider.Factory = viewModelFactory {
+            initializer {
+                LibraryViewModel(
+                    videoRepository = container.videoRepository,
+                    watchStateRepository = container.watchStateRepository,
+                    tmdbRepository = container.tmdbRepository,
+                    settingsRepository = container.settingsRepository,
+                )
+            }
+        }
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/ui/navigation/LocalStreamNavHost.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/navigation/LocalStreamNavHost.kt
@@ -1,10 +1,23 @@
 package com.localstream.app.ui.navigation
 
+import android.net.Uri
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -13,25 +26,78 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.localstream.app.LocalStreamApplication
+import com.localstream.app.domain.model.VideoItem
 import com.localstream.app.ui.components.LocalStreamBottomBar
+import com.localstream.app.ui.home.HomeViewModel
+import com.localstream.app.ui.library.LibraryViewModel
+import com.localstream.app.ui.permission.StoragePermissions
 import com.localstream.app.ui.screens.DetailsScreen
 import com.localstream.app.ui.screens.HistoryScreen
 import com.localstream.app.ui.screens.HomeScreen
 import com.localstream.app.ui.screens.LibraryScreen
+import com.localstream.app.ui.screens.PermissionScreen
 import com.localstream.app.ui.screens.PlaylistsScreen
 import com.localstream.app.ui.screens.SearchScreen
 import com.localstream.app.ui.screens.SettingsScreen
+import com.localstream.app.ui.theme.Black
 
 /**
- * Point d'entrée de l'UI : un [Scaffold] avec barre de navigation basse et le
- * [NavHost] contenant tous les écrans placeholder du socle.
+ * Point d'entrée de l'UI (Phase 7) : gate de permission stockage (Phase 3),
+ * [Scaffold] avec barre de navigation basse, et [NavHost] reliant les écrans
+ * réels Accueil / Bibliothèque / Recherche aux placeholders des phases suivantes.
  */
 @Composable
 fun LocalStreamApp(navController: NavHostController = rememberNavController()) {
+    val context = LocalContext.current
+    val container = (context.applicationContext as LocalStreamApplication).container
+
+    // ViewModels partagés (scope activité) : bibliothèque + dérivation accueil.
+    val libraryViewModel: LibraryViewModel = viewModel(factory = LibraryViewModel.factory(container))
+    val homeViewModel: HomeViewModel = viewModel(factory = HomeViewModel.factory(libraryViewModel))
+
+    // Permission stockage : re-vérifiée à chaque retour au premier plan
+    // (comme le listener "focus" de l'app web).
+    var storageGranted by remember { mutableStateOf(StoragePermissions.hasStoragePermission(context)) }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        storageGranted = StoragePermissions.hasStoragePermission(context)
+    }
+
+    LaunchedEffect(storageGranted) {
+        if (storageGranted) libraryViewModel.refreshLibrary()
+    }
+
+    if (!storageGranted) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background,
+        ) {
+            PermissionScreen(onPermissionGranted = { storageGranted = true })
+        }
+        return
+    }
+
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
 
+    /** Clic logo : retour accueil + réinitialisation filtres/recherche (resetHomeView du web). */
+    val resetToHome: () -> Unit = {
+        libraryViewModel.resetFilters()
+        navController.navigate(Routes.HOME) {
+            popUpTo(navController.graph.findStartDestination().id) { inclusive = true }
+            launchSingleTop = true
+        }
+    }
+    val openSearch: () -> Unit = { navController.navigate(Routes.SEARCH) }
+    val openSettings: () -> Unit = { navController.navigate(Routes.SETTINGS) }
+    // TODO(phase-9) : brancher la lecture sur le lecteur Media3 ; pour
+    // l'instant "Lecture" ouvre la fiche détail comme le tap sur la vignette.
+    val openDetails: (VideoItem) -> Unit = { video ->
+        navController.navigate(Routes.details(Uri.encode(video.name)))
+    }
+
     Scaffold(
+        containerColor = Black,
         bottomBar = {
             // La barre basse n'apparaît que sur les destinations de premier niveau.
             val isTopLevel = TopLevelDestination.entries.any { it.route == currentRoute }
@@ -55,19 +121,53 @@ fun LocalStreamApp(navController: NavHostController = rememberNavController()) {
         NavHost(
             navController = navController,
             startDestination = Routes.HOME,
-            modifier = Modifier.padding(innerPadding),
+            // Seule la barre basse est consommée ici : le hero de l'accueil passe
+            // sous la barre de statut (edge-to-edge), chaque écran gère ses insets.
+            modifier = Modifier.padding(bottom = innerPadding.calculateBottomPadding()),
         ) {
             composable(Routes.HOME) {
+                val uiState by homeViewModel.uiState.collectAsStateWithLifecycle()
                 HomeScreen(
-                    onOpenSearch = { navController.navigate(Routes.SEARCH) },
-                    onOpenSettings = { navController.navigate(Routes.SETTINGS) },
-                    onOpenDetails = { id -> navController.navigate(Routes.details(id)) },
+                    uiState = uiState,
+                    onPlay = openDetails,
+                    onOpenDetails = openDetails,
+                    onResetProgress = libraryViewModel::resetProgress,
+                    onDismissTmdbBanner = libraryViewModel::dismissTmdbBanner,
+                    onConfigureTmdb = openSettings,
+                    onLogoClick = resetToHome,
+                    onSearchClick = openSearch,
+                    onSettingsClick = openSettings,
                 )
             }
-            composable(Routes.LIBRARY) { LibraryScreen() }
+            composable(Routes.LIBRARY) {
+                val uiState by libraryViewModel.uiState.collectAsStateWithLifecycle()
+                LibraryScreen(
+                    uiState = uiState,
+                    onSortBy = libraryViewModel::setSortBy,
+                    onFilterGenre = libraryViewModel::setFilterGenre,
+                    onFilterResolution = libraryViewModel::setFilterResolution,
+                    onOpenDetails = openDetails,
+                    onLogoClick = resetToHome,
+                    onSearchClick = openSearch,
+                    onSettingsClick = openSettings,
+                )
+            }
+            composable(Routes.SEARCH) {
+                val uiState by libraryViewModel.uiState.collectAsStateWithLifecycle()
+                val query by libraryViewModel.searchQuery.collectAsStateWithLifecycle()
+                SearchScreen(
+                    query = query,
+                    results = uiState.searchResults,
+                    metadata = uiState.metadata,
+                    watched = uiState.watched,
+                    progress = uiState.progress,
+                    onQueryChange = libraryViewModel::onSearchChange,
+                    onOpenDetails = openDetails,
+                    onBack = { navController.popBackStack() },
+                )
+            }
             composable(Routes.PLAYLISTS) { PlaylistsScreen() }
             composable(Routes.HISTORY) { HistoryScreen() }
-            composable(Routes.SEARCH) { SearchScreen() }
             composable(Routes.SETTINGS) { SettingsScreen() }
             composable(
                 route = Routes.DETAILS,

--- a/native/app/src/main/java/com/localstream/app/ui/permission/StoragePermissions.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/permission/StoragePermissions.kt
@@ -1,0 +1,26 @@
+package com.localstream.app.ui.permission
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+/**
+ * Permissions de lecture du stockage requises par le scan MediaStore (Phase 3) :
+ * `READ_MEDIA_VIDEO` à partir d'Android 13 (API 33), `READ_EXTERNAL_STORAGE` avant.
+ */
+object StoragePermissions {
+
+    val required: Array<String>
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(Manifest.permission.READ_MEDIA_VIDEO)
+        } else {
+            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+
+    fun hasStoragePermission(context: Context): Boolean =
+        required.all {
+            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+        }
+}

--- a/native/app/src/main/java/com/localstream/app/ui/screens/HomeScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/HomeScreen.kt
@@ -1,75 +1,239 @@
 package com.localstream.app.ui.screens
 
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.localstream.app.domain.model.VideoItem
+import com.localstream.app.ui.components.HeroSection
+import com.localstream.app.ui.components.TopBar
+import com.localstream.app.ui.components.VideoRow
+import com.localstream.app.ui.home.HomeUiState
+import com.localstream.app.ui.theme.Red600
+import com.localstream.app.ui.theme.White
+import com.localstream.app.ui.theme.Zinc500
+import com.localstream.app.ui.theme.Zinc900
+
+/** Seuil de scroll (px) au-delà duquel la TopBar devient opaque. */
+private const val TOPBAR_SOLID_OFFSET_PX = 80
 
 /**
- * Écran d'accueil (placeholder). Démontre la navigation vers Recherche, Paramètres
- * et l'écran Détails ; le contenu réel arrivera dans les phases suivantes.
+ * Écran d'accueil (Phase 7, réf. `HomeScreen.tsx`) : hero rotatif puis rows
+ * "Continuer la lecture", "Nouveautés", "Recommandations", "Séries", "Films",
+ * une row par dossier non-système, "De A à Z".
  */
 @Composable
 fun HomeScreen(
-    onOpenSearch: () -> Unit,
-    onOpenSettings: () -> Unit,
-    onOpenDetails: (String) -> Unit,
+    uiState: HomeUiState,
+    onPlay: (VideoItem) -> Unit,
+    onOpenDetails: (VideoItem) -> Unit,
+    onResetProgress: (String) -> Unit,
+    onDismissTmdbBanner: () -> Unit,
+    onConfigureTmdb: () -> Unit,
+    onLogoClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Surface(
-        modifier = modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+    val listState = rememberLazyListState()
+    val topBarSolid by remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex > 0 ||
+                listState.firstVisibleItemScrollOffset > TOPBAR_SOLID_OFFSET_PX
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        when {
+            uiState.isLoading -> LoadingContent(Modifier.align(Alignment.Center))
+            !uiState.hasContent -> EmptyLibraryContent(Modifier.align(Alignment.Center))
+            else -> LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize(),
             ) {
-                Text(
-                    text = "LocalStream",
-                    style = MaterialTheme.typography.displaySmall,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-                Row {
-                    IconButton(onClick = onOpenSearch) {
-                        Icon(Icons.Filled.Search, contentDescription = "Rechercher")
-                    }
-                    IconButton(onClick = onOpenSettings) {
-                        Icon(Icons.Filled.Settings, contentDescription = "Paramètres")
+                item(key = "hero", contentType = "hero") {
+                    HeroSection(
+                        candidates = uiState.heroCandidates,
+                        metadata = uiState.metadata,
+                        onPlay = onPlay,
+                        onOpenDetails = onOpenDetails,
+                    )
+                }
+                item(key = "rows", contentType = "rows") {
+                    // Chevauchement du bas du hero (-mt-12 du web).
+                    Column(modifier = Modifier.offset(y = (-24).dp)) {
+                        if (uiState.showTmdbBanner) {
+                            TmdbBanner(
+                                onConfigure = onConfigureTmdb,
+                                onDismiss = onDismissTmdbBanner,
+                            )
+                        }
+                        if (uiState.continueWatching.isNotEmpty()) {
+                            HomeRow(
+                                title = "Continuer la lecture",
+                                items = uiState.continueWatching,
+                                uiState = uiState,
+                                showResetProgress = true,
+                                onOpenDetails = onOpenDetails,
+                                onResetProgress = onResetProgress,
+                            )
+                        }
+                        HomeRow("Nouveautés", uiState.recentAdditions, uiState, false, onOpenDetails, onResetProgress)
+                        HomeRow("Recommandations", uiState.recommendations, uiState, false, onOpenDetails, onResetProgress)
+                        HomeRow("Séries", uiState.series, uiState, false, onOpenDetails, onResetProgress)
+                        HomeRow("Films", uiState.movies, uiState, false, onOpenDetails, onResetProgress)
+                        uiState.folderRows.forEach { folder ->
+                            HomeRow(folder.title, folder.items, uiState, false, onOpenDetails, onResetProgress)
+                        }
+                        HomeRow("De A à Z", uiState.alphabetical, uiState, false, onOpenDetails, onResetProgress)
+                        Spacer(modifier = Modifier.height(24.dp))
                     }
                 }
             }
+        }
 
+        TopBar(
+            solid = topBarSolid || !uiState.hasContent,
+            showSearch = uiState.hasContent,
+            isFetchingMetadata = uiState.isFetchingMetadata,
+            onLogoClick = onLogoClick,
+            onSearchClick = onSearchClick,
+            onSettingsClick = onSettingsClick,
+            modifier = Modifier.align(Alignment.TopCenter),
+        )
+    }
+}
+
+@Composable
+private fun HomeRow(
+    title: String,
+    items: List<VideoItem>,
+    uiState: HomeUiState,
+    showResetProgress: Boolean,
+    onOpenDetails: (VideoItem) -> Unit,
+    onResetProgress: (String) -> Unit,
+) {
+    VideoRow(
+        title = title,
+        items = items,
+        metadata = uiState.metadata,
+        watched = uiState.watched,
+        progress = uiState.progress,
+        showResetProgress = showResetProgress,
+        onOpenDetails = onOpenDetails,
+        onResetProgress = onResetProgress,
+    )
+}
+
+@Composable
+private fun LoadingContent(modifier: Modifier = Modifier) {
+    CircularProgressIndicator(color = Red600, modifier = modifier)
+}
+
+/** Bibliothèque vide après scan (équivalent de l'écran d'accueil sans vidéos du web). */
+@Composable
+private fun EmptyLibraryContent(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Vos films et séries.",
+            color = White,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = "Aucune vidéo trouvée sur l'appareil. Ajoutez des vidéos dans vos dossiers (Movies, Download…) puis relancez l'application.",
+            color = Zinc500,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(top = 12.dp),
+        )
+    }
+}
+
+/** Bannière d'onboarding TMDB (réf. `HomeScreen.tsx`) : guide vers les réglages. */
+@Composable
+private fun TmdbBanner(
+    onConfigure: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 16.dp)
+            .background(Zinc900, RoundedCornerShape(16.dp))
+            .padding(16.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Image,
+            contentDescription = null,
+            tint = Red600,
+            modifier = Modifier.padding(top = 2.dp),
+        )
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 12.dp),
+        ) {
             Text(
-                text = "Socle natif (Phase 1) — écran de démonstration.",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                text = "Ajoutez les affiches et synopsis",
+                color = White,
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
             )
-
-            Button(onClick = { onOpenDetails("demo") }) {
-                Text("Ouvrir un exemple de détails")
+            Text(
+                text = "Configurez une clé API TMDB (gratuite) pour récupérer automatiquement les affiches, résumés et regroupements en sagas.",
+                color = Zinc500,
+                fontSize = 12.sp,
+                lineHeight = 16.sp,
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+            Button(
+                onClick = onConfigure,
+                colors = ButtonDefaults.buttonColors(containerColor = Red600, contentColor = White),
+                shape = RoundedCornerShape(8.dp),
+            ) {
+                Text(text = "Configurer TMDB", fontWeight = FontWeight.Black, fontSize = 12.sp)
             }
+        }
+        IconButton(onClick = onDismiss) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = "Masquer cette bannière",
+                tint = Zinc500,
+            )
         }
     }
 }

--- a/native/app/src/main/java/com/localstream/app/ui/screens/LibraryScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/LibraryScreen.kt
@@ -1,0 +1,91 @@
+package com.localstream.app.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.localstream.app.domain.model.ResolutionFilter
+import com.localstream.app.domain.model.SortBy
+import com.localstream.app.domain.model.VideoItem
+import com.localstream.app.ui.components.LibraryFilterBar
+import com.localstream.app.ui.components.TopBar
+import com.localstream.app.ui.components.VideoGrid
+import com.localstream.app.ui.library.LibraryUiState
+import com.localstream.app.ui.theme.White
+import com.localstream.app.ui.theme.Zinc500
+
+/**
+ * Écran Bibliothèque (Phase 7, réf. `LibraryScreen.tsx` + `FilterBar.tsx`) :
+ * barre de tri (A-Z, date, taille, durée) et filtres (genre TMDB, qualité) en
+ * chips/menus M3, grille adaptative identique à la recherche, état vide dédié.
+ * Le filtrage/tri est assuré par [com.localstream.app.domain.VideoFilterSorter].
+ */
+@Composable
+fun LibraryScreen(
+    uiState: LibraryUiState,
+    onSortBy: (SortBy) -> Unit,
+    onFilterGenre: (Int?) -> Unit,
+    onFilterResolution: (ResolutionFilter) -> Unit,
+    onOpenDetails: (VideoItem) -> Unit,
+    onLogoClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxSize()) {
+        TopBar(
+            solid = true,
+            showSearch = uiState.videos.isNotEmpty(),
+            isFetchingMetadata = uiState.isFetchingMetadata,
+            onLogoClick = onLogoClick,
+            onSearchClick = onSearchClick,
+            onSettingsClick = onSettingsClick,
+        )
+
+        LibraryFilterBar(
+            sortBy = uiState.sortBy,
+            filterGenre = uiState.filterGenre,
+            filterResolution = uiState.filterResolution,
+            onSortBy = onSortBy,
+            onFilterGenre = onFilterGenre,
+            onFilterResolution = onFilterResolution,
+        )
+
+        Text(
+            text = "Bibliothèque",
+            color = White,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        )
+
+        if (uiState.filteredSorted.isEmpty()) {
+            Text(
+                text = if (uiState.videos.isEmpty()) {
+                    "Aucune vidéo dans la bibliothèque."
+                } else {
+                    "Aucun résultat correspondant à ces filtres."
+                },
+                color = Zinc500,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .padding(32.dp)
+                    .align(Alignment.CenterHorizontally),
+            )
+        } else {
+            VideoGrid(
+                videos = uiState.filteredSorted,
+                metadata = uiState.metadata,
+                watched = uiState.watched,
+                progress = uiState.progress,
+                onOpenDetails = onOpenDetails,
+            )
+        }
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/ui/screens/OtherScreens.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/OtherScreens.kt
@@ -4,13 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 /**
- * Écrans placeholder du socle. Ils réutilisent [PlaceholderScreen] et seront
- * remplacés par les implémentations réelles au fil des phases de migration.
+ * Écrans placeholder restants du socle. Ils seront remplacés par les
+ * implémentations réelles lors des phases suivantes (Phase 8 : fiche détail,
+ * épisodes, playlists, historique, paramètres).
  */
-
-@Composable
-fun LibraryScreen(modifier: Modifier = Modifier) =
-    PlaceholderScreen(title = "Bibliothèque", modifier = modifier)
 
 @Composable
 fun PlaylistsScreen(modifier: Modifier = Modifier) =
@@ -19,10 +16,6 @@ fun PlaylistsScreen(modifier: Modifier = Modifier) =
 @Composable
 fun HistoryScreen(modifier: Modifier = Modifier) =
     PlaceholderScreen(title = "Historique", modifier = modifier)
-
-@Composable
-fun SearchScreen(modifier: Modifier = Modifier) =
-    PlaceholderScreen(title = "Recherche", modifier = modifier)
 
 @Composable
 fun SettingsScreen(modifier: Modifier = Modifier) =

--- a/native/app/src/main/java/com/localstream/app/ui/screens/PermissionScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PermissionScreen.kt
@@ -1,0 +1,122 @@
+package com.localstream.app.ui.screens
+
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.localstream.app.ui.permission.StoragePermissions
+import com.localstream.app.ui.theme.Red600
+import com.localstream.app.ui.theme.White
+import com.localstream.app.ui.theme.Zinc500
+import com.localstream.app.ui.theme.Zinc800
+
+/**
+ * Écran bloquant de demande d'accès au stockage (Phase 7, branché sur la
+ * Phase 3 — équivalent Compose de `PermissionGate.tsx`). Tant que la
+ * permission n'est pas accordée, le scan MediaStore ne peut pas démarrer.
+ */
+@Composable
+fun PermissionScreen(
+    onPermissionGranted: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions(),
+    ) { results ->
+        if (results.values.any { it }) {
+            onPermissionGranted()
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.FolderOpen,
+            contentDescription = null,
+            tint = Red600,
+            modifier = Modifier
+                .size(64.dp)
+                .padding(bottom = 24.dp),
+        )
+        Text(
+            text = "Accès au stockage",
+            color = White,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = "LocalStream a besoin d'accéder à vos dossiers pour scanner et afficher vos vidéos. Veuillez accorder les permissions nécessaires pour continuer.",
+            color = Zinc500,
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(vertical = 24.dp),
+        )
+        Button(
+            onClick = { launcher.launch(StoragePermissions.required) },
+            colors = ButtonDefaults.buttonColors(containerColor = Red600, contentColor = White),
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = "ACCORDER L'ACCÈS",
+                fontWeight = FontWeight.Black,
+                fontSize = 12.sp,
+                letterSpacing = 1.sp,
+                modifier = Modifier.padding(vertical = 6.dp),
+            )
+        }
+        OutlinedButton(
+            onClick = {
+                val intent = Intent(
+                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    Uri.fromParts("package", context.packageName, null),
+                )
+                context.startActivity(intent)
+            },
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp),
+        ) {
+            Text(text = "Ouvrir les réglages système", color = White, fontSize = 12.sp)
+        }
+        Text(
+            text = "Si la demande n'apparaît plus, activez la permission dans les réglages système.",
+            color = Zinc500.copy(alpha = 0.6f),
+            fontSize = 10.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 16.dp),
+        )
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/ui/screens/SearchScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/SearchScreen.kt
@@ -1,0 +1,164 @@
+package com.localstream.app.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoItem
+import com.localstream.app.ui.components.VideoGrid
+import com.localstream.app.ui.theme.White
+import com.localstream.app.ui.theme.Zinc500
+import com.localstream.app.ui.theme.Zinc800
+import com.localstream.app.ui.theme.Zinc900
+
+/**
+ * Écran de recherche (Phase 7, réf. `SearchScreen.tsx`) : champ dans la barre
+ * supérieure (focus automatique), filtrage insensible à la casse appliqué par
+ * le ViewModel sur les groupes filtrés/triés, grille adaptative, état vide.
+ */
+@Composable
+fun SearchScreen(
+    query: String,
+    results: List<VideoItem>,
+    metadata: Map<String, TmdbMetadata>,
+    watched: Map<String, Boolean>,
+    progress: Map<String, Double>,
+    onQueryChange: (String) -> Unit,
+    onOpenDetails: (VideoItem) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxSize()) {
+        SearchTopBar(
+            query = query,
+            onQueryChange = onQueryChange,
+            onBack = onBack,
+        )
+
+        if (query.isNotBlank()) {
+            Text(
+                text = "Résultats pour \"$query\"",
+                color = White,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            )
+        }
+
+        if (query.isBlank()) {
+            EmptySearchHint()
+        } else if (results.isEmpty()) {
+            Text(
+                text = "Aucun résultat trouvé pour \"$query\"",
+                color = Zinc500,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .padding(32.dp)
+                    .align(Alignment.CenterHorizontally),
+            )
+        } else {
+            VideoGrid(
+                videos = results,
+                metadata = metadata,
+                watched = watched,
+                progress = progress,
+                onOpenDetails = onOpenDetails,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchTopBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(horizontal = 8.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Retour",
+                tint = White,
+            )
+        }
+        TextField(
+            value = query,
+            onValueChange = onQueryChange,
+            placeholder = { Text("Rechercher un titre...", color = Zinc500) },
+            leadingIcon = {
+                Icon(Icons.Filled.Search, contentDescription = null, tint = White)
+            },
+            trailingIcon = {
+                if (query.isNotEmpty()) {
+                    IconButton(onClick = { onQueryChange("") }) {
+                        Icon(Icons.Filled.Close, contentDescription = "Effacer", tint = White)
+                    }
+                }
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            shape = CircleShape,
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = Zinc900,
+                unfocusedContainerColor = Zinc800,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                cursorColor = White,
+                focusedTextColor = White,
+                unfocusedTextColor = White,
+            ),
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 8.dp)
+                .focusRequester(focusRequester),
+        )
+    }
+
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+}
+
+/** Invitation à saisir quand la recherche est vide. */
+@Composable
+private fun EmptySearchHint() {
+    Text(
+        text = "Recherchez un film ou une série par son titre.",
+        color = Zinc500,
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.padding(32.dp),
+    )
+}

--- a/native/app/src/test/java/com/localstream/app/domain/HomeRowsDeriverTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/HomeRowsDeriverTest.kt
@@ -1,0 +1,113 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.VideoItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests de [HomeRowsDeriver] : ordre et contenu des rows de l'accueil,
+ * parité avec la logique web (`App.tsx` / `HomeScreen.tsx`).
+ */
+class HomeRowsDeriverTest {
+
+    private fun movie(
+        name: String,
+        path: String = "/storage/emulated/0/Movies/$name",
+        lastModified: Long = 0L,
+    ) = VideoItem(
+        url = "content://media/$name",
+        name = name,
+        path = path,
+        lastModified = lastModified,
+    )
+
+    private fun series(name: String, episodes: List<VideoItem>) = VideoItem(
+        url = episodes.first().url,
+        name = name,
+        path = episodes.first().path,
+        isSeriesGroup = true,
+        isTvSeries = true,
+        episodes = episodes,
+        seriesName = name,
+    )
+
+    // grouped : ordre du scan MediaStore (plus récent d'abord)
+    private val ep1 = VideoItem(url = "u1", name = "Show S01E01.mkv", path = "/storage/emulated/0/Series/Show/Show S01E01.mkv")
+    private val ep2 = VideoItem(url = "u2", name = "Show S01E02.mkv", path = "/storage/emulated/0/Series/Show/Show S01E02.mkv")
+    private val show = series("Show", listOf(ep1, ep2))
+    private val filmA = movie("Alpha.2020.1080p.mkv", lastModified = 300)
+    private val filmB = movie("Beta.2021.720p.mkv", path = "/storage/emulated/0/Download/Beta.2021.720p.mkv", lastModified = 200)
+    private val filmC = movie("Charlie.mp4", path = "/storage/emulated/0/DCIM/Camera/Charlie.mp4", lastModified = 100)
+
+    private val grouped = listOf(filmA, show, filmB, filmC) // récent → ancien
+
+    @Test
+    fun `nouveautés = ordre scan inversé, limité à 15`() {
+        val rows = HomeRowsDeriver.derive(grouped, grouped, emptyMap(), emptyMap())
+        assertEquals(listOf(filmC, filmB, show, filmA), rows.recentAdditions)
+    }
+
+    @Test
+    fun `recommandations = 15 premiers de l'ordre du scan`() {
+        val rows = HomeRowsDeriver.derive(grouped, grouped, emptyMap(), emptyMap())
+        assertEquals(grouped, rows.recommendations)
+    }
+
+    @Test
+    fun `séries et films sont partitionnés comme le web`() {
+        val rows = HomeRowsDeriver.derive(grouped, grouped, emptyMap(), emptyMap())
+        assertEquals(listOf(show), rows.series)
+        assertEquals(listOf(filmA, filmB, filmC), rows.movies)
+    }
+
+    @Test
+    fun `continuer la lecture = progression entre 0 et 95 exclus, sur la liste filtrée`() {
+        val progress = mapOf(
+            filmA.name to 50.0,
+            filmB.name to 95.0,   // exclu : >= 95
+            filmC.name to 0.0,    // exclu : 0
+            show.name to 10.0,
+        )
+        val rows = HomeRowsDeriver.derive(grouped, grouped, emptyMap(), progress)
+        assertEquals(listOf(filmA, show), rows.continueWatching)
+    }
+
+    @Test
+    fun `rows par dossier = basename, dossiers système exclus, tri alphabétique`() {
+        val rows = HomeRowsDeriver.derive(grouped, grouped, emptyMap(), emptyMap())
+        // DCIM/Camera exclu (dossier système) ; Movies et Download conservés ; Series (série) conservé
+        assertEquals(listOf("Dossier : Download", "Dossier : Movies", "Dossier : Series"), rows.folderRows.map { it.title })
+        assertEquals(listOf(filmB), rows.folderRows[0].items)
+        assertEquals(listOf(filmA), rows.folderRows[1].items)
+        assertEquals(listOf(show), rows.folderRows[2].items)
+    }
+
+    @Test
+    fun `de A à Z = tri insensible à la casse sur la liste filtrée`() {
+        val unsorted = listOf(filmC, filmA, filmB)
+        val rows = HomeRowsDeriver.derive(grouped, unsorted, emptyMap(), emptyMap())
+        assertEquals(listOf(filmA, filmB, filmC), rows.alphabetical)
+    }
+
+    @Test
+    fun `hero = candidats HeroSelector, repli sur le premier filtré sinon`() {
+        // Tout vu → HeroSelector vide → repli sur le premier de la liste filtrée.
+        val allWatched = mapOf(
+            filmA.name to true,
+            filmB.name to true,
+            filmC.name to true,
+            ep1.name to true,
+            ep2.name to true,
+        )
+        val rows = HomeRowsDeriver.derive(grouped, grouped, allWatched, emptyMap())
+        assertEquals(listOf(filmA), rows.heroCandidates)
+    }
+
+    @Test
+    fun `hero privilégie les contenus en cours de lecture`() {
+        val progress = mapOf(filmC.name to 40.0)
+        val rows = HomeRowsDeriver.derive(grouped, grouped, emptyMap(), progress)
+        assertEquals(filmC, rows.heroCandidates.first())
+    }
+}

--- a/native/app/src/test/java/com/localstream/app/domain/VideoUiSelectorsTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/VideoUiSelectorsTest.kt
@@ -1,0 +1,74 @@
+package com.localstream.app.domain
+
+import com.localstream.app.domain.model.VideoItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests de [VideoUiSelectors] : parité avec la logique d'affichage de
+ * `VideoRow.tsx` / `VideoCard.tsx` (vu, progression, clés de métadonnées).
+ */
+class VideoUiSelectorsTest {
+
+    private val ep1 = VideoItem(url = "u1", name = "Show S01E01.mkv")
+    private val ep2 = VideoItem(url = "u2", name = "Show S01E02.mkv")
+    private val ep3 = VideoItem(url = "u3", name = "Show S01E03.mkv")
+    private val show = VideoItem(
+        url = "u1",
+        name = "Show",
+        isSeriesGroup = true,
+        isTvSeries = true,
+        episodes = listOf(ep1, ep2, ep3),
+        seriesName = "Show",
+    )
+    private val film = VideoItem(url = "u4", name = "Film.2024.1080p.mkv")
+
+    @Test
+    fun `vu - groupe vu seulement si tous les épisodes sont vus`() {
+        assertFalse(VideoUiSelectors.isWatched(show, mapOf("Show S01E01.mkv" to true, "Show S01E02.mkv" to true)))
+        assertTrue(
+            VideoUiSelectors.isWatched(
+                show,
+                mapOf("Show S01E01.mkv" to true, "Show S01E02.mkv" to true, "Show S01E03.mkv" to true),
+            ),
+        )
+        assertTrue(VideoUiSelectors.isWatched(film, mapOf("Film.2024.1080p.mkv" to true)))
+        assertFalse(VideoUiSelectors.isWatched(film, emptyMap()))
+    }
+
+    @Test
+    fun `progression - groupe = premier épisode en cours, sinon celle du nom`() {
+        val progress = mapOf(
+            "Show S01E01.mkv" to 100.0,
+            "Show S01E02.mkv" to 42.0,
+            "Show S01E03.mkv" to 0.0,
+        )
+        assertEquals(42.0, VideoUiSelectors.progressOf(show, progress), 0.001)
+        assertEquals(0.0, VideoUiSelectors.progressOf(show, emptyMap()), 0.001)
+        assertEquals(12.5, VideoUiSelectors.progressOf(film, mapOf("Film.2024.1080p.mkv" to 12.5)), 0.001)
+    }
+
+    @Test
+    fun `clé métadonnées = nom de série pour un groupe, nom du fichier sinon`() {
+        assertEquals("Show", VideoUiSelectors.metadataKey(show))
+        assertEquals("Film.2024.1080p.mkv", VideoUiSelectors.metadataKey(film))
+    }
+
+    @Test
+    fun `titre affiché = nom de série, sinon titre nettoyé du fichier`() {
+        assertEquals("Show", VideoUiSelectors.displayTitle(show))
+        assertEquals("Film", VideoUiSelectors.displayTitle(film))
+    }
+
+    @Test
+    fun `recherche - insensible à la casse, vide si requête blanche`() {
+        val videos = listOf(show, film)
+        assertEquals(listOf(show), VideoUiSelectors.filterByQuery(videos, "show"))
+        assertEquals(listOf(show), VideoUiSelectors.filterByQuery(videos, "SHOW"))
+        assertEquals(listOf(film), VideoUiSelectors.filterByQuery(videos, "film.2024"))
+        assertTrue(VideoUiSelectors.filterByQuery(videos, "   ").isEmpty())
+        assertTrue(VideoUiSelectors.filterByQuery(videos, "inconnu").isEmpty())
+    }
+}

--- a/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
@@ -1,0 +1,228 @@
+package com.localstream.app.ui.library
+
+import com.localstream.app.data.db.dao.PlaybackStateDao
+import com.localstream.app.data.db.dao.TmdbMetadataDao
+import com.localstream.app.data.db.dao.WatchedItemDao
+import com.localstream.app.data.db.entity.PlaybackStateEntity
+import com.localstream.app.data.db.entity.TmdbMetadataEntity
+import com.localstream.app.data.db.entity.WatchedItemEntity
+import com.localstream.app.data.remote.tmdb.TmdbApi
+import com.localstream.app.data.remote.tmdb.dto.TmdbCollectionDetailsDto
+import com.localstream.app.data.remote.tmdb.dto.TmdbMovieDetailsDto
+import com.localstream.app.data.remote.tmdb.dto.TmdbSearchResponse
+import com.localstream.app.data.remote.tmdb.dto.TmdbSeasonDetailsDto
+import com.localstream.app.data.repository.SettingsRepository
+import com.localstream.app.data.repository.TmdbRepository
+import com.localstream.app.data.repository.VideoRepository
+import com.localstream.app.data.repository.WatchStateRepository
+import retrofit2.Response
+import com.localstream.app.data.scanner.MediaScanner
+import com.localstream.app.domain.model.MovieCollection
+import com.localstream.app.domain.model.ResolutionFilter
+import com.localstream.app.domain.model.SortBy
+import com.localstream.app.domain.model.SubtitleEntry
+import com.localstream.app.domain.model.VideoItem
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests du pipeline de [LibraryViewModel] : scan → état, tri/filtres
+ * (parité web), recherche débouncée, reset de progression.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LibraryViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private val film4k = VideoItem(
+        url = "u1", name = "Avatar.2009.2160p.mkv", path = "/storage/emulated/0/Movies/Avatar.2009.2160p.mkv",
+        size = 4000L, duration = 7200L,
+    )
+    private val filmSd = VideoItem(
+        url = "u2", name = "Old.Movie.avi", path = "/storage/emulated/0/Movies/Old.Movie.avi",
+        size = 1000L, duration = 3600L,
+    )
+    private val filmHd = VideoItem(
+        url = "u3", name = "Blockbuster.2024.1080p.mkv", path = "/storage/emulated/0/Movies/Blockbuster.2024.1080p.mkv",
+        size = 2000L, duration = 5400L,
+    )
+    private val raw = listOf(film4k, filmSd, filmHd)
+    private val grouped = listOf(film4k, filmSd, filmHd)
+
+    private lateinit var playbackDao: FakePlaybackStateDao
+    private lateinit var viewModel: LibraryViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        playbackDao = FakePlaybackStateDao()
+        val videoRepository = VideoRepository(FakeScanner(raw, grouped))
+        val watchStateRepository = WatchStateRepository(FakeWatchedItemDao(), playbackDao)
+        val tmdbRepository = TmdbRepository(
+            tmdbApi = UnusedTmdbApi(),
+            tmdbMetadataDao = FakeTmdbMetadataDao(),
+            settingsRepository = SettingsRepository(),
+        )
+        viewModel = LibraryViewModel(
+            videoRepository = videoRepository,
+            watchStateRepository = watchStateRepository,
+            tmdbRepository = tmdbRepository,
+            settingsRepository = SettingsRepository(),
+            ioDispatcher = testDispatcher,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `le scan publie les vidéos triées A-Z par défaut`() = runTest(testDispatcher) {
+        viewModel.refreshLibrary()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.hasScanned)
+        assertEquals(grouped, state.videos)
+        assertEquals(
+            listOf("Avatar.2009.2160p.mkv", "Blockbuster.2024.1080p.mkv", "Old.Movie.avi"),
+            state.filteredSorted.map { it.name },
+        )
+    }
+
+    @Test
+    fun `le tri par taille ordonne par taille décroissante comme le web`() = runTest(testDispatcher) {
+        viewModel.refreshLibrary()
+        advanceUntilIdle()
+
+        viewModel.setSortBy(SortBy.SIZE)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("Avatar.2009.2160p.mkv", "Blockbuster.2024.1080p.mkv", "Old.Movie.avi"),
+            viewModel.uiState.value.filteredSorted.map { it.name },
+        )
+    }
+
+    @Test
+    fun `le filtre qualité 4K ne garde que les fichiers 2160p ou 4k`() = runTest(testDispatcher) {
+        viewModel.refreshLibrary()
+        advanceUntilIdle()
+
+        viewModel.setFilterResolution(ResolutionFilter.FOUR_K)
+        advanceUntilIdle()
+
+        assertEquals(listOf("Avatar.2009.2160p.mkv"), viewModel.uiState.value.filteredSorted.map { it.name })
+    }
+
+    @Test
+    fun `la recherche est débouncée et insensible à la casse`() = runTest(testDispatcher) {
+        viewModel.refreshLibrary()
+        advanceUntilIdle()
+
+        viewModel.onSearchChange("BLOCK")
+        advanceTimeBy(100)
+        assertTrue(viewModel.uiState.value.searchResults.isEmpty()) // pas encore émis
+
+        advanceTimeBy(300)
+        assertEquals(listOf("Blockbuster.2024.1080p.mkv"), viewModel.uiState.value.searchResults.map { it.name })
+    }
+
+    @Test
+    fun `resetProgress supprime la progression persistée`() = runTest(testDispatcher) {
+        viewModel.resetProgress("Avatar.2009.2160p.mkv")
+        advanceUntilIdle()
+
+        assertEquals(listOf("Avatar.2009.2160p.mkv"), playbackDao.deletedNames)
+    }
+
+    // -------- Fakes --------
+
+    private class FakeScanner(
+        private val rawVideos: List<VideoItem>,
+        private val groupedVideos: List<VideoItem>,
+    ) : MediaScanner {
+        override fun scanVideoFiles(): List<VideoItem> = rawVideos
+        override fun scanSubtitleFiles(): List<SubtitleEntry> = emptyList()
+        override fun scanAndGroup(
+            whitelistedVideos: Set<String>,
+            movieCollections: Map<String, MovieCollection>,
+            releaseDates: Map<String, String>,
+        ): List<VideoItem> = groupedVideos
+    }
+
+    private class FakeWatchedItemDao : WatchedItemDao {
+        private val items = MutableStateFlow<List<WatchedItemEntity>>(emptyList())
+        override fun observeWatchedItems(): Flow<List<WatchedItemEntity>> = items
+        override suspend fun getAllWatchedItems(): List<WatchedItemEntity> = items.value
+        override suspend fun upsert(item: WatchedItemEntity) {
+            items.value = items.value.filterNot { it.name == item.name } + item
+        }
+        override suspend fun upsertAll(items: List<WatchedItemEntity>) = items.forEach { upsert(it) }
+        override suspend fun deleteByName(name: String) {
+            items.value = items.value.filterNot { it.name == name }
+        }
+        override suspend fun deleteAll() {
+            items.value = emptyList()
+        }
+        override suspend fun findByName(name: String): WatchedItemEntity? = items.value.find { it.name == name }
+    }
+
+    private class FakePlaybackStateDao : PlaybackStateDao {
+        val deletedNames = mutableListOf<String>()
+        private val items = MutableStateFlow<List<PlaybackStateEntity>>(emptyList())
+        override fun observeActivePlaybackStates(): Flow<List<PlaybackStateEntity>> = items
+        override suspend fun getRecentlyPlayed(limit: Int): List<PlaybackStateEntity> = items.value.take(limit)
+        override suspend fun getAll(): List<PlaybackStateEntity> = items.value
+        override suspend fun upsert(state: PlaybackStateEntity) {
+            items.value = items.value.filterNot { it.name == state.name } + state
+        }
+        override suspend fun upsertAll(states: List<PlaybackStateEntity>) = states.forEach { upsert(it) }
+        override suspend fun deleteByName(name: String) {
+            deletedNames += name
+            items.value = items.value.filterNot { it.name == name }
+        }
+        override suspend fun deleteAll() {
+            items.value = emptyList()
+        }
+        override suspend fun findByName(name: String): PlaybackStateEntity? = items.value.find { it.name == name }
+    }
+
+    private class FakeTmdbMetadataDao : TmdbMetadataDao {
+        private val items = mutableMapOf<String, TmdbMetadataEntity>()
+        override suspend fun getMetadata(queryKey: String): TmdbMetadataEntity? = items[queryKey]
+        override suspend fun insertMetadata(entity: TmdbMetadataEntity) {
+            items[entity.queryKey] = entity
+        }
+        override suspend fun deleteMetadata(queryKey: String) {
+            items.remove(queryKey)
+        }
+        override suspend fun clearAll() = items.clear()
+        override suspend fun getAll(): List<TmdbMetadataEntity> = items.values.toList()
+    }
+
+    /** Sans clé API configurée, aucune méthode distante ne doit être appelée. */
+    private class UnusedTmdbApi : TmdbApi {
+        private fun unused(): Nothing = throw UnsupportedOperationException("appel réseau inattendu")
+        override suspend fun searchMulti(apiKey: String, query: String, language: String): TmdbSearchResponse = unused()
+        override suspend fun searchMovie(apiKey: String, query: String, language: String): TmdbSearchResponse = unused()
+        override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String): TmdbMovieDetailsDto = unused()
+        override suspend fun getCollection(collectionId: Long, apiKey: String, language: String): TmdbCollectionDetailsDto = unused()
+        override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String): TmdbSeasonDetailsDto = unused()
+        override suspend fun getPopular(apiKey: String, language: String): Response<TmdbSearchResponse> = unused()
+    }
+}

--- a/native/config/detekt/detekt.yml
+++ b/native/config/detekt/detekt.yml
@@ -26,5 +26,8 @@ style:
 complexity:
   LongMethod:
     ignoreAnnotated: ['Composable']
+  LongParameterList:
+    # Les @Composable reçoivent légitimement état + callbacks en paramètres.
+    ignoreAnnotated: ['Composable']
   TooManyFunctions:
     active: false

--- a/native/gradle/libs.versions.toml
+++ b/native/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ agp = "8.13.0"
 kotlin = "2.0.21"
 coreKtx = "1.15.0"
 lifecycleRuntimeKtx = "2.8.7"
+# Phase 7 — ViewModels Compose
+lifecycleViewmodelCompose = "2.8.7"
 activityCompose = "1.9.3"
 composeBom = "2024.12.01"
 navigationCompose = "2.8.5"
@@ -28,6 +30,8 @@ coil = "2.7.0"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleViewmodelCompose" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }


### PR DESCRIPTION
## Contexte

Implémente la **Phase 7** (#39) de la migration native : les écrans de consultation de l'app en Jetpack Compose — Accueil (Hero + rows), Recherche, Bibliothèque — branchés sur les couches des Phases 2 (domaine), 3 (MediaStore), 4 (persistance) et 5 (TMDB). Le design Netflix-like sombre du web (Phase 0, qui sert de spécification) est conservé à l'identique.

## Écrans et composables

- **`HomeScreen`** (réf. `HomeScreen.tsx` + `hero.ts`) : hero 62 vh (backdrop TMDB, dégradés noirs bas + gauche, titre nettoyé, synopsis 3 lignes, boutons « Lecture » blanc et « Plus d'infos » gris translucide), **rotation auto toutes les 10 s** confinée au composable `HeroSection` (`LaunchedEffect` + `Crossfade`) — le tick ne recompose ni les rows ni l'écran. Rows `LazyRow` dans l'ordre exact : « Continuer la lecture » (si non vide), « Nouveautés » (15), « Recommandations » (15), « Séries », « Films », **une row par dossier non-système** (logique retrouvée dans le commit initial du web : `Dossier : X`, dossiers caméra/sociaux/système exclus), « De A à Z ». Bannière onboarding TMDB persistée (DataStore).
- **`VideoCard` / `VideoRow` / `VideoGrid`** (réf. `VideoCard.tsx` / `VideoRow.tsx`) : vignette 2/3 Coil, badge résolution, badge Série/Saga, coche verte « vu », barre de progression rouge, bouton reset progression (row « Continuer la lecture »), contenus vus atténués (opacité + désaturation), clés stables.
- **`SearchScreen`** (réf. `SearchScreen.tsx`) : champ auto-focus dans la barre supérieure, filtrage **insensible à la casse débouncé 250 ms** sur les groupes filtrés/triés, grille adaptative (`LazyVerticalGrid`, minSize 110 dp ≈ 2-6 colonnes), état vide « Aucun résultat trouvé pour… ».
- **`LibraryScreen`** (réf. `LibraryScreen.tsx` + `FilterBar.tsx`) : tri (A-Z, date, taille, durée) + filtres genre (`TmdbGenre`) et qualité (4K/1080p/720p/SD) en chips/menus M3, grille identique à la recherche, état vide dédié. Branché sur `VideoFilterSorter` (Phase 2) → mêmes résultats que le web sur le même jeu de données.
- **`TopBar`** (réf. `AppHeader.tsx`) : logo « LOCALSTREAM » rouge (retour accueil + reset filtres), spinner de récupération TMDB, recherche, réglages ; fond transparent → noir au scroll (dérivé du `LazyListState`), `statusBarsPadding`.
- **`PermissionScreen`** (réf. `PermissionGate.tsx`, branchée sur la Phase 3) : demande `READ_MEDIA_VIDEO` (API 33+) / `READ_EXTERNAL_STORAGE`, ouverture des réglages système, re-vérification au retour au premier plan (comme le listener `focus` du web).

## Architecture

- **ViewModels** `HomeViewModel` / `LibraryViewModel` exposant des `StateFlow<UiState>`, partageant `VideoRepository` + `TmdbRepository` + `WatchStateRepository` via un `AppContainer` (injection manuelle, cf. README) hébergé par `LocalStreamApplication`.
- `LibraryViewModel` pilote le pipeline : scan MediaStore → métadonnées **depuis le cache Room d'abord** (affiches instantanées) → enrichissement réseau progressif par paquets → **regroupement en sagas** grâce au nouveau `VideoRepository.regroup()` (2ᵉ passe sans requête MediaStore, comme le web qui groupe après récupération des métadonnées).
- `HomeViewModel` dérive les rows via `HomeRowsDeriver` (pur, testé JVM) ; aucune E/S propre.
- Images : Coil ; placeholder = titre nettoyé sur fond zinc-800 (comme le web sans affiche).
- Perf : clés stables dans les Lazy lists, pas de pagination (< 1000 items), rotation du hero sans recomposition globale, insets `statusBars` (hero edge-to-edge).

## Notes de portage

- « Lecture » mène pour l'instant vers la fiche détail (placeholder Phase 8) en attendant le lecteur Media3 — TODO Phase 9.
- « Nouveautés » reproduit fidèlement l'ordre du web actuel (ordre de scan inversé).
- Le bouton web « Changer de dossier » (sélecteur de fichiers navigateur) n'a pas d'équivalent natif : le scan MediaStore couvre tout le stockage autorisé.
- Manifest : ajout `INTERNET`, `READ_MEDIA_VIDEO`, `READ_EXTERNAL_STORAGE` (maxSdk 32), classe `Application`.
- detekt : `LongParameterList` assouplie pour les `@Composable` (cohérent avec les assouplissements Compose existants).

## Tests

- **18 nouveaux tests JVM** : `HomeRowsDeriverTest` (ordre/contenu des rows, seuils 0-95, rows dossiers, fallback hero), `VideoUiSelectorsTest` (parité vu/progression/clés avec `VideoRow.tsx`), `LibraryViewModelTest` (pipeline scan → état, tri/filtres parité web, recherche débouncée, reset progression, fakes Room/TMDB).
- `./gradlew assembleDebug testDebugUnitTest detekt` ✅ (122 tests au total).

## Critères d'acceptation restants (manuels)

- [ ] Captures côte à côte avec l'app Capacitor (mêmes rows, ordre, badges).
- [ ] Vérifier l'absence de jank du hero sur appareil.
- [ ] Scroll 60 fps avec 300+ vidéos sur appareil milieu de gamme.

Closes #39