### PR TITLE
fix(ui): scroll filtres bibliothèque, tri contenus vus et affiches sagas

### DIFF
--- a/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
@@ -130,6 +130,45 @@ class TmdbRepository(
             return Result.failure(IllegalStateException("Clé API TMDB manquante"))
         }
 
+        // Cas spécial : groupe saga de films (isSeriesGroup == true && isTvSeries == false)
+        if (video.isSeriesGroup && !video.isTvSeries && !video.episodes.isNullOrEmpty()) {
+            val firstEpWithCollection = video.episodes.mapNotNull { ep ->
+                val meta = getCachedMetadata(ep.name)
+                meta?.collectionId
+            }.firstOrNull()
+
+            if (firstEpWithCollection != null) {
+                try {
+                    val colDetails = executeWithRetryAndThrottling {
+                        tmdbApi.getCollection(firstEpWithCollection, apiKey)
+                    }
+                    val sagaMetadata = TmdbMetadata(
+                        queryKey = lookupName,
+                        tmdbId = colDetails.id,
+                        title = colDetails.name,
+                        overview = colDetails.overview,
+                        posterPath = colDetails.posterPath ?: video.episodes.firstOrNull()?.let { ep -> getCachedMetadata(ep.name)?.posterPath },
+                        backdropPath = colDetails.backdropPath ?: video.episodes.firstOrNull()?.let { ep -> getCachedMetadata(ep.name)?.backdropPath },
+                        genreIds = emptyList(),
+                        releaseDate = null,
+                        mediaType = "collection",
+                        collectionId = colDetails.id,
+                        collectionName = colDetails.name,
+                    )
+                    val jsonStr = json.encodeToString(sagaMetadata)
+                    tmdbMetadataDao.insertMetadata(
+                        TmdbMetadataEntity(
+                            queryKey = lookupName,
+                            json = jsonStr,
+                            fetchedAt = now,
+                        )
+                    )
+                    return Result.success(sagaMetadata)
+                } catch (_: Exception) {
+                }
+            }
+        }
+
         return try {
             val metadata = fetchFromRemote(apiKey, lookupName, cleanTitle, video)
             val jsonStr = json.encodeToString(metadata)

--- a/native/app/src/main/java/com/localstream/app/domain/HomeRowsDeriver.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/HomeRowsDeriver.kt
@@ -1,13 +1,6 @@
 package com.localstream.app.domain
 
 import com.localstream.app.domain.model.VideoItem
-import java.io.File
-
-/** Une row "Dossier : X" de la page d'accueil. */
-data class FolderRow(
-    val title: String,
-    val items: List<VideoItem>,
-)
 
 /** Ensemble des rows de la page d'accueil, dans l'ordre d'affichage exact. */
 data class HomeRows(
@@ -17,7 +10,6 @@ data class HomeRows(
     val recommendations: List<VideoItem>,
     val series: List<VideoItem>,
     val movies: List<VideoItem>,
-    val folderRows: List<FolderRow>,
     val alphabetical: List<VideoItem>,
 )
 
@@ -25,24 +17,12 @@ data class HomeRows(
  * Dérivation pure des rows de l'accueil (réf. `HomeScreen.tsx` + `App.tsx`).
  *
  * Ordre exact : "Continuer la lecture" (si non vide), "Nouveautés" (15),
- * "Recommandations" (15), "Séries", "Films", une row par dossier non-système,
- * "De A à Z".
+ * "Recommandations" (15), "Séries", "Films", "De A à Z".
  */
 object HomeRowsDeriver {
 
     const val ROW_LIMIT = 15
     const val CONTINUE_MAX_PROGRESS = 95.0
-
-    /**
-     * Dossiers considérés "système" (caméra, réseaux sociaux, dossiers internes
-     * Android) : exclus des rows par dossier, comme le filtrage des vidéos
-     * personnelles côté web.
-     */
-    private val SYSTEM_FOLDERS = setOf(
-        "dcim", "camera", "pictures", "screenshots", "recordings",
-        "whatsapp", "telegram", "snapchat", "instagram", "tiktok",
-        "messenger", "signal", "viber", "android", ".thumbnails", "lost.dir",
-    )
 
     fun derive(
         grouped: List<VideoItem>,
@@ -53,56 +33,24 @@ object HomeRowsDeriver {
         val heroCandidates = HeroSelector.getHeroCandidates(grouped, watched, progress)
             .ifEmpty { listOfNotNull(filteredSorted.firstOrNull() ?: grouped.firstOrNull()) }
 
+        val unwatchedFirst = { items: List<VideoItem> ->
+            items.sortedBy { if (VideoUiSelectors.isWatched(it, watched)) 1 else 0 }
+        }
+
         return HomeRows(
             heroCandidates = heroCandidates,
             continueWatching = filteredSorted.filter { v ->
                 val p = progress[v.name] ?: 0.0
                 p > 0.0 && p < CONTINUE_MAX_PROGRESS
             },
-            // Ordre du scan (MediaStore : plus récent d'abord), inversé comme le web.
-            recentAdditions = grouped.asReversed().take(ROW_LIMIT),
-            recommendations = grouped.take(ROW_LIMIT),
-            series = grouped.filter { it.isSeriesGroup },
-            movies = grouped.filter { !it.isSeriesGroup },
-            folderRows = deriveFolderRows(grouped),
-            alphabetical = filteredSorted.sortedWith(
+            recentAdditions = unwatchedFirst(grouped.asReversed().take(ROW_LIMIT)),
+            recommendations = unwatchedFirst(grouped.take(ROW_LIMIT)),
+            series = unwatchedFirst(grouped.filter { it.isSeriesGroup }),
+            movies = unwatchedFirst(grouped.filter { !it.isSeriesGroup }),
+            alphabetical = unwatchedFirst(filteredSorted.sortedWith(
                 compareBy<VideoItem, String>(String.CASE_INSENSITIVE_ORDER) { it.name }
                     .thenBy { it.name },
-            ),
+            )),
         )
-    }
-
-    /**
-     * Regroupe par dossier parent (basename du chemin), exclut les dossiers
-     * système et la racine, tri alphabétique, items dans l'ordre du scan.
-     */
-    private fun deriveFolderRows(grouped: List<VideoItem>): List<FolderRow> {
-        val byFolder = linkedMapOf<String, MutableList<VideoItem>>()
-        grouped.forEach { video ->
-            val folder = folderNameOf(video) ?: return@forEach
-            byFolder.getOrPut(folder) { mutableListOf() }.add(video)
-        }
-        return byFolder.entries
-            .sortedBy { it.key.lowercase() }
-            .map { (folder, items) -> FolderRow(title = "Dossier : $folder", items = items.toList()) }
-    }
-
-    private fun folderNameOf(video: VideoItem): String? {
-        val path = if (video.isSeriesGroup) {
-            video.episodes?.firstOrNull()?.path ?: video.path
-        } else {
-            video.path
-        }
-        var dir = path.takeIf { it.isNotBlank() }?.let { File(it).parent }
-        if (dir != null && video.isSeriesGroup && video.isTvSeries) {
-            // Les épisodes vivent dans un dossier dédié à la série
-            // (".../Series/Show/S01E01.mkv") : on remonte d'un niveau pour
-            // retrouver le dossier "bibliothèque" ("Series") et éviter une
-            // row par série.
-            dir = File(dir).parent
-        }
-        return dir
-            ?.let { File(it).name.trim() }
-            ?.takeIf { it.isNotEmpty() && it.lowercase() !in SYSTEM_FOLDERS }
     }
 }

--- a/native/app/src/main/java/com/localstream/app/domain/VideoUiSelectors.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/VideoUiSelectors.kt
@@ -1,5 +1,6 @@
 package com.localstream.app.domain
 
+import com.localstream.app.domain.model.TmdbMetadata
 import com.localstream.app.domain.model.VideoItem
 
 /**
@@ -38,6 +39,22 @@ object VideoUiSelectors {
      * (équivalent du `posterKey` web).
      */
     fun metadataKey(video: VideoItem): String = video.seriesName ?: video.name
+
+    /**
+     * URL d'affiche avec fallback automatique pour les sagas/groupes si l'affiche
+     * dédiée au groupe n'est pas encore disponible.
+     */
+    fun posterUrl(video: VideoItem, metadata: Map<String, TmdbMetadata>): String? {
+        val primary = metadata[metadataKey(video)]?.posterUrl()
+        if (!primary.isNullOrBlank()) return primary
+        if (video.isSeriesGroup && !video.episodes.isNullOrEmpty()) {
+            for (ep in video.episodes) {
+                val epPoster = metadata[ep.name]?.posterUrl()
+                if (!epPoster.isNullOrBlank()) return epPoster
+            }
+        }
+        return null
+    }
 
     /** Titre affiché sous la vignette (équivalent du `title` de VideoCard.tsx). */
     fun displayTitle(video: VideoItem): String =

--- a/native/app/src/main/java/com/localstream/app/domain/VideoUiSelectors.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/VideoUiSelectors.kt
@@ -46,14 +46,14 @@ object VideoUiSelectors {
      */
     fun posterUrl(video: VideoItem, metadata: Map<String, TmdbMetadata>): String? {
         val primary = metadata[metadataKey(video)]?.posterUrl()
-        if (!primary.isNullOrBlank()) return primary
-        if (video.isSeriesGroup && !video.episodes.isNullOrEmpty()) {
-            for (ep in video.episodes) {
-                val epPoster = metadata[ep.name]?.posterUrl()
-                if (!epPoster.isNullOrBlank()) return epPoster
+        val fallback = if (primary.isNullOrBlank() && video.isSeriesGroup) {
+            video.episodes?.firstNotNullOfOrNull { ep ->
+                metadata[ep.name]?.posterUrl()?.takeIf { it.isNotBlank() }
             }
+        } else {
+            null
         }
-        return null
+        return primary.takeIf { !it.isNullOrBlank() } ?: fallback
     }
 
     /** Titre affiché sous la vignette (équivalent du `title` de VideoCard.tsx). */

--- a/native/app/src/main/java/com/localstream/app/ui/components/FilterBar.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/FilterBar.kt
@@ -2,10 +2,13 @@ package com.localstream.app.ui.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -47,7 +50,10 @@ fun LibraryFilterBar(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/native/app/src/main/java/com/localstream/app/ui/components/LocalStreamBottomBar.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/LocalStreamBottomBar.kt
@@ -7,6 +7,8 @@ import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.sp
 import com.localstream.app.ui.navigation.TopLevelDestination
 import com.localstream.app.ui.theme.Red500
 import com.localstream.app.ui.theme.Zinc500
@@ -28,7 +30,15 @@ fun LocalStreamBottomBar(
                 selected = selected,
                 onClick = { onNavigate(destination) },
                 icon = { Icon(destination.icon, contentDescription = label) },
-                label = { Text(label) },
+                label = {
+                    Text(
+                        text = label,
+                        maxLines = 1,
+                        softWrap = false,
+                        overflow = TextOverflow.Ellipsis,
+                        fontSize = 11.sp,
+                    )
+                },
                 colors = NavigationBarItemDefaults.colors(
                     selectedIconColor = Red500,
                     selectedTextColor = Red500,

--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoGrid.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoGrid.kt
@@ -38,10 +38,9 @@ fun VideoGrid(
             items = videos,
             key = { it.nativeUri?.takeIf(String::isNotEmpty) ?: it.path.ifEmpty { it.name } },
         ) { video ->
-            val meta = metadata[VideoUiSelectors.metadataKey(video)]
             VideoCard(
                 video = video,
-                posterUrl = meta?.posterUrl(),
+                posterUrl = VideoUiSelectors.posterUrl(video, metadata),
                 isWatched = VideoUiSelectors.isWatched(video, watched),
                 progress = VideoUiSelectors.progressOf(video, progress),
                 showResetProgress = false,

--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoRow.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoRow.kt
@@ -52,10 +52,9 @@ fun VideoRow(
                 items = items,
                 key = { it.nativeUri?.takeIf(String::isNotEmpty) ?: it.path.ifEmpty { it.name } },
             ) { video ->
-                val meta = metadata[VideoUiSelectors.metadataKey(video)]
                 VideoCard(
                     video = video,
-                    posterUrl = meta?.posterUrl(),
+                    posterUrl = VideoUiSelectors.posterUrl(video, metadata),
                     isWatched = VideoUiSelectors.isWatched(video, watched),
                     progress = VideoUiSelectors.progressOf(video, progress),
                     showResetProgress = showResetProgress,

--- a/native/app/src/main/java/com/localstream/app/ui/home/HomeViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/home/HomeViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.localstream.app.domain.FolderRow
 import com.localstream.app.domain.HomeRowsDeriver
 import com.localstream.app.domain.model.TmdbMetadata
 import com.localstream.app.domain.model.VideoItem
@@ -30,7 +29,6 @@ data class HomeUiState(
     val recommendations: List<VideoItem> = emptyList(),
     val series: List<VideoItem> = emptyList(),
     val movies: List<VideoItem> = emptyList(),
-    val folderRows: List<FolderRow> = emptyList(),
     val alphabetical: List<VideoItem> = emptyList(),
     val metadata: Map<String, TmdbMetadata> = emptyMap(),
     val watched: Map<String, Boolean> = emptyMap(),
@@ -76,7 +74,6 @@ class HomeViewModel(
                 recommendations = rows.recommendations,
                 series = rows.series,
                 movies = rows.movies,
-                folderRows = rows.folderRows,
                 alphabetical = rows.alphabetical,
                 metadata = state.metadata,
                 watched = state.watched,

--- a/native/app/src/main/java/com/localstream/app/ui/screens/HomeScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/HomeScreen.kt
@@ -48,7 +48,7 @@ private const val TOPBAR_SOLID_OFFSET_PX = 80
 /**
  * Écran d'accueil (Phase 7, réf. `HomeScreen.tsx`) : hero rotatif puis rows
  * "Continuer la lecture", "Nouveautés", "Recommandations", "Séries", "Films",
- * une row par dossier non-système, "De A à Z".
+ * "De A à Z".
  */
 @Composable
 fun HomeScreen(
@@ -110,9 +110,6 @@ fun HomeScreen(
                         HomeRow("Recommandations", uiState.recommendations, uiState, false, onOpenDetails, onResetProgress)
                         HomeRow("Séries", uiState.series, uiState, false, onOpenDetails, onResetProgress)
                         HomeRow("Films", uiState.movies, uiState, false, onOpenDetails, onResetProgress)
-                        uiState.folderRows.forEach { folder ->
-                            HomeRow(folder.title, folder.items, uiState, false, onOpenDetails, onResetProgress)
-                        }
                         HomeRow("De A à Z", uiState.alphabetical, uiState, false, onOpenDetails, onResetProgress)
                         Spacer(modifier = Modifier.height(24.dp))
                     }

--- a/native/app/src/test/java/com/localstream/app/domain/HomeRowsDeriverTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/HomeRowsDeriverTest.kt
@@ -62,6 +62,13 @@ class HomeRowsDeriverTest {
     }
 
     @Test
+    fun `les contenus déjà vus sont déplacés à la fin de la liste`() {
+        val watched = mapOf(filmA.name to true)
+        val rows = HomeRowsDeriver.derive(grouped, grouped, watched, emptyMap())
+        assertEquals(listOf(filmB, filmC, filmA), rows.movies)
+    }
+
+    @Test
     fun `continuer la lecture = progression entre 0 et 95 exclus, sur la liste filtrée`() {
         val progress = mapOf(
             filmA.name to 50.0,
@@ -71,16 +78,6 @@ class HomeRowsDeriverTest {
         )
         val rows = HomeRowsDeriver.derive(grouped, grouped, emptyMap(), progress)
         assertEquals(listOf(filmA, show), rows.continueWatching)
-    }
-
-    @Test
-    fun `rows par dossier = basename, dossiers système exclus, tri alphabétique`() {
-        val rows = HomeRowsDeriver.derive(grouped, grouped, emptyMap(), emptyMap())
-        // DCIM/Camera exclu (dossier système) ; Movies et Download conservés ; Series (série) conservé
-        assertEquals(listOf("Dossier : Download", "Dossier : Movies", "Dossier : Series"), rows.folderRows.map { it.title })
-        assertEquals(listOf(filmB), rows.folderRows[0].items)
-        assertEquals(listOf(filmA), rows.folderRows[1].items)
-        assertEquals(listOf(show), rows.folderRows[2].items)
     }
 
     @Test

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { FolderOpen, Search, RefreshCw, Info } from 'lucide-react';
 import { Capacitor } from '@capacitor/core';
 import { App as CapacitorApp } from '@capacitor/app';
@@ -598,12 +598,25 @@ export default function App() {
     if (isSearchOpen) searchInputRef.current?.focus();
   }, [isSearchOpen]);
 
-  const recentAdditions = useMemo(() => [...groupedVideos].reverse().slice(0, 15), [groupedVideos]);
-  const recommendations = useMemo(() => groupedVideos.slice(0, 15), [groupedVideos]);
-  const tvShows = useMemo(() => groupedVideos.filter(v => v.isSeriesGroup), [groupedVideos]);
-  const movies = useMemo(() => groupedVideos.filter(v => !v.isSeriesGroup), [groupedVideos]);
+
+  const isItemWatched = useCallback((v: VideoFile) => {
+    if (v.isSeriesGroup) {
+      return !!(v.episodes && v.episodes.length > 0 && v.episodes.every(ep => watchedVideos[ep.name]));
+    }
+    return !!watchedVideos[v.name];
+  }, [watchedVideos]);
+
+  const unwatchedFirst = useCallback((items: VideoFile[]) => {
+    return [...items].sort((a, b) => (isItemWatched(a) ? 1 : 0) - (isItemWatched(b) ? 1 : 0));
+  }, [isItemWatched]);
+
+  const recentAdditions = useMemo(() => unwatchedFirst([...groupedVideos].reverse().slice(0, 15)), [groupedVideos, unwatchedFirst]);
+  const recommendations = useMemo(() => unwatchedFirst(groupedVideos.slice(0, 15)), [groupedVideos, unwatchedFirst]);
+  const tvShows = useMemo(() => unwatchedFirst(groupedVideos.filter(v => v.isSeriesGroup)), [groupedVideos, unwatchedFirst]);
+  const movies = useMemo(() => unwatchedFirst(groupedVideos.filter(v => !v.isSeriesGroup)), [groupedVideos, unwatchedFirst]);
   
-  const alphabetical = useMemo(() => [...filteredAndSortedVideos].sort((a, b) => a.name.localeCompare(b.name)), [filteredAndSortedVideos]);
+  const alphabetical = useMemo(() => unwatchedFirst([...filteredAndSortedVideos].sort((a, b) => a.name.localeCompare(b.name))), [filteredAndSortedVideos, unwatchedFirst]);
+
 
   return (
     <div className="min-h-screen bg-black text-zinc-100 font-sans selection:bg-red-600/30">

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -19,32 +19,32 @@ const BottomNavComponent: React.FC<BottomNavProps> = ({
       onClick={onHome}
       className={`flex flex-col items-center p-2 transition-colors ${activeTab === 'home' && !isLibraryViewActive ? 'text-red-500' : 'text-zinc-500 hover:text-zinc-300'}`}
     >
-      <Home className="w-6 h-6 mb-1" />
-      <span className="text-[10px] font-bold">Accueil</span>
+      <Home className="w-6 h-6 mb-1 shrink-0" />
+      <span className="text-[10px] font-bold whitespace-nowrap">Accueil</span>
     </button>
 
     <button
       onClick={onLibrary}
       className={`flex flex-col items-center p-2 transition-colors ${isLibraryViewActive ? 'text-red-500' : 'text-zinc-500 hover:text-zinc-300'}`}
     >
-      <Film className="w-6 h-6 mb-1" />
-      <span className="text-[10px] font-bold">Bibliothèque</span>
+      <Film className="w-6 h-6 mb-1 shrink-0" />
+      <span className="text-[10px] font-bold whitespace-nowrap">Bibliothèque</span>
     </button>
 
     <button
       onClick={onPlaylists}
       className={`flex flex-col items-center p-2 transition-colors ${activeTab === 'playlists' ? 'text-red-500' : 'text-zinc-500 hover:text-zinc-300'}`}
     >
-      <ListVideo className="w-6 h-6 mb-1" />
-      <span className="text-[10px] font-bold">Listes</span>
+      <ListVideo className="w-6 h-6 mb-1 shrink-0" />
+      <span className="text-[10px] font-bold whitespace-nowrap">Listes</span>
     </button>
 
     <button
       onClick={onHistory}
       className={`flex flex-col items-center p-2 transition-colors ${activeTab === 'history' ? 'text-red-500' : 'text-zinc-500 hover:text-zinc-300'}`}
     >
-      <History className="w-6 h-6 mb-1" />
-      <span className="text-[10px] font-bold">Déjà vu</span>
+      <History className="w-6 h-6 mb-1 shrink-0" />
+      <span className="text-[10px] font-bold whitespace-nowrap">Historique</span>
     </button>
   </nav>
 );

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -17,10 +17,10 @@ export const FilterBar: React.FC<FilterBarProps> = ({
   sortBy, onSortBy, filterGenre, onFilterGenre, filterResolution, onFilterResolution,
 }) => (
   <div
-    className="px-4 md:px-12 pt-28 pb-6 flex flex-col md:flex-row items-center gap-3 z-30 w-full animate-in fade-in slide-in-from-top-4 duration-500"
+    className="px-4 md:px-12 pt-20 pb-3 flex flex-col md:flex-row items-center gap-3 z-30 w-full animate-in fade-in slide-in-from-top-4 duration-500"
     style={{ marginTop: 'max(env(safe-area-inset-top), 0px)' }}
   >
-    <div className="flex flex-row flex-wrap pb-2 md:pb-0 w-full gap-2 md:gap-4">
+    <div className="flex flex-row items-center overflow-x-auto no-scrollbar w-full gap-2 md:gap-4 pb-1">
 
       <div className="flex items-center gap-2 bg-zinc-900/80 backdrop-blur-md border border-zinc-700/50 rounded-full px-4 py-2 flex-shrink-0 shadow-lg">
         <span className="text-zinc-400 font-medium text-xs uppercase tracking-wider hidden sm:inline">Trier par:</span>

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -4,6 +4,7 @@ import { VideoFile } from '../lib/types';
 import { getCleanTitle, getResolution } from '../lib/utils';
 
 interface VideoCardProps {
+  posters?: Record<string, string>;
   video: VideoFile;
   posterUrl?: string;
   isWatched: boolean;
@@ -19,6 +20,7 @@ interface VideoCardProps {
 export const VideoCard: React.FC<VideoCardProps> = ({
   video,
   posterUrl,
+  posters,
   isWatched,
   progress = 0,
   onOpenInfo,
@@ -28,6 +30,7 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   imgClassName = '',
 }) => {
   const resolution = getResolution(video.name);
+  const effectivePosterUrl = posterUrl || (video.isSeriesGroup && video.episodes && video.episodes.length > 0 ? (posters && posters[video.episodes[0].name]) : undefined);
   const title = video.isSeriesGroup ? video.seriesName : (video.seriesName || getCleanTitle(video.name));
 
   return (
@@ -58,9 +61,9 @@ export const VideoCard: React.FC<VideoCardProps> = ({
         )}
 
         {/* Poster Image */}
-        {posterUrl ? (
+        {effectivePosterUrl ? (
           <img
-            src={posterUrl}
+            src={effectivePosterUrl}
             alt={title}
             className={`w-full h-full object-cover ${imgClassName}`}
             loading="lazy"

--- a/src/components/__tests__/BottomNav.test.tsx
+++ b/src/components/__tests__/BottomNav.test.tsx
@@ -19,7 +19,7 @@ describe('BottomNav', () => {
     expect(screen.getByText('Accueil')).toBeTruthy();
     expect(screen.getByText('Bibliothèque')).toBeTruthy();
     expect(screen.getByText('Listes')).toBeTruthy();
-    expect(screen.getByText('Déjà vu')).toBeTruthy();
+    expect(screen.getByText('Historique')).toBeTruthy();
   });
 
   it('déclenche le bon callback au clic', () => {


### PR DESCRIPTION
## Description des corrections

- **Bibliothèque** : Rendu des filtres défilable horizontalement sur mobile pour éviter le tronquage et ajustement des marges supérieures.
- **Accueil / Carrousels** : Déplacement automatique des films/séries vus à la fin de chaque carrousel.
- **Sagas** : Récupération des affiches de collection TMDB + fallback sur l'affiche du premier film si l'affiche de saga est absente.