### PR TITLE
fix(details,home): correct episode overview, episode progress tracking, and hide watched items on home

### DIFF
--- a/native/app/src/main/java/com/localstream/app/domain/HomeRowsDeriver.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/HomeRowsDeriver.kt
@@ -33,8 +33,8 @@ object HomeRowsDeriver {
         val heroCandidates = HeroSelector.getHeroCandidates(grouped, watched, progress)
             .ifEmpty { listOfNotNull(filteredSorted.firstOrNull() ?: grouped.firstOrNull()) }
 
-        val unwatchedFirst = { items: List<VideoItem> ->
-            items.sortedBy { if (VideoUiSelectors.isWatched(it, watched)) 1 else 0 }
+        val unwatchedOnly = { items: List<VideoItem> ->
+            items.filter { !VideoUiSelectors.isWatched(it, watched) }
         }
 
         return HomeRows(
@@ -43,11 +43,11 @@ object HomeRowsDeriver {
                 val p = progress[v.name] ?: 0.0
                 p > 0.0 && p < CONTINUE_MAX_PROGRESS
             },
-            recentAdditions = unwatchedFirst(grouped.asReversed().take(ROW_LIMIT)),
-            recommendations = unwatchedFirst(grouped.take(ROW_LIMIT)),
-            series = unwatchedFirst(grouped.filter { it.isSeriesGroup }),
-            movies = unwatchedFirst(grouped.filter { !it.isSeriesGroup }),
-            alphabetical = unwatchedFirst(filteredSorted.sortedWith(
+            recentAdditions = unwatchedOnly(grouped.asReversed().take(ROW_LIMIT)),
+            recommendations = unwatchedOnly(grouped.take(ROW_LIMIT)),
+            series = unwatchedOnly(grouped.filter { it.isSeriesGroup }),
+            movies = unwatchedOnly(grouped.filter { !it.isSeriesGroup }),
+            alphabetical = unwatchedOnly(filteredSorted.sortedWith(
                 compareBy<VideoItem, String>(String.CASE_INSENSITIVE_ORDER) { it.name }
                     .thenBy { it.name },
             )),

--- a/native/app/src/main/java/com/localstream/app/ui/details/DetailsViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/details/DetailsViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -34,6 +35,8 @@ data class DetailsUiState(
     val isWatched: Boolean = false,
     val watchPositionMs: Long = 0L,
     val watchDurationMs: Long = 0L,
+    val activeEpisodeName: String? = null,
+    val activeEpisodeNumber: Int? = null,
     val userPlaylists: List<PlaylistInfo> = emptyList(),
     val selectedSeason: Int = 1,
     val availableSeasons: List<Int> = listOf(1),
@@ -42,7 +45,14 @@ data class DetailsUiState(
     val tmdbError: String? = null,
 )
 
-@Suppress("TooManyFunctions", "LongMethod", "UNCHECKED_CAST")
+private data class ActiveEpisodeState(
+    val posMs: Long,
+    val durMs: Long,
+    val name: String,
+    val number: Int?,
+)
+
+@Suppress("TooManyFunctions", "LongMethod", "UNCHECKED_CAST", "CyclomaticComplexMethod")
 class DetailsViewModel(
     val id: String,
     private val container: AppContainer,
@@ -141,10 +151,6 @@ class DetailsViewModel(
         val isGroupWatched = watchedSet.contains(group.name) ||
             (group.episodes?.isNotEmpty() == true && group.episodes.all { watchedSet.contains(it.name) })
 
-        val playback = playbackMap[group.name]
-        val posMs = playback?.positionMs ?: 0L
-        val durMs = group.duration * 1000L
-
         val seasons = group.episodes?.mapNotNull { it.season }?.distinct()?.sorted()?.ifEmpty { listOf(1) } ?: listOf(1)
         val currentSeason = if (seasons.contains(season)) season else seasons.firstOrNull() ?: 1
 
@@ -154,7 +160,12 @@ class DetailsViewModel(
             val epWatched = watchedSet.contains(ep.name)
             val epPb = playbackMap[ep.name]
             val epPos = epPb?.positionMs ?: 0L
-            val epDur = ep.duration * 1000L
+            val epDur = if (ep.duration > 0) {
+                ep.duration * 1000L
+            } else {
+                val pct = epPb?.progressPct ?: 0.0
+                if (pct > 0.0) (epPos / (pct / 100.0)).toLong() else 0L
+            }
             val epProgress = if (epDur > 0L) (epPos.toFloat() / epDur.toFloat()).coerceIn(0f, 1f) else 0f
 
             val tmdbEp = cachedEpisodes[ep.name]
@@ -171,12 +182,41 @@ class DetailsViewModel(
             )
         }
 
+        // Active episode & header watch position computation
+        val activeState = if (group.isSeriesGroup && !group.episodes.isNullOrEmpty()) {
+            val inProgressEp = group.episodes.firstOrNull { ep ->
+                val pos = playbackMap[ep.name]?.positionMs ?: 0L
+                pos > 0L && !watchedSet.contains(ep.name)
+            }
+            val targetEp = inProgressEp
+                ?: group.episodes.firstOrNull { !watchedSet.contains(it.name) }
+                ?: group.episodes.first()
+
+            val targetPb = playbackMap[targetEp.name]
+            val targetPos = targetPb?.positionMs ?: 0L
+            val targetDur = if (targetEp.duration > 0) {
+                targetEp.duration * 1000L
+            } else {
+                val pct = targetPb?.progressPct ?: 0.0
+                if (pct > 0.0) (targetPos / (pct / 100.0)).toLong() else 0L
+            }
+            val targetNum = targetEp.episode ?: (group.episodes.indexOf(targetEp) + 1)
+            ActiveEpisodeState(targetPos, targetDur, targetEp.name, targetNum)
+        } else {
+            val playback = playbackMap[group.name]
+            val posMs = playback?.positionMs ?: 0L
+            val durMs = group.duration * 1000L
+            ActiveEpisodeState(posMs, durMs, group.name, null)
+        }
+
         DetailsUiState(
             videoGroup = group,
             metadata = meta,
             isWatched = isGroupWatched,
-            watchPositionMs = posMs,
-            watchDurationMs = durMs,
+            watchPositionMs = activeState.posMs,
+            watchDurationMs = activeState.durMs,
+            activeEpisodeName = activeState.name,
+            activeEpisodeNumber = activeState.number,
             userPlaylists = playlists,
             selectedSeason = currentSeason,
             availableSeasons = seasons,
@@ -253,8 +293,16 @@ class DetailsViewModel(
             val result = container.tmdbRepository.fetchMetadataForVideo(group, forceRefresh = true)
             if (result.isSuccess) {
                 cachedMetadataFlow.value = result.getOrNull()
+                group.episodes?.let { eps ->
+                    val lookupName = if (group.isSeriesGroup && !group.seriesName.isNullOrEmpty()) {
+                        group.seriesName
+                    } else {
+                        group.name
+                    }
+                    loadEpisodesFromCache(lookupName, eps)
+                }
             } else {
-                tmdbErrorFlow.value = result.exceptionOrNull()?.message ?: "Erreur de récupération TMDB"
+                tmdbErrorFlow.value = result.exceptionOrNull()?.message ?: "Erreur de r�cup�ration TMDB"
             }
             isLoadingTmdbFlow.value = false
         }

--- a/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
@@ -186,7 +186,7 @@ fun DetailsScreen(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         val badgeText = when {
-                            videoGroup?.isTvSeries == true -> "SÉRIE ORIGINALE"
+                            videoGroup?.isTvSeries == true -> "S�RIE ORIGINALE"
                             videoGroup?.isSeriesGroup == true -> "SAGA / COLLECTION"
                             else -> "FILM"
                         }
@@ -197,7 +197,7 @@ fun DetailsScreen(
                             fontWeight = FontWeight.Bold,
                         )
                         meta?.releaseDate?.take(4)?.let { year ->
-                            Text(text = "• $year", color = Zinc300, style = MaterialTheme.typography.labelMedium)
+                            Text(text = "� $year", color = Zinc300, style = MaterialTheme.typography.labelMedium)
                         }
                     }
 
@@ -216,13 +216,25 @@ fun DetailsScreen(
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                         modifier = Modifier.fillMaxWidth(),
                     ) {
-                        val playLabel = if (uiState.watchPositionMs > 0L) {
-                            "REPRENDRE À ${Formatters.formatDuration(uiState.watchPositionMs / 1000L)}"
-                        } else {
-                            "LECTURE"
+                        val playVideoTarget = uiState.activeEpisodeName ?: videoGroup?.name ?: id
+                        val playLabel = when {
+                            videoGroup?.isSeriesGroup == true || videoGroup?.isTvSeries == true -> {
+                                val epNum = uiState.activeEpisodeNumber ?: 1
+                                if (uiState.watchPositionMs > 0L) {
+                                    "REPRENDRE �P. $epNum (${Formatters.formatDuration(uiState.watchPositionMs / 1000L)})"
+                                } else {
+                                    "LECTURE �P. $epNum"
+                                }
+                            }
+                            uiState.watchPositionMs > 0L -> {
+                                "REPRENDRE � ${Formatters.formatDuration(uiState.watchPositionMs / 1000L)}"
+                            }
+                            else -> {
+                                "LECTURE"
+                            }
                         }
                         Button(
-                            onClick = { onPlayVideo(videoGroup?.name ?: id) },
+                            onClick = { onPlayVideo(playVideoTarget) },
                             colors = ButtonDefaults.buttonColors(containerColor = White, contentColor = Color.Black),
                             shape = RoundedCornerShape(4.dp),
                         ) {
@@ -277,7 +289,7 @@ fun DetailsScreen(
                                 overflow = TextOverflow.Ellipsis,
                             )
                             Text(
-                                text = if (isSynopsisExpanded) "RÉDUIRE" else "LIRE LA SUITE",
+                                text = if (isSynopsisExpanded) "R�DUIRE" else "LIRE LA SUITE",
                                 color = Red600,
                                 style = MaterialTheme.typography.labelSmall,
                                 fontWeight = FontWeight.Bold,
@@ -305,7 +317,7 @@ fun DetailsScreen(
                                 )
                             }
                             val ext = item.name.substringAfterLast('.', "").uppercase()
-                            if (ext.isNotBlank()) {
+                            if (ext.isNotBlank() && ext != item.name.uppercase()) {
                                 Text(
                                     text = ext,
                                     color = White,
@@ -315,14 +327,16 @@ fun DetailsScreen(
                                         .padding(horizontal = 6.dp, vertical = 2.dp),
                                 )
                             }
-                            Text(
-                                text = Formatters.formatSize(item.size),
-                                color = Zinc300,
-                                style = MaterialTheme.typography.labelSmall,
-                                modifier = Modifier
-                                    .background(Zinc800, RoundedCornerShape(2.dp))
-                                    .padding(horizontal = 6.dp, vertical = 2.dp),
-                            )
+                            if (item.size > 0L) {
+                                Text(
+                                    text = Formatters.formatSize(item.size),
+                                    color = Zinc300,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    modifier = Modifier
+                                        .background(Zinc800, RoundedCornerShape(2.dp))
+                                        .padding(horizontal = 6.dp, vertical = 2.dp),
+                                )
+                            }
                         }
                     }
 
@@ -335,7 +349,7 @@ fun DetailsScreen(
                 item {
                     Column(modifier = Modifier.padding(horizontal = 16.dp)) {
                         Text(
-                            text = "ÉPISODES",
+                            text = "�PISODES",
                             color = White,
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold,
@@ -445,18 +459,27 @@ private fun EpisodeItemRow(
 
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = "Ép. ${ep.video.episode ?: ep.tmdbEpisode?.episodeNumber ?: ""} - ${ep.tmdbEpisode?.name ?: TitleCleaner.getCleanTitle(ep.video.name)}",
+                        text = "�p. ${ep.video.episode ?: ep.tmdbEpisode?.episodeNumber ?: ""} - ${ep.tmdbEpisode?.name ?: TitleCleaner.getCleanTitle(ep.video.name)}",
                         color = White,
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Bold,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
-                    Text(
-                        text = Formatters.formatDuration(ep.durationMs / 1000L),
-                        color = Zinc300,
-                        style = MaterialTheme.typography.bodySmall,
-                    )
+                    if (ep.positionMs > 0L && !ep.isWatched) {
+                        Text(
+                            text = "En cours � ${Formatters.formatDuration(ep.positionMs / 1000L)}",
+                            color = Red600,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    } else {
+                        Text(
+                            text = Formatters.formatDuration(ep.durationMs / 1000L),
+                            color = Zinc300,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
                 }
 
                 IconButton(onClick = onToggleWatched) {
@@ -470,7 +493,7 @@ private fun EpisodeItemRow(
                 IconButton(onClick = onToggleExpanded) {
                     Icon(
                         if (ep.isExpanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
-                        contentDescription = "D?tails de l'?pisode",
+                        contentDescription = "D�tails de l'�pisode",
                         tint = White,
                     )
                 }
@@ -482,10 +505,9 @@ private fun EpisodeItemRow(
                         .fillMaxWidth()
                         .padding(top = 8.dp),
                 ) {
-                    ep.tmdbEpisode?.overview?.takeIf { it.isNotBlank() }?.let { overview ->
-                        Text(text = overview, color = Zinc300, style = MaterialTheme.typography.bodySmall)
-                        Spacer(modifier = Modifier.height(8.dp))
-                    }
+                    val overviewText = ep.tmdbEpisode?.overview?.takeIf { it.isNotBlank() } ?: "Aucun r�sum� disponible."
+                    Text(text = overviewText, color = Zinc300, style = MaterialTheme.typography.bodySmall)
+                    Spacer(modifier = Modifier.height(8.dp))
                     Button(
                         onClick = onPlay,
                         colors = ButtonDefaults.buttonColors(containerColor = Red600),
@@ -496,16 +518,6 @@ private fun EpisodeItemRow(
                         Spacer(modifier = Modifier.width(6.dp))
                         Text("Lecture", color = White, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
                     }
-                    Text(
-                        text = "Fichier : ${ep.video.name}",
-                        color = Zinc300.copy(alpha = 0.7f),
-                        style = MaterialTheme.typography.labelSmall,
-                    )
-                    Text(
-                        text = "Taille : ${Formatters.formatSize(ep.video.size)}",
-                        color = Zinc300.copy(alpha = 0.7f),
-                        style = MaterialTheme.typography.labelSmall,
-                    )
                     if (ep.progressPercent > 0f) {
                         Spacer(modifier = Modifier.height(6.dp))
                         Button(
@@ -513,7 +525,7 @@ private fun EpisodeItemRow(
                             colors = ButtonDefaults.buttonColors(containerColor = Zinc800),
                             shape = RoundedCornerShape(4.dp),
                         ) {
-                            Text("Réinitialiser la progression", color = Red600, style = MaterialTheme.typography.labelSmall)
+                            Text("R�initialiser la progression", color = Red600, style = MaterialTheme.typography.labelSmall)
                         }
                     }
                 }

--- a/native/app/src/test/java/com/localstream/app/domain/HomeRowsDeriverTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/HomeRowsDeriverTest.kt
@@ -65,7 +65,7 @@ class HomeRowsDeriverTest {
     fun `les contenus déjà vus sont déplacés à la fin de la liste`() {
         val watched = mapOf(filmA.name to true)
         val rows = HomeRowsDeriver.derive(grouped, grouped, watched, emptyMap())
-        assertEquals(listOf(filmB, filmC, filmA), rows.movies)
+        assertEquals(listOf(filmB, filmC), rows.movies)
     }
 
     @Test


### PR DESCRIPTION
## Résumé des modifications
- **Synopsis d'épisode dans les détails** : Chargement et affichage des métadonnées TMDB de l'épisode au lieu de les forcer à null. Suppression des mentions inutiles 'Fichier' et 'Taille'.
- **Suivi de progression des épisodes** : Calcul correct de la progression d'épisode dans DetailsViewModel et affichage du badge 'En cours' ainsi que de l'épisode actif dans le bouton principal ('REPRENDRE ÉP. X (5m)').
- **Masquage des contenus vus à l'accueil** : Filtrage des films et séries déjà marqués comme vus dans HomeRowsDeriver.