### PR TITLE
fix(ui): remove SXX:EXX from red series badge and normalize episode item heights

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoCard.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoCard.kt
@@ -83,8 +83,7 @@ fun VideoCard(
 
             // Badge type (Série / Saga) — coin haut gauche.
             if (video.isSeriesGroup) {
-                val shortEp = episodeLabel?.substringAfter(" : ")?.takeIf { it.isNotBlank() }
-                val badgeText = if (shortEp != null) "Série • $shortEp" else (if (video.isTvSeries) "Série" else "Saga")
+                val badgeText = if (video.isTvSeries) "Série" else "Saga"
                 Badge(
                     text = badgeText,
                     background = Red600,

--- a/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
@@ -426,7 +426,9 @@ private fun EpisodeItemRow(
         Column(modifier = Modifier.padding(12.dp)) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
             ) {
                 // Episode thumbnail
                 Box(
@@ -470,7 +472,10 @@ private fun EpisodeItemRow(
 
                 Spacer(modifier = Modifier.width(12.dp))
 
-                Column(modifier = Modifier.weight(1f)) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.Center,
+                ) {
                     Text(
                         text = "$epLabel • $epTitle",
                         color = White,


### PR DESCRIPTION
Fixes red series badge to display only 'Série' and normalizes episode row height across watched and unwatched states.