### PR TITLE
fix(player): ajouts des gestes volume/luminosité et correction du saut de barre de lecture

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -176,37 +176,46 @@ class PlayerViewModel(
             val allRaw = container.videoRepository.getRawVideos()
             val allGrouped = container.videoRepository.getGroupedVideos()
 
-            val rawVideo = allRaw.find { it.name == decodedName || it.name == videoName }
+            val targetVideo = resolveTargetVideo(decodedName, videoName, allGrouped, allRaw)
 
-            val foundGroup = allGrouped.find { group ->
-                group.name == decodedName || group.name == videoName
-            }
+            val state = container.watchStateRepository.getPlaybackState(targetVideo.name)
+            val rawPos = state?.positionMs ?: 0L
+            val pct = state?.progressPct ?: 0.0
+            val pos = if (pct >= 95.0) 0L else rawPos
 
-            val targetVideo = if (foundGroup != null && foundGroup.isSeriesGroup && !foundGroup.episodes.isNullOrEmpty()) {
+            initialPositionMsFlow.value = pos
+            positionMsFlow.value = pos
+            currentVideoFlow.value = targetVideo
+
+            resolveNextVideo(targetVideo, allGrouped, allRaw)
+        }
+    }
+
+    private suspend fun resolveTargetVideo(
+        decodedName: String,
+        rawName: String,
+        allGrouped: List<VideoItem>,
+        allRaw: List<VideoItem>,
+    ): VideoItem {
+        val rawVideo = allRaw.find { it.name == decodedName || it.name == rawName }
+        val foundGroup = allGrouped.find { group ->
+            group.name == decodedName || group.name == rawName
+        }
+
+        return when {
+            foundGroup != null && foundGroup.isSeriesGroup && !foundGroup.episodes.isNullOrEmpty() -> {
                 val watchedMap = container.watchStateRepository.getWatchedMap()
-                val activeEp = foundGroup.episodes.firstOrNull { ep ->
+                foundGroup.episodes.firstOrNull { ep ->
                     val state = container.watchStateRepository.getPlaybackState(ep.name)
                     (state?.positionMs ?: 0L) > 0L && watchedMap[ep.name] != true
                 } ?: foundGroup.episodes.firstOrNull { ep ->
                     watchedMap[ep.name] != true
                 } ?: foundGroup.episodes.first()
-                activeEp
-            } else if (rawVideo != null) {
-                rawVideo
-            } else {
-                allGrouped.firstNotNullOfOrNull { group ->
-                    group.episodes?.find { it.name == decodedName || it.name == videoName }
-                } ?: VideoItem(name = decodedName)
             }
-
-            currentVideoFlow.value = targetVideo
-
-            val state = container.watchStateRepository.getPlaybackState(targetVideo.name)
-            val pos = state?.positionMs ?: 0L
-            initialPositionMsFlow.value = pos
-            positionMsFlow.value = pos
-
-            resolveNextVideo(targetVideo, allGrouped, allRaw)
+            rawVideo != null -> rawVideo
+            else -> allGrouped.firstNotNullOfOrNull { group ->
+                group.episodes?.find { it.name == decodedName || it.name == rawName }
+            } ?: VideoItem(name = decodedName)
         }
     }
 
@@ -398,26 +407,34 @@ class PlayerViewModel(
     }
 
     private fun videoNameFlowOrLoad(newName: String) {
-        isEndedFlow.value = false
-        positionMsFlow.value = 0L
-        initialPositionMsFlow.value = 0L
-        val decodedName = decodeUri(newName)
-        val allRaw = container.videoRepository.getRawVideos()
-        val allGrouped = container.videoRepository.getGroupedVideos()
+        viewModelScope.launch {
+            isEndedFlow.value = false
+            val decodedName = decodeUri(newName)
+            val allRaw = container.videoRepository.getRawVideos()
+            val allGrouped = container.videoRepository.getGroupedVideos()
 
-        val foundInGrouped = allGrouped.firstNotNullOfOrNull { group ->
-            if (group.name == decodedName || group.name == newName) {
-                group
-            } else {
-                group.episodes?.find { it.name == decodedName || it.name == newName }
+            val foundInGrouped = allGrouped.firstNotNullOfOrNull { group ->
+                if (group.name == decodedName || group.name == newName) {
+                    group
+                } else {
+                    group.episodes?.find { it.name == decodedName || it.name == newName }
+                }
             }
-        }
-        val video = allRaw.find { it.name == decodedName || it.name == newName }
-            ?: foundInGrouped
-            ?: VideoItem(name = decodedName)
+            val video = allRaw.find { it.name == decodedName || it.name == newName }
+                ?: foundInGrouped
+                ?: VideoItem(name = decodedName)
 
-        currentVideoFlow.value = video
-        resolveNextVideo(video, allGrouped, allRaw)
+            val state = container.watchStateRepository.getPlaybackState(video.name)
+            val rawPos = state?.positionMs ?: 0L
+            val pct = state?.progressPct ?: 0.0
+            val pos = if (pct >= 95.0) 0L else rawPos
+
+            initialPositionMsFlow.value = pos
+            positionMsFlow.value = pos
+            currentVideoFlow.value = video
+
+            resolveNextVideo(video, allGrouped, allRaw)
+        }
     }
 
     companion object {

--- a/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
@@ -22,6 +22,9 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -242,11 +245,13 @@ fun PlayerScreen(
         } ?: return@LaunchedEffect
 
         val mediaItem = MediaItem.fromUri(uri)
-        exoPlayer.setMediaItem(mediaItem)
-        exoPlayer.prepare()
-        if (uiState.initialPositionMs > 0L) {
-            exoPlayer.seekTo(uiState.initialPositionMs)
+        val startPos = uiState.initialPositionMs
+        if (startPos > 0L) {
+            exoPlayer.setMediaItem(mediaItem, startPos)
+        } else {
+            exoPlayer.setMediaItem(mediaItem)
         }
+        exoPlayer.prepare()
         exoPlayer.playWhenReady = true
     }
 
@@ -277,21 +282,50 @@ fun PlayerScreen(
             .fillMaxSize()
             .background(Black)
             .pointerInput(Unit) {
-                detectTapGestures(
-                    onTap = {
-                        viewModel.toggleControlsVisibility()
-                    },
-                    onDoubleTap = { offset ->
-                        val screenWidth = size.width
-                        if (offset.x < screenWidth / 2) {
-                            viewModel.seekBy(-10000L)
-                            exoPlayer.seekTo((exoPlayer.currentPosition - 10000L).coerceAtLeast(0L))
-                        } else {
-                            viewModel.seekBy(10000L)
-                            exoPlayer.seekTo((exoPlayer.currentPosition + 10000L).coerceAtMost(exoPlayer.duration))
-                        }
-                    },
-                )
+                coroutineScope {
+                    launch {
+                        detectTapGestures(
+                            onTap = {
+                                viewModel.toggleControlsVisibility()
+                            },
+                            onDoubleTap = { offset ->
+                                val screenWidth = size.width
+                                if (offset.x < screenWidth / 2) {
+                                    viewModel.seekBy(-10000L)
+                                    exoPlayer.seekTo((exoPlayer.currentPosition - 10000L).coerceAtLeast(0L))
+                                } else {
+                                    viewModel.seekBy(10000L)
+                                    exoPlayer.seekTo((exoPlayer.currentPosition + 10000L).coerceAtMost(exoPlayer.duration))
+                                }
+                            },
+                        )
+                    }
+                    launch {
+                        var isLeftSide = false
+                        var accumVolume = 0f
+                        detectVerticalDragGestures(
+                            onDragStart = { offset ->
+                                isLeftSide = offset.x < size.width / 2
+                                accumVolume = 0f
+                            },
+                            onVerticalDrag = { change, dragAmount ->
+                                change.consume()
+                                val height = size.height.toFloat().coerceAtLeast(1f)
+                                val deltaRatio = -dragAmount / height
+                                if (isLeftSide) {
+                                    viewModel.adjustBrightness(deltaRatio)
+                                } else {
+                                    accumVolume += deltaRatio * 100f
+                                    val deltaInt = accumVolume.toInt()
+                                    if (deltaInt != 0) {
+                                        viewModel.adjustVolume(deltaInt)
+                                        accumVolume -= deltaInt
+                                    }
+                                }
+                            },
+                        )
+                    }
+                }
             },
     ) {
         // Vue vidéo ExoPlayer

--- a/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
@@ -90,6 +90,19 @@ class PlayerViewModelTest {
     }
 
     @Test
+    fun `loadVideoDetails resets position to 0 if finished past threshold`() = runTest {
+        playbackDao.upsert(PlaybackStateEntity(name = video1.name, progressPct = 96.0, positionMs = 8500000L))
+
+        val viewModel = PlayerViewModel(video1.name, container)
+        backgroundScope.launch { viewModel.uiState.collect {} }
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(0L, state.initialPositionMs)
+        assertEquals(0L, state.positionMs)
+    }
+
+    @Test
     fun `loadVideoDetails populates currentVideo and restores position`() = runTest {
         playbackDao.upsert(PlaybackStateEntity(name = video1.name, progressPct = 50.0, positionMs = 4400000L))
 


### PR DESCRIPTION
## Description
- Ajout des gestes verticaux sur le lecteur vidéo (gauche: luminosité, droite: volume).
- Correction du bug où la barre de lecture sautait vers la dernière frame avant de revenir à la position de visionnage.
- Synchronisation préalable des états et de la position d'ExoPlayer.

## Vérification
- 	estDebugUnitTest OK
- detekt OK
- ssembleDebug OK