### PR TITLE
fix(player): preserve system device volume on launch

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -335,6 +335,10 @@ class PlayerViewModel(
         setVolumePercent(volumePercentFlow.value + deltaPercent)
     }
 
+    fun setInitialVolumePercent(newVol: Int) {
+        volumePercentFlow.value = newVol.coerceIn(0, 100)
+    }
+
     fun setVolumePercent(newVol: Int) {
         val coerced = newVol.coerceIn(0, 100)
         volumePercentFlow.value = coerced

--- a/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
@@ -135,6 +135,18 @@ fun PlayerScreen(
         context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
     }
 
+    // Initialisation du volume depuis l'AudioManager syst?me au lancement (conserve le volume du t?l?phone)
+    LaunchedEffect(Unit) {
+        audioManager?.let { am ->
+            val maxVol = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+            if (maxVol > 0) {
+                val curVol = am.getStreamVolume(AudioManager.STREAM_MUSIC)
+                val curPct = ((curVol.toFloat() / maxVol) * 100).roundToInt().coerceIn(0, 100)
+                viewModel.setInitialVolumePercent(curPct)
+            }
+        }
+    }
+
     // Synchronisation du volume avec AudioManager syst?me
     LaunchedEffect(uiState.volumePercent) {
         audioManager?.let { am ->
@@ -192,7 +204,13 @@ fun PlayerScreen(
 
     // Initialisation et gestion d'ExoPlayer
     val exoPlayer = remember(context) {
-        ExoPlayer.Builder(context).build()
+        val audioAttributes = androidx.media3.common.AudioAttributes.Builder()
+            .setUsage(C.USAGE_MEDIA)
+            .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+            .build()
+        ExoPlayer.Builder(context)
+            .setAudioAttributes(audioAttributes, true)
+            .build()
     }
 
     DisposableEffect(exoPlayer) {

--- a/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
@@ -234,6 +234,19 @@ class PlayerViewModelTest {
     }
 
     @Test
+    fun `setInitialVolumePercent updates volumePercent without gesture feedback`() = runTest {
+        val viewModel = PlayerViewModel(video1.name, container)
+        backgroundScope.launch { viewModel.uiState.collect {} }
+        advanceUntilIdle()
+
+        viewModel.setInitialVolumePercent(45)
+        advanceUntilIdle()
+
+        assertEquals(45, viewModel.uiState.value.volumePercent)
+        assertEquals(null, viewModel.uiState.value.gestureFeedback)
+    }
+
+    @Test
     fun `adjustVolume and adjustBrightness emit gesture feedback`() = runTest {
         val viewModel = PlayerViewModel(video1.name, container)
         backgroundScope.launch { viewModel.uiState.collect {} }


### PR DESCRIPTION
Conserve le volume actuel du téléphone au moment de lancer une vidéo au lieu de réinitialiser le volume à 100%.