### PR TITLE
fix(player): preserve system volume on video launch

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -335,6 +335,11 @@ class PlayerViewModel(
         setVolumePercent(volumePercentFlow.value + deltaPercent)
     }
 
+    fun initVolumePercent(newVol: Int) {
+        val coerced = newVol.coerceIn(0, 100)
+        volumePercentFlow.value = coerced
+    }
+
     fun setVolumePercent(newVol: Int) {
         val coerced = newVol.coerceIn(0, 100)
         volumePercentFlow.value = coerced

--- a/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
@@ -135,8 +135,24 @@ fun PlayerScreen(
         context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
     }
 
-    // Synchronisation du volume avec AudioManager syst?me
-    LaunchedEffect(uiState.volumePercent) {
+    var isVolumeInitialized by remember { mutableStateOf(false) }
+
+    // Initialisation du volume depuis l'AudioManager système au lancement
+    LaunchedEffect(Unit) {
+        audioManager?.let { am ->
+            val maxVol = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+            if (maxVol > 0) {
+                val curVol = am.getStreamVolume(AudioManager.STREAM_MUSIC)
+                val curPct = ((curVol.toFloat() / maxVol) * 100).roundToInt().coerceIn(0, 100)
+                viewModel.initVolumePercent(curPct)
+            }
+        }
+        isVolumeInitialized = true
+    }
+
+    // Synchronisation du volume avec AudioManager système
+    LaunchedEffect(uiState.volumePercent, isVolumeInitialized) {
+        if (!isVolumeInitialized) return@LaunchedEffect
         audioManager?.let { am ->
             val maxVol = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
             if (maxVol > 0) {


### PR DESCRIPTION
Fixes an issue where launching a video forced device media volume to maximum (100%). Now initializes player volume state from the system's AudioManager current volume level without changing device volume on startup.