### PR TITLE
fix(app): force landscape orientation and prevent activity recreation

### DIFF
--- a/native/app/src/main/AndroidManifest.xml
+++ b/native/app/src/main/AndroidManifest.xml
@@ -23,8 +23,10 @@
 
         <activity
             android:name=".MainActivity"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|density"
             android:exported="true"
             android:label="@string/app_name"
+            android:screenOrientation="sensorLandscape"
             android:theme="@style/Theme.LocalStream">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/native/app/src/main/java/com/localstream/app/MainActivity.kt
+++ b/native/app/src/main/java/com/localstream/app/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.localstream.app
 
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -12,6 +13,7 @@ import com.localstream.app.ui.theme.LocalStreamTheme
  */
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {


### PR DESCRIPTION
Fixes video reset issues by locking MainActivity to sensorLandscape orientation and configuring configChanges.