### PR TITLE
fix(player): force landscape orientation only during video playback

### DIFF
--- a/native/app/src/main/AndroidManifest.xml
+++ b/native/app/src/main/AndroidManifest.xml
@@ -26,7 +26,6 @@
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|density"
             android:exported="true"
             android:label="@string/app_name"
-            android:screenOrientation="sensorLandscape"
             android:theme="@style/Theme.LocalStream">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/native/app/src/main/java/com/localstream/app/MainActivity.kt
+++ b/native/app/src/main/java/com/localstream/app/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.localstream.app
 
-import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -13,7 +12,6 @@ import com.localstream.app.ui.theme.LocalStreamTheme
  */
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {

--- a/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
@@ -9,6 +9,7 @@ import android.app.Activity
 import android.app.PictureInPictureParams
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.media.AudioManager
 import android.net.Uri
 import android.os.Build
@@ -141,6 +142,7 @@ fun PlayerScreen(
     // Masquer la barre de statut et la barre de navigation pendant la lecture video (mode immersif)
     DisposableEffect(activity) {
         val window = activity?.window
+        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
         if (window != null) {
             val insetsController = WindowCompat.getInsetsController(window, window.decorView)
             insetsController.systemBarsBehavior =
@@ -148,6 +150,7 @@ fun PlayerScreen(
             insetsController.hide(WindowInsetsCompat.Type.systemBars())
         }
         onDispose {
+            activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
             if (window != null) {
                 val insetsController = WindowCompat.getInsetsController(window, window.decorView)
                 insetsController.show(WindowInsetsCompat.Type.systemBars())


### PR DESCRIPTION
## What changed

La PR #77 forcait l'orientation paysage (`sensorLandscape`) sur toute l'application via `AndroidManifest.xml` et `MainActivity`. Ce changement limite le paysage a la lecture video uniquement :

- Suppression de `android:screenOrientation="sensorLandscape"` du manifest (le `configChanges` est conserve pour eviter la recreation de l'activite lors des rotations).
- Suppression du `requestedOrientation` global dans `MainActivity`.
- Dans `PlayerScreen`, l'activite passe en `SCREEN_ORIENTATION_SENSOR_LANDSCAPE` a l'entree de l'ecran de lecture et revient a `SCREEN_ORIENTATION_UNSPECIFIED` a la sortie (via le `DisposableEffect` existant).

## Why

L'utilisateur veut le paysage uniquement quand une video est en lecture, pas dans toute l'app.

## Impact

Le reste de l'application suit a nouveau l'orientation du systeme ; seule la lecture video force le paysage.

## Validation

- `./gradlew assembleDebug testDebugUnitTest detekt --no-daemon --stacktrace` : BUILD SUCCESSFUL (identique a la CI).