### PR TITLE
fix(player): keep screen on during video playback (#80)

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
@@ -14,6 +14,7 @@ import android.net.Uri
 import android.os.Build
 import android.util.Rational
 import android.view.ViewGroup
+import android.view.WindowManager
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -152,6 +153,17 @@ fun PlayerScreen(
                 val insetsController = WindowCompat.getInsetsController(window, window.decorView)
                 insetsController.show(WindowInsetsCompat.Type.systemBars())
             }
+        }
+    }
+
+    // Garder l'ecran allume tant que la lecture video est en cours
+    DisposableEffect(activity, uiState.isPlaying) {
+        val window = activity?.window
+        if (window != null && uiState.isPlaying) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        onDispose {
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
     }
 


### PR DESCRIPTION
Active FLAG_KEEP_SCREEN_ON when video is playing and removes it on pause, stop or screen exit, preventing the device screen from turning off mid-playback according to the system sleep timeout.

Closes #80