### PR TITLE
fix: ne pas forcer la luminosite au maximum (#79)

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -1,4 +1,4 @@
-﻿package com.localstream.app.ui.player
+package com.localstream.app.ui.player
 
 import java.net.URLDecoder
 import androidx.lifecycle.ViewModel
@@ -59,7 +59,7 @@ data class PlayerUiState(
     val isControlsVisible: Boolean = true,
     val isLocked: Boolean = false,
     val volumePercent: Int = 100,
-    val brightnessPercent: Float = 1.0f,
+    val brightnessPercent: Float = -1f,
     val aspectRatioMode: AspectRatioMode = AspectRatioMode.FIT,
     val playbackSpeed: Float = 1.0f,
     val audioTracks: List<AudioTrackUiState> = emptyList(),
@@ -87,7 +87,7 @@ class PlayerViewModel(
     private val isControlsVisibleFlow = MutableStateFlow(true)
     private val isLockedFlow = MutableStateFlow(false)
     private val volumePercentFlow = MutableStateFlow(100)
-    private val brightnessPercentFlow = MutableStateFlow(1.0f)
+    private val brightnessPercentFlow = MutableStateFlow(-1f)
     private val aspectRatioModeFlow = MutableStateFlow(AspectRatioMode.FIT)
     private val playbackSpeedFlow = MutableStateFlow(1.0f)
     private val audioTracksFlow = MutableStateFlow<List<AudioTrackUiState>>(emptyList())
@@ -354,7 +354,9 @@ class PlayerViewModel(
     }
 
     fun adjustBrightness(deltaPercent: Float) {
-        setBrightnessPercent(brightnessPercentFlow.value + deltaPercent)
+        val current = brightnessPercentFlow.value
+        val baseline = if (current < 0f) 1.0f else current
+        setBrightnessPercent(baseline + deltaPercent)
     }
 
     fun setBrightnessPercent(newBright: Float) {

--- a/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
@@ -219,10 +219,20 @@ fun PlayerScreen(
         }
     }
 
-    // Ajustement de la luminosité de la fenêtre
+    // Ajustement de la luminosite de la fenetre : respecte la luminosite systeme par defaut (-1f)
     LaunchedEffect(uiState.brightnessPercent) {
-        activity?.window?.attributes = activity.window.attributes?.apply {
-            screenBrightness = uiState.brightnessPercent
+        val brightness = uiState.brightnessPercent
+        if (brightness >= 0f) {
+            activity?.window?.attributes = activity?.window?.attributes?.apply {
+                screenBrightness = brightness
+            }
+        }
+    }
+    DisposableEffect(activity) {
+        onDispose {
+            activity?.window?.attributes = activity?.window?.attributes?.apply {
+                screenBrightness = android.view.WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+            }
         }
     }
 
@@ -391,7 +401,18 @@ fun PlayerScreen(
                                 } ?: run {
                                     startVolume = uiState.volumePercent
                                 }
-                                startBrightness = uiState.brightnessPercent
+                                startBrightness = if (uiState.brightnessPercent >= 0f) {
+                                    uiState.brightnessPercent
+                                } else {
+                                    try {
+                                        android.provider.Settings.System.getInt(
+                                            context.contentResolver,
+                                            android.provider.Settings.System.SCREEN_BRIGHTNESS
+                                        ) / 255f
+                                    } catch (_: android.provider.Settings.SettingNotFoundException) {
+                                        1.0f
+                                    }
+                                }
                             },
                             onVerticalDrag = { change, _ ->
                                 change.consume()


### PR DESCRIPTION
Fixes #79

## Probleme
L'application forcait screenBrightness = 1.0f des l'ouverture du lecteur, ignorant la luminosite configuree par l'utilisateur.

## Solution
- **PlayerViewModel** : brightnessPercent initialise a -1f (BRIGHTNESS_OVERRIDE_NONE) au lieu de 1.0f. adjustBrightness utilise 1.0f comme baseline si aucune valeur explicite n'a ete definie.
- **PlayerScreen** : Le LaunchedEffect n'applique la luminosite a la fenetre que si la valeur est >= 0f. Un DisposableEffect restaure BRIGHTNESS_OVERRIDE_NONE a la sortie du lecteur.
- **Geste de luminosite** : Quand startBrightness == -1f, lit la luminosite systeme reelle via Settings.System.SCREEN_BRIGHTNESS comme point de depart du drag.

## Comportement
- A l'ouverture : luminosite inchangee (systeme).
- Geste swipe gauche : commence depuis la luminosite actuelle de l'ecran.
- A la fermeture : luminosite restituee au systeme.