### PR TITLE
fix(build): utiliser le fichier debug.keystore fixe pour garder une signature constante

### DIFF
--- a/native/app/build.gradle.kts
+++ b/native/app/build.gradle.kts
@@ -11,6 +11,15 @@ android {
     namespace = "com.localstream.app"
     compileSdk = 36
 
+    signingConfigs {
+        getByName("debug") {
+            storeFile = file("${rootDir}/debug.keystore")
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+
     defaultConfig {
         // Phase 10 : applicationId final hérité de l'app Capacitor existante.
         applicationId = "com.localstream.app"


### PR DESCRIPTION
## Description des modifications

Cette PR ajoute la configuration signingConfigs dans 
ative/app/build.gradle.kts afin d'utiliser le fichier debug.keystore fixe du projet.

### Pourquoi cette modification ?
Auparavant, chaque build sur la CI (GitHub Actions) utilisait une clé debug générée aléatoirement sur le runner Ubuntu. Cela modifiait l'empreinte numérique de l'APK à chaque build et provoquait l'erreur d'installation Android conflit de package lors de la mise à jour (obligeant à désinstaller l'app et effaçant la base de données).

Désormais, tous les builds (locaux et CI) partagent la même clé de signature debug constante.

## Tests
- ./gradlew test detekt assembleDebug exécutés avec succès.