### PR TITLE
fix(tmdb): désambiguïsation des métadonnées par année et type de média

### DIFF
--- a/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbApi.kt
+++ b/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbApi.kt
@@ -23,6 +23,8 @@ interface TmdbApi {
         @Query("api_key") apiKey: String,
         @Query("query") query: String,
         @Query("language") language: String = DEFAULT_LANGUAGE,
+        @Query("primary_release_year") primaryReleaseYear: Int? = null,
+        @Query("year") year: Int? = null,
     ): TmdbSearchResponse
 
     @GET("movie/{id}")

--- a/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
@@ -208,6 +208,8 @@ class TmdbRepository(
         cleanTitle: String,
         video: VideoItem,
     ): TmdbMetadata {
+        val targetYear = video.year ?: TitleCleaner.extractYear(video.name)
+
         val searchResponse = executeWithRetryAndThrottling {
             tmdbApi.searchMulti(apiKey, cleanTitle)
         }
@@ -217,15 +219,15 @@ class TmdbRepository(
             throw NoSuchElementException("Aucun résultat pour $cleanTitle")
         }
 
-        val bestResult = selectBestMatch(results, cleanTitle, video.isTvSeries)
+        val bestResult = selectBestMatch(results, cleanTitle, video.isTvSeries, targetYear)
             ?: throw NoSuchElementException("Aucun résultat valide pour $cleanTitle")
 
         var collectionId: Long? = null
         var collectionName: String? = null
         var details: TmdbMovieDetailsDto? = null
 
-        val isMovie = bestResult.mediaType == "movie" || (!video.isTvSeries && !video.isSeriesGroup)
-        if (isMovie) {
+        val isMovieResult = bestResult.mediaType == "movie" || (!video.isTvSeries && !video.isSeriesGroup)
+        if (isMovieResult) {
             try {
                 details = executeWithRetryAndThrottling {
                     tmdbApi.getMovieDetails(bestResult.id, apiKey)
@@ -299,29 +301,71 @@ class TmdbRepository(
         results: List<TmdbSearchResultDto>,
         cleanTitle: String,
         isTvSeries: Boolean,
+        targetYear: Int? = null,
     ): TmdbSearchResultDto? {
-        val cleanLower = cleanTitle.lowercase()
-        val exactMatchWithPoster = results.find { dto ->
-            val name = (dto.name ?: dto.title ?: "").lowercase()
-            name == cleanLower && !dto.posterPath.isNullOrBlank()
+        if (results.isEmpty()) return null
+        return results.maxByOrNull { dto ->
+            scoreCandidate(dto, cleanTitle, isTvSeries, targetYear)
         }
-        if (exactMatchWithPoster != null) return exactMatchWithPoster
+    }
 
-        val exactMatchAny = results.find { dto ->
-            val name = (dto.name ?: dto.title ?: "").lowercase()
-            name == cleanLower
+    @Suppress("MagicNumber")
+    private fun scoreCandidate(
+        dto: TmdbSearchResultDto,
+        cleanTitle: String,
+        isTvSeries: Boolean,
+        targetYear: Int?,
+    ): Int {
+        var score = 0
+        val cleanLower = cleanTitle.lowercase().trim()
+        val candidateTitleRaw = (dto.title ?: dto.name ?: "").lowercase().trim()
+        val candidateTitleNormalized = candidateTitleRaw.removePrefix("the ").trim()
+        val cleanNormalized = cleanLower.removePrefix("the ").trim()
+
+        val isExactTitle = candidateTitleRaw == cleanLower
+        val isNormalizedTitleMatch = candidateTitleNormalized == cleanNormalized
+
+        if (isExactTitle) {
+            score += 100
+        } else if (isNormalizedTitleMatch) {
+            score += 80
+        } else if (candidateTitleRaw.contains(cleanLower) || cleanLower.contains(candidateTitleRaw)) {
+            score += 40
         }
-        if (exactMatchAny != null) return exactMatchAny
 
-        return if (isTvSeries) {
-            results.find { it.mediaType == "tv" && !it.posterPath.isNullOrBlank() }
-                ?: results.find { !it.posterPath.isNullOrBlank() }
-                ?: results.firstOrNull()
+        val mediaType = dto.mediaType
+        if (isTvSeries) {
+            if (mediaType == "tv") score += 50
+            else if (mediaType == "movie") score -= 30
         } else {
-            results.find { it.mediaType == "movie" && !it.posterPath.isNullOrBlank() }
-                ?: results.find { !it.posterPath.isNullOrBlank() }
-                ?: results.firstOrNull()
+            if (mediaType == "movie") score += 50
+            else if (mediaType == "tv") score -= 30
         }
+
+        val candidateYear = extractYearFromDateString(dto.releaseDate ?: dto.firstAirDate)
+        if (targetYear != null && candidateYear != null) {
+            if (candidateYear == targetYear) {
+                score += 150
+            } else {
+                val yearDiff = kotlin.math.abs(candidateYear - targetYear)
+                if (yearDiff == 1) {
+                    score += 20
+                } else {
+                    score -= 80
+                }
+            }
+        }
+
+        if (!dto.posterPath.isNullOrBlank()) {
+            score += 10
+        }
+
+        return score
+    }
+
+    private fun extractYearFromDateString(dateStr: String?): Int? {
+        if (dateStr.isNullOrBlank() || dateStr.length < 4) return null
+        return dateStr.take(4).toIntOrNull()
     }
 
     suspend fun fetchAllMetadata(

--- a/native/app/src/main/java/com/localstream/app/data/scanner/MediaStoreScanner.kt
+++ b/native/app/src/main/java/com/localstream/app/data/scanner/MediaStoreScanner.kt
@@ -3,6 +3,7 @@ package com.localstream.app.data.scanner
 import android.content.Context
 import android.database.Cursor
 import android.provider.MediaStore
+import com.localstream.app.domain.TitleCleaner
 import com.localstream.app.domain.VideoGrouper
 import com.localstream.app.domain.VideoNameParser
 import com.localstream.app.domain.model.MovieCollection
@@ -71,6 +72,7 @@ class MediaStoreScanner(
 
         val contentUri = "content://media/external/video/media/$id"
         val seriesInfo = VideoNameParser.parseSeriesInfo(name, path)
+        val extractedYear = TitleCleaner.extractYear(name)
 
         return VideoItem(
             url = contentUri,
@@ -82,7 +84,8 @@ class MediaStoreScanner(
             duration = durationMs / 1000L,
             seriesName = seriesInfo.seriesName,
             season = seriesInfo.season,
-            episode = seriesInfo.episode
+            episode = seriesInfo.episode,
+            year = extractedYear
         )
     }
 
@@ -160,6 +163,7 @@ class MediaStoreScanner(
                 .filter { it.isFile && VideoNameParser.VIDEO_EXT_REGEX.containsMatchIn(it.name) }
                 .map { file ->
                     val seriesInfo = VideoNameParser.parseSeriesInfo(file.name, file.absolutePath)
+                    val extractedYear = TitleCleaner.extractYear(file.name)
                     VideoItem(
                         url = "file://${file.absolutePath}",
                         name = file.name,
@@ -169,7 +173,8 @@ class MediaStoreScanner(
                         lastModified = file.lastModified(),
                         seriesName = seriesInfo.seriesName,
                         season = seriesInfo.season,
-                        episode = seriesInfo.episode
+                        episode = seriesInfo.episode,
+                        year = extractedYear
                     )
                 }.toList()
         }

--- a/native/app/src/main/java/com/localstream/app/di/AppContainer.kt
+++ b/native/app/src/main/java/com/localstream/app/di/AppContainer.kt
@@ -196,7 +196,13 @@ open class AppContainer(
     private class NoOpTmdbApi : TmdbApi {
         private fun unused(): Nothing = throw UnsupportedOperationException("NoOp")
         override suspend fun searchMulti(apiKey: String, query: String, language: String): TmdbSearchResponse = unused()
-        override suspend fun searchMovie(apiKey: String, query: String, language: String): TmdbSearchResponse = unused()
+        override suspend fun searchMovie(
+            apiKey: String,
+            query: String,
+            language: String,
+            primaryReleaseYear: Int?,
+            year: Int?,
+        ): TmdbSearchResponse = unused()
         override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String): TmdbMovieDetailsDto = unused()
         override suspend fun getCollection(collectionId: Long, apiKey: String, language: String): TmdbCollectionDetailsDto = unused()
         override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String): TmdbSeasonDetailsDto = unused()

--- a/native/app/src/main/java/com/localstream/app/domain/Formatters.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/Formatters.kt
@@ -9,6 +9,7 @@ object TitleCleaner {
     private val YEAR_IN_PAREN_REGEX = Regex("[\\(\\[]((?:19|20)\\d{2})[\\)\\]]")
     private val YEAR_REGEX = Regex("(?:^|[\\s\\._\\-\\(\\[])((?:19|20)\\d{2})(?=[\\s\\._\\-\\)\\]]|$)")
 
+    @Suppress("ReturnCount")
     fun extractYear(filename: String): Int? {
         val nameWithoutExt = filename.replace(Regex("\\.[^/.]+$"), "")
         val parenMatch = YEAR_IN_PAREN_REGEX.find(nameWithoutExt)
@@ -16,10 +17,7 @@ object TitleCleaner {
             return parenMatch.groupValues[1].toIntOrNull()
         }
         val matches = YEAR_REGEX.findAll(nameWithoutExt).toList()
-        if (matches.isNotEmpty()) {
-            return matches.last().groupValues[1].toIntOrNull()
-        }
-        return null
+        return matches.lastOrNull()?.groupValues?.get(1)?.toIntOrNull()
     }
 
     fun getCleanTitle(filename: String): String {

--- a/native/app/src/main/java/com/localstream/app/domain/Formatters.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/Formatters.kt
@@ -6,10 +6,26 @@ import kotlin.math.ln
 import kotlin.math.pow
 
 object TitleCleaner {
+    private val YEAR_IN_PAREN_REGEX = Regex("[\\(\\[]((?:19|20)\\d{2})[\\)\\]]")
+    private val YEAR_REGEX = Regex("(?:^|[\\s\\._\\-\\(\\[])((?:19|20)\\d{2})(?=[\\s\\._\\-\\)\\]]|$)")
+
+    fun extractYear(filename: String): Int? {
+        val nameWithoutExt = filename.replace(Regex("\\.[^/.]+$"), "")
+        val parenMatch = YEAR_IN_PAREN_REGEX.find(nameWithoutExt)
+        if (parenMatch != null) {
+            return parenMatch.groupValues[1].toIntOrNull()
+        }
+        val matches = YEAR_REGEX.findAll(nameWithoutExt).toList()
+        if (matches.isNotEmpty()) {
+            return matches.last().groupValues[1].toIntOrNull()
+        }
+        return null
+    }
+
     fun getCleanTitle(filename: String): String {
         var title = filename.replace(Regex("\\.[^/.]+$"), "")
         title = title.replace(Regex("[sS]\\d+(\\s*)?([eE]\\d+)?|(\\d+)(\\s*)?x(\\d+).*", RegexOption.IGNORE_CASE), "")
-        title = title.replace(Regex("(19|20)\\d{2}.*"), "")
+        title = title.replace(Regex("(?<=\\w|\\s|\\.|\\-|_|\\()\\s*[\\(\\.\\[\\-_]?(19|20)\\d{2}.*"), "")
         title = title.replace(Regex("[\\.\\-_]"), " ")
         title = title.replace(
             Regex("1080p|720p|2160p|4k|bluray|webrip|hdtv|x264|x265|hevc|vostfr|french|truefrench", RegexOption.IGNORE_CASE),

--- a/native/app/src/main/java/com/localstream/app/domain/VideoGrouper.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/VideoGrouper.kt
@@ -34,7 +34,12 @@ object VideoGrouper {
                 val finalName = resolveSeriesName(updatedVideo, match)
                 groups.getOrPut(finalName) { mutableListOf() }.add(updatedVideo)
             } else {
-                standalone.add(video.copy(cleanTitle = TitleCleaner.getCleanTitle(video.name)))
+                standalone.add(
+                    video.copy(
+                        cleanTitle = TitleCleaner.getCleanTitle(video.name),
+                        year = video.year ?: TitleCleaner.extractYear(video.name)
+                    )
+                )
             }
         }
         return Pair(groups, standalone)
@@ -129,4 +134,3 @@ object VideoGrouper {
         return Pair(sagas, remaining)
     }
 }
-

--- a/native/app/src/main/java/com/localstream/app/domain/model/VideoItem.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/VideoItem.kt
@@ -19,6 +19,7 @@ data class VideoItem(
     val isTvSeries: Boolean = false,
     val episodes: List<VideoItem>? = null,
     val cleanTitle: String? = null,
+    val year: Int? = null,
     /** ID MediaStore : null si inconnu. Sert \u00e0 fiabiliser la cl\u00e9 d'identit\u00e9 \u00e0 terme. */
     val mediaStoreId: Long? = null,
 )

--- a/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
@@ -120,6 +120,54 @@ class TmdbRepositoryTest {
     }
 
     @Test
+    fun testFetchMetadataForMovieDisambiguatesByYearAndType() = runTest {
+        val searchJson = """
+            {
+              "results": [
+                {
+                  "id": 33260,
+                  "name": "Running Man",
+                  "overview": "Korean variety show...",
+                  "poster_path": "/tv_poster.jpg",
+                  "first_air_date": "2010-07-11",
+                  "media_type": "tv"
+                },
+                {
+                  "id": 123456,
+                  "title": "The Running Man",
+                  "overview": "The 2025 movie...",
+                  "poster_path": "/movie2025_poster.jpg",
+                  "release_date": "2025-11-21",
+                  "media_type": "movie"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val detailsJson = """
+            {
+              "id": 123456,
+              "title": "The Running Man",
+              "poster_path": "/movie2025_poster.jpg",
+              "release_date": "2025-11-21"
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(jsonResponse(searchJson))
+        mockWebServer.enqueue(jsonResponse(detailsJson))
+
+        val video = VideoItem(name = "Running Man (2025).mp4")
+        val result = repository.fetchMetadataForVideo(video)
+
+        assertTrue(result.isSuccess)
+        val metadata = result.getOrNull()
+        assertNotNull(metadata)
+        assertEquals("The Running Man", metadata?.title)
+        assertEquals(123456L, metadata?.tmdbId)
+        assertEquals("movie", metadata?.mediaType)
+    }
+
+    @Test
     fun testCacheHitDoesNotHitNetwork() = runTest {
         val searchJson = """
             {

--- a/native/app/src/test/java/com/localstream/app/domain/FormattersTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/FormattersTest.kt
@@ -13,6 +13,15 @@ class FormattersTest {
         assertEquals("Inception", TitleCleaner.getCleanTitle("Inception.2010.1080p.BluRay.x264.mkv"))
         assertEquals("Breaking Bad", TitleCleaner.getCleanTitle("Breaking.Bad.S01E01.720p.mkv"))
         assertEquals("The Office", TitleCleaner.getCleanTitle("The Office 1x05.mp4"))
+        assertEquals("Running Man", TitleCleaner.getCleanTitle("Running Man (2025).mp4"))
+    }
+
+    @Test
+    fun extractYear_correctlyExtractsYearFromFilename() {
+        assertEquals(2025, TitleCleaner.extractYear("Running Man (2025).mp4"))
+        assertEquals(2010, TitleCleaner.extractYear("Inception.2010.1080p.mkv"))
+        assertEquals(1999, TitleCleaner.extractYear("Fight.Club.1999.mp4"))
+        assertNull(TitleCleaner.extractYear("Breaking.Bad.S01E01.mp4"))
     }
 
     @Test

--- a/native/app/src/test/java/com/localstream/app/ui/details/DetailsViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/details/DetailsViewModelTest.kt
@@ -266,7 +266,13 @@ class DetailsViewModelTest {
     private class UnusedTmdbApi : TmdbApi {
         private fun unused(): Nothing = throw UnsupportedOperationException("appel inattendu")
         override suspend fun searchMulti(apiKey: String, query: String, language: String): TmdbSearchResponse = unused()
-        override suspend fun searchMovie(apiKey: String, query: String, language: String): TmdbSearchResponse = unused()
+        override suspend fun searchMovie(
+            apiKey: String,
+            query: String,
+            language: String,
+            primaryReleaseYear: Int?,
+            year: Int?,
+        ): TmdbSearchResponse = unused()
         override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String): TmdbMovieDetailsDto = unused()
         override suspend fun getCollection(collectionId: Long, apiKey: String, language: String): TmdbCollectionDetailsDto = unused()
         override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String): TmdbSeasonDetailsDto = unused()

--- a/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
@@ -248,7 +248,13 @@ class LibraryViewModelTest {
     private class UnusedTmdbApi : TmdbApi {
         private fun unused(): Nothing = throw UnsupportedOperationException("appel réseau inattendu")
         override suspend fun searchMulti(apiKey: String, query: String, language: String): TmdbSearchResponse = unused()
-        override suspend fun searchMovie(apiKey: String, query: String, language: String): TmdbSearchResponse = unused()
+        override suspend fun searchMovie(
+            apiKey: String,
+            query: String,
+            language: String,
+            primaryReleaseYear: Int?,
+            year: Int?,
+        ): TmdbSearchResponse = unused()
         override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String): TmdbMovieDetailsDto = unused()
         override suspend fun getCollection(collectionId: Long, apiKey: String, language: String): TmdbCollectionDetailsDto = unused()
         override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String): TmdbSeasonDetailsDto = unused()


### PR DESCRIPTION
### Description
Amélioration de la recherche et sélection des métadonnées TMDB lorsqu'un film et une série partagent le même titre (ex: film *Running Man (2025)* vs émission TV *Running Man (2010)*).

### Modifications
- Extraction de l'année depuis le nom de fichier (\TitleCleaner.extractYear\) et intégration dans \VideoItem\.
- Amélioration de \selectBestMatch\ dans \TmdbRepository\ avec un système de scoring favorisant :
  - Le type de média (\movie\ vs \	v\).
  - L'année de sortie extraite du nom du fichier par rapport à l'année TMDB.
  - La présence d'un poster et l'exactitude du titre.
- Ajout de tests unitaires couvrant la désambiguïsation par année et type de média.