### PR TITLE
fix(details): feedback visuel du bouton de rafraîchissement TMDB

### DIFF
--- a/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
@@ -191,7 +191,7 @@ class TmdbRepository(
             Result.failure(e)
         } catch (e: Exception) {
             // En cas d'erreur réseau / HTTP, repli sur le cache expiré si présent
-            if (cachedEntity != null && cachedEntity.json != NOT_FOUND_JSON) {
+            if (!forceRefresh && cachedEntity != null && cachedEntity.json != NOT_FOUND_JSON) {
                 try {
                     val meta = json.decodeFromString<TmdbMetadata>(cachedEntity.json)
                     return Result.success(meta)

--- a/native/app/src/main/java/com/localstream/app/ui/details/DetailsViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/details/DetailsViewModel.kt
@@ -44,6 +44,7 @@ data class DetailsUiState(
     val episodes: List<EpisodeUiState> = emptyList(),
     val isLoadingTmdb: Boolean = false,
     val tmdbError: String? = null,
+    val refreshSuccess: Boolean = false,
 )
 
 @Suppress("TooManyFunctions", "LongMethod", "UNCHECKED_CAST", "CyclomaticComplexMethod")
@@ -56,6 +57,7 @@ class DetailsViewModel(
     private val expandedEpisodesFlow = MutableStateFlow<Set<String>>(emptySet())
     private val isLoadingTmdbFlow = MutableStateFlow(false)
     private val tmdbErrorFlow = MutableStateFlow<String?>(null)
+    private val refreshSuccessFlow = MutableStateFlow(false)
     private val cachedMetadataFlow = MutableStateFlow<TmdbMetadata?>(null)
     private val cachedEpisodesFlow = MutableStateFlow<Map<String, TmdbEpisode>>(emptyMap())
 
@@ -137,6 +139,7 @@ class DetailsViewModel(
         val tmdbErr = args[7] as String?
         val meta = args[8] as TmdbMetadata?
         val cachedEpisodes = args[9] as Map<String, TmdbEpisode>
+        val refreshSuccess = args[10] as Boolean
 
         val group = videos.find { it.name == id || it.seriesName == id }
             ?: videos.find { it.name.lowercase() == id.lowercase() }
@@ -208,6 +211,7 @@ class DetailsViewModel(
             episodes = episodeUiStates,
             isLoadingTmdb = isLoading,
             tmdbError = tmdbErr,
+            refreshSuccess = refreshSuccess,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -275,6 +279,7 @@ class DetailsViewModel(
         viewModelScope.launch {
             isLoadingTmdbFlow.value = true
             tmdbErrorFlow.value = null
+            refreshSuccessFlow.value = false
             val result = container.tmdbRepository.fetchMetadataForVideo(group, forceRefresh = true)
             if (result.isSuccess) {
                 cachedMetadataFlow.value = result.getOrNull()
@@ -286,10 +291,14 @@ class DetailsViewModel(
                     }
                     loadEpisodesFromCache(lookupName, eps)
                 }
+                isLoadingTmdbFlow.value = false
+                refreshSuccessFlow.value = true
+                kotlinx.coroutines.delay(REFRESH_FEEDBACK_DURATION_MS)
+                refreshSuccessFlow.value = false
             } else {
                 tmdbErrorFlow.value = result.exceptionOrNull()?.message ?: "Erreur de récupération TMDB"
+                isLoadingTmdbFlow.value = false
             }
-            isLoadingTmdbFlow.value = false
         }
     }
 
@@ -313,6 +322,8 @@ class DetailsViewModel(
     }
 
     companion object {
+        private const val REFRESH_FEEDBACK_DURATION_MS = 3000L
+
         fun factory(id: String, container: AppContainer): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/native/app/src/main/java/com/localstream/app/ui/details/DetailsViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/details/DetailsViewModel.kt
@@ -47,6 +47,12 @@ data class DetailsUiState(
     val refreshSuccess: Boolean = false,
 )
 
+private data class TmdbRefreshFeedback(
+    val isLoading: Boolean,
+    val error: String?,
+    val success: Boolean,
+)
+
 @Suppress("TooManyFunctions", "LongMethod", "UNCHECKED_CAST", "CyclomaticComplexMethod")
 class DetailsViewModel(
     val id: String,
@@ -60,6 +66,14 @@ class DetailsViewModel(
     private val refreshSuccessFlow = MutableStateFlow(false)
     private val cachedMetadataFlow = MutableStateFlow<TmdbMetadata?>(null)
     private val cachedEpisodesFlow = MutableStateFlow<Map<String, TmdbEpisode>>(emptyMap())
+
+    private val refreshFeedbackFlow: StateFlow<TmdbRefreshFeedback> = combine(
+        isLoadingTmdbFlow,
+        tmdbErrorFlow,
+        refreshSuccessFlow,
+    ) { isLoading, error, success ->
+        TmdbRefreshFeedback(isLoading = isLoading, error = error, success = success)
+    }.stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.Eagerly, TmdbRefreshFeedback(isLoading = false, error = null, success = false))
 
     init {
         loadMetadata()
@@ -123,8 +137,7 @@ class DetailsViewModel(
             container.playlistRepository.observePlaylists,
             selectedSeasonFlow,
             expandedEpisodesFlow,
-            isLoadingTmdbFlow,
-            tmdbErrorFlow,
+            refreshFeedbackFlow,
             cachedMetadataFlow,
             cachedEpisodesFlow,
         )
@@ -135,11 +148,9 @@ class DetailsViewModel(
         val playlists = args[3] as List<PlaylistInfo>
         val season = args[4] as Int
         val expandedSet = args[5] as Set<String>
-        val isLoading = args[6] as Boolean
-        val tmdbErr = args[7] as String?
-        val meta = args[8] as TmdbMetadata?
-        val cachedEpisodes = args[9] as Map<String, TmdbEpisode>
-        val refreshSuccess = args[10] as Boolean
+        val refreshFeedback = args[6] as TmdbRefreshFeedback
+        val meta = args[7] as TmdbMetadata?
+        val cachedEpisodes = args[8] as Map<String, TmdbEpisode>
 
         val group = videos.find { it.name == id || it.seriesName == id }
             ?: videos.find { it.name.lowercase() == id.lowercase() }
@@ -209,9 +220,9 @@ class DetailsViewModel(
             selectedSeason = currentSeason,
             availableSeasons = seasons,
             episodes = episodeUiStates,
-            isLoadingTmdb = isLoading,
-            tmdbError = tmdbErr,
-            refreshSuccess = refreshSuccess,
+            isLoadingTmdb = refreshFeedback.isLoading,
+            tmdbError = refreshFeedback.error,
+            refreshSuccess = refreshFeedback.success,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
@@ -271,13 +271,49 @@ fun DetailsScreen(
                             Text(text = "MA LISTE", modifier = Modifier.padding(start = 4.dp))
                         }
 
-                        IconButton(onClick = detailsViewModel::refreshTmdbMetadata) {
-                            Icon(Icons.Filled.Refresh, contentDescription = "Recharger TMDB", tint = White)
+                        IconButton(
+                            onClick = detailsViewModel::refreshTmdbMetadata,
+                            enabled = !uiState.isLoadingTmdb,
+                        ) {
+                            Icon(
+                                Icons.Filled.Refresh,
+                                contentDescription = "Recharger TMDB",
+                                tint = if (uiState.isLoadingTmdb) Zinc500 else White,
+                            )
                         }
 
                         IconButton(onClick = { showSubtitleSheet = true }) {
                             Icon(Icons.Filled.ClosedCaption, contentDescription = "Sous-titres", tint = White)
                         }
+                    }
+
+                    // Loading indicator while refreshing TMDB
+                    if (uiState.isLoadingTmdb) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        LinearProgressIndicator(
+                            modifier = Modifier.fillMaxWidth(),
+                            color = Red600,
+                        )
+                    }
+
+                    // Success feedback after refresh
+                    if (uiState.refreshSuccess) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "Métadonnées actualisées",
+                            color = Color(0xFF4CAF50),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+
+                    // Error message if refresh failed
+                    uiState.tmdbError?.let { error ->
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = error,
+                            color = Red600,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
                     }
 
                     Spacer(modifier = Modifier.height(16.dp))

--- a/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
@@ -252,6 +252,24 @@ class TmdbRepositoryTest {
     }
 
     @Test
+    fun testForceRefreshDoesNotFallbackOnFailure() = runTest {
+        val expiredTimestamp = System.currentTimeMillis() - (35L * 24 * 3600 * 1000)
+        fakeDao.insertMetadata(
+            TmdbMetadataEntity(
+                queryKey = "BladeRunner.mp4",
+                json = """{"queryKey":"BladeRunner.mp4","tmdbId":400,"title":"Blade Runner Cached"}""",
+                fetchedAt = expiredTimestamp,
+            )
+        )
+
+        mockWebServer.enqueue(jsonResponse("Internal Error", 500))
+
+        val video = VideoItem(name = "BladeRunner.mp4")
+        val result = repository.fetchMetadataForVideo(video, forceRefresh = true)
+        assertTrue(result.isFailure)
+    }
+
+    @Test
     fun testNotFoundReturnsErrorAndCachesMarker() = runTest {
         val emptySearch = """{"results": []}"""
         mockWebServer.enqueue(jsonResponse(emptySearch))


### PR DESCRIPTION
## Résumé

Le bouton de rafraîchissement des métadonnées TMDB sur la fiche d'un film/série ne donnait aucun retour visuel à l'utilisateur : rien ne montrait qu'un chargement était en cours, qu'une erreur s'était produite, ou que le rafraîchissement avait réussi.

## Changements

- **DetailsScreen** : le bouton Refresh est désactivé et grisé pendant le chargement, une barre de progression LinearProgressIndicator s'affiche, un message vert de succès apparaît pendant 3 s, et un message rouge d'erreur s'affiche si le fetch échoue.
- **DetailsViewModel** : ajout d'un efreshSuccessFlow dans le combine et de l'état efreshSuccess dans DetailsUiState.
- **TmdbRepository** : correction du fallback silencieux — quand orceRefresh = true (bouton utilisateur), les erreurs réseau/HTTP remontent au lieu de servir silencieusement le cache expiré.
- **TmdbRepositoryTest** : ajout du test 	estForceRefreshDoesNotFallbackOnFailure qui vérifie ce comportement.

## Vérification

- :app:compileDebugKotlin : OK
- :app:testDebugUnitTest --tests TmdbRepositoryTest : OK