### PR TITLE
fix(build): enable code minification and resource shrinking for release build

### DIFF
--- a/native/app/build.gradle.kts
+++ b/native/app/build.gradle.kts
@@ -33,7 +33,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/native/app/proguard-rules.pro
+++ b/native/app/proguard-rules.pro
@@ -1,2 +1,21 @@
-# Règles ProGuard/R8 spécifiques au module.
-# Vide pour l'instant : le socle n'active pas la minification (isMinifyEnabled = false).
+# ProGuard / R8 rules for LocalStream release build
+
+# ExoPlayer / Media3
+-keep class androidx.media3.** { *; }
+-dontwarn androidx.media3.**
+
+# Retrofit + kotlinx.serialization
+-keepattributes *Annotation*, InnerClasses, EnclosingMethod, Signature, Exceptions
+-keepclassmembers class * {
+    @kotlinx.serialization.Serializable <fields>;
+    @kotlinx.serialization.Serializable <methods>;
+}
+-keep class com.localstream.app.data.remote.** { *; }
+-keepclassmembers class * {
+    @retrofit2.http.* <methods>;
+}
+
+# Room
+-keep class * extends androidx.room.RoomDatabase
+-keep @androidx.room.Entity class *
+-dontwarn androidx.room.paging.**


### PR DESCRIPTION
Closes #93. Enables isMinifyEnabled and isShrinkResources for release build with ProGuard/R8 rules.