### PR TITLE
fix(player): empedcher le saut de la barre de lecture a la fin lors de la reprise

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -196,8 +196,19 @@ class PlayerViewModel(
             val pct = state?.progressPct ?: 0.0
             val pos = if (isFinished(isWatched, pct, rawPos, targetVideo.duration * 1000L)) 0L else rawPos
 
+            val targetDur = if (targetVideo.duration > 0L) {
+                targetVideo.duration * 1000L
+            } else if (pct > 0.0 && rawPos > 0L) {
+                (rawPos / (pct / 100.0)).toLong()
+            } else {
+                0L
+            }
+
             initialPositionMsFlow.value = pos
             positionMsFlow.value = pos
+            if (targetDur > 0L) {
+                durationMsFlow.value = targetDur
+            }
             currentVideoFlow.value = targetVideo
 
             resolveNextVideo(targetVideo, allGrouped, allRaw)
@@ -516,8 +527,19 @@ class PlayerViewModel(
             val pct = state?.progressPct ?: 0.0
             val pos = if (isFinished(isWatched, pct, rawPos, video.duration * 1000L)) 0L else rawPos
 
+            val targetDur = if (video.duration > 0L) {
+                video.duration * 1000L
+            } else if (pct > 0.0 && rawPos > 0L) {
+                (rawPos / (pct / 100.0)).toLong()
+            } else {
+                0L
+            }
+
             initialPositionMsFlow.value = pos
             positionMsFlow.value = pos
+            if (targetDur > 0L) {
+                durationMsFlow.value = targetDur
+            }
             currentVideoFlow.value = video
 
             resolveNextVideo(video, allGrouped, allRaw)

--- a/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
@@ -299,6 +299,10 @@ fun PlayerScreen(
                         viewModel.setBuffering(false)
                         viewModel.setErrorMessage(null)
                         isPlayerReady = true
+                        val dur = exoPlayer.duration.coerceAtLeast(0L)
+                        if (dur > 0L) {
+                            viewModel.onPositionChanged(exoPlayer.currentPosition.coerceAtLeast(0L), dur)
+                        }
                     }
                     Player.STATE_ENDED -> {
                         viewModel.setBuffering(false)
@@ -465,9 +469,9 @@ fun PlayerScreen(
     // Continuously update position flow
     LaunchedEffect(exoPlayer) {
         while (true) {
-            if (exoPlayer.isPlaying && isPlayerReady) {
+            if (isPlayerReady) {
                 viewModel.onPositionChanged(
-                    positionMs = exoPlayer.currentPosition,
+                    positionMs = exoPlayer.currentPosition.coerceAtLeast(0L),
                     durationMs = exoPlayer.duration.coerceAtLeast(0L),
                 )
             }
@@ -996,15 +1000,25 @@ private fun BottomPlayerBar(
             }
         }
 
+        val sliderValue = if (durationMs > 0L) {
+            displayPos.coerceIn(0L, durationMs).toFloat()
+        } else {
+            0f
+        }
+
         Slider(
-            value = displayPos.coerceIn(0L, durationMs.coerceAtLeast(1L)).toFloat(),
+            value = sliderValue,
             onValueChange = {
-                isSeeking = true
-                seekPositionMs = it.toLong()
+                if (durationMs > 0L) {
+                    isSeeking = true
+                    seekPositionMs = it.toLong()
+                }
             },
             onValueChangeFinished = {
-                onSeek(seekPositionMs)
-                isSeeking = false
+                if (durationMs > 0L) {
+                    onSeek(seekPositionMs)
+                    isSeeking = false
+                }
             },
             valueRange = 0f..durationMs.coerceAtLeast(1L).toFloat(),
             colors = SliderDefaults.colors(


### PR DESCRIPTION
Fix le probleme ou la barre de lecture sautait a la fin avant de revenir a la position sauvegardee lorsqu'on relance un film ou une serie.

**Cause du bug :**
1. \durationMsFlow\ valait 0L lors du chargement initial.
2. Avec \durationMs == 0L\, la \alueRange\ du Slider valait \