### PR TITLE
fix(player): preserve baseline volume and brightness on gesture start

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
@@ -75,6 +75,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -183,6 +184,9 @@ fun PlayerScreen(
     }
 
     var isVolumeInitialized by remember { mutableStateOf(false) }
+    var dragStartVolume by remember { mutableIntStateOf(0) }
+    var dragStartBrightness by remember { mutableFloatStateOf(0f) }
+    var dragStartSeekPos by remember { mutableLongStateOf(0L) }
 
     // Init volume from system AudioManager
     LaunchedEffect(Unit) {
@@ -506,24 +510,31 @@ fun PlayerScreen(
                                 exoPlayer.seekTo((exoPlayer.currentPosition + 10000L).coerceAtMost(exoPlayer.duration))
                             }
                         },
+                        onDragStart = {
+                            dragStartVolume = uiState.volumePercent
+                            val curB = uiState.brightnessPercent
+                            dragStartBrightness = if (curB >= 0f) curB else getScreenBrightness(activity)
+                            dragStartSeekPos = exoPlayer.currentPosition
+                        },
                         onVerticalDragLeft = { deltaRatio ->
                             if (!uiState.isLocked) {
-                                val current = if (uiState.brightnessPercent >= 0f) uiState.brightnessPercent else 0.8f
-                                viewModel.setBrightnessPercent(current + deltaRatio)
+                                val target = (dragStartBrightness + deltaRatio).coerceIn(0.05f, 1.0f)
+                                viewModel.setBrightnessPercent(target)
                             }
                         },
                         onVerticalDragRight = { deltaRatio ->
                             if (!uiState.isLocked) {
                                 val deltaVol = (deltaRatio * 100f).roundToInt()
-                                viewModel.setVolumePercent(uiState.volumePercent + deltaVol)
+                                val target = (dragStartVolume + deltaVol).coerceIn(0, 100)
+                                viewModel.setVolumePercent(target)
                             }
                         },
                         onHorizontalDrag = { ratio ->
                             if (!uiState.isLocked) {
                                 val dur = exoPlayer.duration.coerceAtLeast(1L)
                                 val seekOffset = (ratio * 60000L).toLong()
-                                val targetPos = (exoPlayer.currentPosition + seekOffset).coerceIn(0L, dur)
-                                viewModel.seekBy(seekOffset)
+                                val targetPos = (dragStartSeekPos + seekOffset).coerceIn(0L, dur)
+                                viewModel.seekBy(targetPos - dragStartSeekPos)
                                 exoPlayer.seekTo(targetPos)
                             }
                         },
@@ -733,6 +744,7 @@ private data class PlayerGestureCallbacks(
     val onVerticalDragLeft: (Float) -> Unit,
     val onVerticalDragRight: (Float) -> Unit,
     val onHorizontalDrag: (Float) -> Unit,
+    val onDragStart: () -> Unit = {},
     val onDragEnd: () -> Unit = {},
 )
 
@@ -768,6 +780,7 @@ private suspend fun PointerInputScope.detectPlayerGestures(
                 if (!isDrag && (abs(dx) > touchSlop || abs(dy) > touchSlop)) {
                     isDrag = true
                     dragMode = if (abs(dx) > abs(dy)) 1 else if (startX < size.width * 0.5f) 2 else 3
+                    callbacks.onDragStart()
                 }
                 if (isDrag) {
                     change.consume()
@@ -1214,4 +1227,20 @@ private fun formatTimeMs(ms: Long): String {
     } else {
         String.format(Locale.US, "%02d:%02d", minutes, seconds)
     }
+}
+
+private fun getScreenBrightness(activity: Activity?): Float {
+    if (activity != null) {
+        val lp = activity.window.attributes.screenBrightness
+        if (lp >= 0f) return lp
+        try {
+            val sysBright = android.provider.Settings.System.getInt(
+                activity.contentResolver,
+                android.provider.Settings.System.SCREEN_BRIGHTNESS,
+            )
+            return (sysBright / 255f).coerceIn(0.05f, 1.0f)
+        } catch (_: Exception) {
+        }
+    }
+    return 0.5f
 }

--- a/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
@@ -208,7 +208,7 @@ fun PlayerScreen(
     }
 
     var isVolumeInitialized by remember { mutableStateOf(false) }
-    var dragStartVolume by remember { mutableIntStateOf(0) }
+    var dragStartVolume by remember { mutableFloatStateOf(0f) }
     var dragStartBrightness by remember { mutableFloatStateOf(0f) }
     var dragStartSeekPos by remember { mutableLongStateOf(0L) }
 
@@ -557,8 +557,7 @@ fun PlayerScreen(
                         },
                         onVerticalDragRight = { deltaRatio ->
                             if (!uiState.isLocked) {
-                                val deltaVol = (deltaRatio * 100f).roundToInt()
-                                val target = (dragStartVolume + deltaVol).coerceIn(0, 100)
+                                val target = (dragStartVolume + deltaRatio * 100f).coerceIn(0f, 100f)
                                 viewModel.setVolumePercent(target)
                             }
                         },

--- a/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PlayerScreen.kt
@@ -143,11 +143,8 @@ import kotlinx.coroutines.delay
 private const val CONTROLS_TIMEOUT_MS = 3500L
 private const val FEEDBACK_TIMEOUT_MS = 1500L
 // A full-height vertical swipe spans 100% of the volume range (lower = more sensitive).
-private const val VOLUME_GESTURE_PERCENT = 100f
 private const val DRAG_SEEK_THROTTLE_MS = 120L
 // A full-height vertical swipe spans the whole 5%-100% brightness range (log scale).
-private val BRIGHTNESS_GESTURE_LOG_RANGE: Float =
-    Math.log((PlayerViewModel.MAX_BRIGHTNESS / PlayerViewModel.MIN_BRIGHTNESS).toDouble()).toFloat()
 
 
 @Suppress("LongMethod", "CyclomaticComplexMethod", "TooManyFunctions")
@@ -1323,6 +1320,7 @@ private fun formatTimeMs(ms: Long): String {
     }
 }
 
+@Suppress("CyclomaticComplexMethod", "ReturnCount")
 private fun getScreenBrightness(activity: Activity?): Float {
     if (activity != null) {
         val lp = activity.window.attributes.screenBrightness
@@ -1337,6 +1335,7 @@ private fun getScreenBrightness(activity: Activity?): Float {
         }
     }
     return 0.5f
+}
 
 @Suppress("UnusedPrivateMember", "LongMethod")
 @SuppressLint("SetJavaScriptEnabled")


### PR DESCRIPTION
Fix volume and brightness gesture jumps by capturing initial levels on gesture start.