### PR TITLE
ci: trigger test workflow only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 ﻿name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Supprime le déclencheur push: main du workflow CI pour qu'il ne s'exécute que sur les Pull Requests. Lors du merge sur main, seul le workflow Build APK se déclenchera.