### PR TITLE
perf(player): optimize track selection override lookups (#98)

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
@@ -334,17 +334,8 @@ fun PlayerScreen(
 
         val selAudioId = uiState.selectedAudioTrackId
         if (selAudioId != null) {
-            for (group in tracks.groups) {
-                if (group.type == C.TRACK_TYPE_AUDIO) {
-                    for (i in 0 until group.length) {
-                        val format = group.getTrackFormat(i)
-                        val id = format.id ?: "${group.type}-$i"
-                        if (id == selAudioId) {
-                            builder.setOverrideForType(TrackSelectionOverride(group.mediaTrackGroup, i))
-                            break
-                        }
-                    }
-                }
+            findTrackOverride(tracks, C.TRACK_TYPE_AUDIO, selAudioId)?.let {
+                builder.setOverrideForType(it)
             }
         }
 
@@ -353,17 +344,8 @@ fun PlayerScreen(
             builder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
         } else {
             builder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
-            for (group in tracks.groups) {
-                if (group.type == C.TRACK_TYPE_TEXT) {
-                    for (i in 0 until group.length) {
-                        val format = group.getTrackFormat(i)
-                        val id = format.id ?: "${group.type}-$i"
-                        if (id == selSubId) {
-                            builder.setOverrideForType(TrackSelectionOverride(group.mediaTrackGroup, i))
-                            break
-                        }
-                    }
-                }
+            findTrackOverride(tracks, C.TRACK_TYPE_TEXT, selSubId)?.let {
+                builder.setOverrideForType(it)
             }
         }
 
@@ -753,4 +735,18 @@ private fun getScreenBrightness(activity: Activity?): Float {
         }
     }
     return 0.5f
+}
+
+private fun findTrackOverride(tracks: Tracks, trackType: @C.TrackType Int, targetId: String): TrackSelectionOverride? {
+    for (group in tracks.groups) {
+        if (group.type != trackType) continue
+        for (i in 0 until group.length) {
+            val format = group.getTrackFormat(i)
+            val id = format.id ?: "$trackType-$i"
+            if (id == targetId) {
+                return TrackSelectionOverride(group.mediaTrackGroup, i)
+            }
+        }
+    }
+    return null
 }


### PR DESCRIPTION
Resolves #98

### Summary of Changes:
- Replaced duplicated full-scan O(n^2) nested loops in LaunchedEffect for audio and text track selections with an optimized indTrackOverride helper with early return.
- Cleaner code and reduced overhead during track switching.