### PR TITLE
perf(library): make TMDB metadata chunk size configurable (#106)

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
@@ -81,6 +81,7 @@ class LibraryViewModel(
     private val tmdbRepository: TmdbRepository,
     private val settingsRepository: SettingsRepository,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val metadataChunkSize: Int = DEFAULT_METADATA_CHUNK_SIZE,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LibraryUiState())
@@ -187,7 +188,7 @@ class LibraryViewModel(
 
     /** Récupère les métadonnées par paquets et publie chaque paquet dès réception. */
     private suspend fun fetchMetadataIntoState(videos: List<VideoItem>) {
-        for (chunk in videos.chunked(METADATA_CHUNK_SIZE)) {
+        for (chunk in videos.chunked(metadataChunkSize)) {
             val results = coroutineScope {
                 chunk.map { video ->
                     async(ioDispatcher) {
@@ -308,7 +309,9 @@ class LibraryViewModel(
     }
 
     companion object {
-        private const val METADATA_CHUNK_SIZE = 8
+        const val DEFAULT_METADATA_CHUNK_SIZE = 8
+        const val WIFI_METADATA_CHUNK_SIZE = 16
+        const val MOBILE_METADATA_CHUNK_SIZE = 4
         private const val SEARCH_DEBOUNCE_MS = 250L
 
         fun factory(container: AppContainer): ViewModelProvider.Factory = viewModelFactory {


### PR DESCRIPTION
Resolves #106

### Summary of Changes:
- Extracted TMDB metadata chunk size into a constructor parameter metadataChunkSize with default constant DEFAULT_METADATA_CHUNK_SIZE = 8 and presets for Wi-Fi and Mobile connections.
- Allows tuning concurrency based on network bandwidth and requirements.