### PR TITLE
chore(rollup): consolidation de 7 Pull Requests dans main

### DIFF
--- a/.github/scripts/combine_prs.py
+++ b/.github/scripts/combine_prs.py
@@ -10,6 +10,7 @@ Fonctionne aussi bien en local qu'au sein d'un workflow GitHub Actions.
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime
@@ -119,6 +120,19 @@ def generate_markdown_summary(
         for pr in merged_prs:
             author_login = pr.get("author", {}).get("login", "inconnu") if isinstance(pr.get("author"), dict) else str(pr.get("author", "inconnu"))
             lines.append(f"| [#{pr['number']}]({pr['url']}) | {pr['title']} | @{author_login} | `{pr['headRefName']}` |")
+        lines.append("")
+        lines.append("## 🎯 Clôture automatique des PRs et Issues")
+        lines.append("")
+        closes_list = []
+        for pr in merged_prs:
+            closes_list.append(f"Closes #{pr['number']}")
+            title_issues = re.findall(r"#(\d+)", pr.get("title", ""))
+            body_issues = re.findall(r"(?:closes|fixes|resolves)\s*#(\d+)", pr.get("body", "") or "", re.IGNORECASE)
+            for iss in set(title_issues + body_issues):
+                if iss != str(pr["number"]):
+                    closes_list.append(f"Closes #{iss}")
+        unique_closes = list(dict.fromkeys(closes_list))
+        lines.append(", ".join(unique_closes))
         lines.append("")
 
     if conflicted_prs:

--- a/native/app/src/main/java/com/localstream/app/data/scanner/MediaStoreScanner.kt
+++ b/native/app/src/main/java/com/localstream/app/data/scanner/MediaStoreScanner.kt
@@ -160,7 +160,7 @@ class MediaStoreScanner(
         val dirsToScan = customDirectories.ifEmpty { defaultDirsToScan() }
         return dirsToScan.filter { it.isDirectory }.flatMap { dir ->
             dir.walkTopDown().maxDepth(MAX_SCAN_DEPTH)
-                .filter { it.isFile && VideoNameParser.VIDEO_EXT_REGEX.containsMatchIn(it.name) }
+                .filter { it.isFile && it.extension.lowercase() in VIDEO_EXTENSIONS }
                 .map { file ->
                     val seriesInfo = VideoNameParser.parseSeriesInfo(file.name, file.absolutePath)
                     val extractedYear = TitleCleaner.extractYear(file.name)
@@ -184,7 +184,7 @@ class MediaStoreScanner(
         val dirsToScan = customDirectories.ifEmpty { defaultDirsToScan() }
         return dirsToScan.filter { it.isDirectory }.flatMap { dir ->
             dir.walkTopDown().maxDepth(MAX_SCAN_DEPTH)
-                .filter { it.isFile && VideoNameParser.SUBTITLE_EXT_REGEX.containsMatchIn(it.name) }
+                .filter { it.isFile && it.extension.lowercase() in SUBTITLE_EXTENSIONS }
                 .map { file ->
                     val folder = VideoNameParser.parentFolder(file.absolutePath)
                     SubtitleEntry(
@@ -205,6 +205,8 @@ class MediaStoreScanner(
 
     private companion object {
         private const val MAX_SCAN_DEPTH = 5
+        private val VIDEO_EXTENSIONS = setOf("mp4", "mkv", "webm", "avi", "mov")
+        private val SUBTITLE_EXTENSIONS = setOf("srt", "vtt", "ass", "ssa")
     }
 }
 

--- a/native/app/src/main/java/com/localstream/app/di/AppContainer.kt
+++ b/native/app/src/main/java/com/localstream/app/di/AppContainer.kt
@@ -38,9 +38,11 @@ import com.localstream.app.domain.model.MovieCollection
 import com.localstream.app.domain.model.SubtitleEntry
 import com.localstream.app.domain.model.VideoItem
 import java.io.File
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.serialization.json.Json
+import okhttp3.Cache
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.ResponseBody
@@ -72,7 +74,16 @@ open class AppContainer(
         appContext?.let { AppDatabase.getInstance(it) }
     }
 
-    private val okHttpClient: OkHttpClient by lazy { OkHttpClient.Builder().build() }
+    private val okHttpClient: OkHttpClient by lazy {
+        val builder = OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+
+        appContext?.cacheDir?.let { cacheDir ->
+            builder.cache(Cache(File(cacheDir, "http_cache"), 50L * 1024 * 1024))
+        }
+        builder.build()
+    }
 
     private val tmdbApi: TmdbApi by lazy {
         if (appContext == null) NoOpTmdbApi() else Retrofit.Builder()

--- a/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
@@ -81,6 +81,7 @@ class LibraryViewModel(
     private val tmdbRepository: TmdbRepository,
     private val settingsRepository: SettingsRepository,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val metadataChunkSize: Int = DEFAULT_METADATA_CHUNK_SIZE,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LibraryUiState())
@@ -187,7 +188,7 @@ class LibraryViewModel(
 
     /** Récupère les métadonnées par paquets et publie chaque paquet dès réception. */
     private suspend fun fetchMetadataIntoState(videos: List<VideoItem>) {
-        for (chunk in videos.chunked(METADATA_CHUNK_SIZE)) {
+        for (chunk in videos.chunked(metadataChunkSize)) {
             val results = coroutineScope {
                 chunk.map { video ->
                     async(ioDispatcher) {
@@ -308,7 +309,9 @@ class LibraryViewModel(
     }
 
     companion object {
-        private const val METADATA_CHUNK_SIZE = 8
+        const val DEFAULT_METADATA_CHUNK_SIZE = 8
+        const val WIFI_METADATA_CHUNK_SIZE = 16
+        const val MOBILE_METADATA_CHUNK_SIZE = 4
         private const val SEARCH_DEBOUNCE_MS = 250L
 
         fun factory(container: AppContainer): ViewModelProvider.Factory = viewModelFactory {

--- a/native/app/src/main/java/com/localstream/app/ui/player/BottomPlayerBar.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/BottomPlayerBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -56,6 +57,20 @@ fun BottomPlayerBar(
 
     val displayPos = if (isSeeking) seekPositionMs else positionMs
 
+    val timeLabel by remember(displayPos, durationMs) {
+        derivedStateOf { "${formatTimeMs(displayPos)} / ${formatTimeMs(durationMs)}" }
+    }
+
+    val sliderValue by remember(displayPos, durationMs) {
+        derivedStateOf {
+            if (durationMs > 0L) {
+                displayPos.coerceIn(0L, durationMs).toFloat()
+            } else {
+                0f
+            }
+        }
+    }
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -67,7 +82,7 @@ fun BottomPlayerBar(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
-                text = "${formatTimeMs(displayPos)} / ${formatTimeMs(durationMs)}",
+                text = timeLabel,
                 color = White,
                 fontSize = 12.sp,
             )

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
@@ -334,17 +334,8 @@ fun PlayerScreen(
 
         val selAudioId = uiState.selectedAudioTrackId
         if (selAudioId != null) {
-            for (group in tracks.groups) {
-                if (group.type == C.TRACK_TYPE_AUDIO) {
-                    for (i in 0 until group.length) {
-                        val format = group.getTrackFormat(i)
-                        val id = format.id ?: "${group.type}-$i"
-                        if (id == selAudioId) {
-                            builder.setOverrideForType(TrackSelectionOverride(group.mediaTrackGroup, i))
-                            break
-                        }
-                    }
-                }
+            findTrackOverride(tracks, C.TRACK_TYPE_AUDIO, selAudioId)?.let {
+                builder.setOverrideForType(it)
             }
         }
 
@@ -353,17 +344,8 @@ fun PlayerScreen(
             builder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
         } else {
             builder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
-            for (group in tracks.groups) {
-                if (group.type == C.TRACK_TYPE_TEXT) {
-                    for (i in 0 until group.length) {
-                        val format = group.getTrackFormat(i)
-                        val id = format.id ?: "${group.type}-$i"
-                        if (id == selSubId) {
-                            builder.setOverrideForType(TrackSelectionOverride(group.mediaTrackGroup, i))
-                            break
-                        }
-                    }
-                }
+            findTrackOverride(tracks, C.TRACK_TYPE_TEXT, selSubId)?.let {
+                builder.setOverrideForType(it)
             }
         }
 
@@ -753,4 +735,18 @@ private fun getScreenBrightness(activity: Activity?): Float {
         }
     }
     return 0.5f
+}
+
+private fun findTrackOverride(tracks: Tracks, trackType: @C.TrackType Int, targetId: String): TrackSelectionOverride? {
+    for (group in tracks.groups) {
+        if (group.type != trackType) continue
+        for (i in 0 until group.length) {
+            val format = group.getTrackFormat(i)
+            val id = format.id ?: "$trackType-$i"
+            if (id == targetId) {
+                return TrackSelectionOverride(group.mediaTrackGroup, i)
+            }
+        }
+    }
+    return null
 }

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
@@ -88,6 +88,7 @@ import com.localstream.app.ui.theme.White
 import com.localstream.app.ui.theme.Zinc900
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import kotlin.math.roundToInt
 
@@ -283,6 +284,17 @@ fun PlayerScreen(
                 viewModel.onPlayingStateChanged(isPlaying)
             }
 
+            override fun onPositionDiscontinuity(
+                oldPosition: Player.PositionInfo,
+                newPosition: Player.PositionInfo,
+                reason: Int,
+            ) {
+                val dur = exoPlayer.duration.coerceAtLeast(0L)
+                if (dur > 0L) {
+                    viewModel.onPositionChanged(exoPlayer.currentPosition.coerceAtLeast(0L), dur)
+                }
+            }
+
             override fun onTracksChanged(tracks: Tracks) {
                 val audioList = mutableListOf<AudioTrackUiState>()
                 val subList = mutableListOf<SubtitleTrackUiState>()
@@ -423,15 +435,15 @@ fun PlayerScreen(
         exoPlayer.playWhenReady = true
     }
 
-    LaunchedEffect(exoPlayer) {
-        while (true) {
-            if (isPlayerReady) {
+    LaunchedEffect(exoPlayer, isPlayerReady, uiState.isPlaying) {
+        if (isPlayerReady && uiState.isPlaying) {
+            while (isActive) {
                 viewModel.onPositionChanged(
                     positionMs = exoPlayer.currentPosition.coerceAtLeast(0L),
                     durationMs = exoPlayer.duration.coerceAtLeast(0L),
                 )
+                delay(250L)
             }
-            delay(500L)
         }
     }
 

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -117,20 +117,19 @@ class PlayerViewModel(
 
     private val savePositionChannel = Channel<SavePositionRequest>(Channel.CONFLATED)
 
-    @OptIn(FlowPreview::class)
-    private val positionSaveJob = viewModelScope.launch {
-        savePositionChannel.receiveAsFlow()
-            .debounce(2000L)
-            .collect { req ->
-                container.watchStateRepository.savePlaybackState(
-                    videoName = req.videoName,
-                    positionMs = req.positionMs,
-                    durationMs = req.durationMs,
-                )
-            }
-    }
-
     init {
+        @OptIn(FlowPreview::class)
+        viewModelScope.launch {
+            savePositionChannel.receiveAsFlow()
+                .debounce(2000L)
+                .collect { req ->
+                    container.watchStateRepository.savePlaybackState(
+                        videoName = req.videoName,
+                        positionMs = req.positionMs,
+                        durationMs = req.durationMs,
+                    )
+                }
+        }
         loadVideoDetails()
     }
 

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -8,10 +8,14 @@ import androidx.lifecycle.viewModelScope
 import com.localstream.app.di.AppContainer
 import com.localstream.app.domain.YoutubeUtils
 import com.localstream.app.domain.model.VideoItem
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -105,8 +109,26 @@ class PlayerViewModel(
     private val isBufferingFlow = MutableStateFlow(false)
     private val errorMessageFlow = MutableStateFlow<String?>(null)
 
-    private var lastSavedPosMs = 0L
-    private var lastSavedTime = 0L
+    private data class SavePositionRequest(
+        val videoName: String,
+        val positionMs: Long,
+        val durationMs: Long,
+    )
+
+    private val savePositionChannel = Channel<SavePositionRequest>(Channel.CONFLATED)
+
+    @OptIn(FlowPreview::class)
+    private val positionSaveJob = viewModelScope.launch {
+        savePositionChannel.receiveAsFlow()
+            .debounce(2000L)
+            .collect { req ->
+                container.watchStateRepository.savePlaybackState(
+                    videoName = req.videoName,
+                    positionMs = req.positionMs,
+                    durationMs = req.durationMs,
+                )
+            }
+    }
 
     init {
         loadVideoDetails()
@@ -316,30 +338,24 @@ class PlayerViewModel(
         }
         val video = currentVideoFlow.value ?: return
 
-        val now = System.currentTimeMillis()
-        val isThresholdReached = durationMs > 0L && positionMs >= (durationMs * WATCHED_THRESHOLD_RATIO)
-        val timeDelta = now - lastSavedTime
-        val posDelta = kotlin.math.abs(positionMs - lastSavedPosMs)
+        if (positionMs > 0L) {
+            savePositionChannel.trySend(
+                SavePositionRequest(
+                    videoName = video.name,
+                    positionMs = positionMs,
+                    durationMs = durationMs,
+                )
+            )
+        }
 
-        val isIntervalReached = timeDelta >= 3000L || posDelta >= 2000L
-        if (lastSavedPosMs == 0L || isThresholdReached || isIntervalReached) {
-            lastSavedTime = now
-            lastSavedPosMs = positionMs
+        val isThresholdReached = durationMs > 0L && positionMs >= (durationMs * WATCHED_THRESHOLD_RATIO)
+        if (isThresholdReached) {
             viewModelScope.launch {
-                if (positionMs > 0L) {
-                    container.watchStateRepository.savePlaybackState(
-                        videoName = video.name,
-                        positionMs = positionMs,
-                        durationMs = durationMs,
-                    )
-                }
-                if (isThresholdReached) {
-                    container.watchStateRepository.setWatched(
-                        videoName = video.name,
-                        watched = true,
-                        mediaStoreId = video.mediaStoreId,
-                    )
-                }
+                container.watchStateRepository.setWatched(
+                    videoName = video.name,
+                    watched = true,
+                    mediaStoreId = video.mediaStoreId,
+                )
             }
         }
     }

--- a/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
@@ -1,4 +1,4 @@
-﻿package com.localstream.app.ui.screens
+package com.localstream.app.ui.screens
 
 import android.net.Uri
 import androidx.compose.animation.AnimatedVisibility
@@ -44,6 +44,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -108,8 +109,10 @@ fun DetailsScreen(
 
     val videoGroup = uiState.videoGroup
     val meta = uiState.metadata
-    val cleanTitle = remember(videoGroup?.name) {
-        TitleCleaner.getCleanTitle(videoGroup?.seriesName ?: videoGroup?.name ?: id)
+    val cleanTitle by remember(videoGroup?.name, videoGroup?.seriesName, id) {
+        derivedStateOf {
+            TitleCleaner.getCleanTitle(videoGroup?.seriesName ?: videoGroup?.name ?: id)
+        }
     }
 
     if (showPlaylistSheet && videoGroup != null) {
@@ -189,10 +192,14 @@ fun DetailsScreen(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        val badgeText = when {
-                            videoGroup?.isTvSeries == true -> "SÉRIE ORIGINALE"
-                            videoGroup?.isSeriesGroup == true -> "SAGA / COLLECTION"
-                            else -> "FILM"
+                        val badgeText by remember(videoGroup?.isTvSeries, videoGroup?.isSeriesGroup) {
+                            derivedStateOf {
+                                when {
+                                    videoGroup?.isTvSeries == true -> "SÉRIE ORIGINALE"
+                                    videoGroup?.isSeriesGroup == true -> "SAGA / COLLECTION"
+                                    else -> "FILM"
+                                }
+                            }
                         }
                         Text(
                             text = badgeText,
@@ -221,20 +228,30 @@ fun DetailsScreen(
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         val playVideoTarget = uiState.activeEpisodeName ?: videoGroup?.name ?: id
-                        val playLabel = when {
-                            videoGroup?.isSeriesGroup == true || videoGroup?.isTvSeries == true -> {
-                                val epLabel = uiState.activeEpisodeLabel ?: "Ép. ${uiState.activeEpisodeNumber ?: 1}"
-                                if (uiState.watchPositionMs > 0L) {
-                                    "REPRENDRE $epLabel (${Formatters.formatDuration(uiState.watchPositionMs / 1000L)})"
-                                } else {
-                                    "LECTURE $epLabel"
+                        val playLabel by remember(
+                            videoGroup?.isSeriesGroup,
+                            videoGroup?.isTvSeries,
+                            uiState.activeEpisodeLabel,
+                            uiState.activeEpisodeNumber,
+                            uiState.watchPositionMs,
+                        ) {
+                            derivedStateOf {
+                                when {
+                                    videoGroup?.isSeriesGroup == true || videoGroup?.isTvSeries == true -> {
+                                        val epLabel = uiState.activeEpisodeLabel ?: "Ép. ${uiState.activeEpisodeNumber ?: 1}"
+                                        if (uiState.watchPositionMs > 0L) {
+                                            "REPRENDRE $epLabel (${Formatters.formatDuration(uiState.watchPositionMs / 1000L)})"
+                                        } else {
+                                            "LECTURE $epLabel"
+                                        }
+                                    }
+                                    uiState.watchPositionMs > 0L -> {
+                                        "REPRENDRE À ${Formatters.formatDuration(uiState.watchPositionMs / 1000L)}"
+                                    }
+                                    else -> {
+                                        "LECTURE"
+                                    }
                                 }
-                            }
-                            uiState.watchPositionMs > 0L -> {
-                                "REPRENDRE À ${Formatters.formatDuration(uiState.watchPositionMs / 1000L)}"
-                            }
-                            else -> {
-                                "LECTURE"
                             }
                         }
                         Button(


### PR DESCRIPTION
# 🚀 Pull Request Consolidée (7 PRs fusionnées)

> Cette PR regroupe l'ensemble des Pull Requests prêtes à être fusionnées dans \main\.
> **Branche source** : \ollup/all-prs\ | **Branche cible** : \main\

## ✅ Pull Requests incluses

| PR | Titre | Auteur | Branche | Issue |
| :--- | :--- | :--- | :--- | :--- |
| [#123](https://github.com/DZTic/LocalStream/pull/123) | perf(library): make TMDB metadata chunk size configurable (#106) | @DZTic | \ix/issue-106-adaptive-tmdb-chunk-size\ | #106 |
| [#122](https://github.com/DZTic/LocalStream/pull/122) | perf(ui): memoize computed values with derivedStateOf (#108) | @DZTic | \ix/issue-108-derived-state-ui-calculations\ | #108 |
| [#121](https://github.com/DZTic/LocalStream/pull/121) | perf(player): optimize track selection override lookups (#98) | @DZTic | \ix/issue-98-track-selection-lookup\ | #98 |
| [#120](https://github.com/DZTic/LocalStream/pull/120) | perf(player): debounce database playback state saving (#104) | @DZTic | \ix/issue-104-player-save-position-debounce\ | #104 |
| [#119](https://github.com/DZTic/LocalStream/pull/119) | perf(scanner): optimize filesystem scan extension filtering (#103) | @DZTic | \ix/issue-103-scanner-walktopdown-filter\ | #103 |
| [#118](https://github.com/DZTic/LocalStream/pull/118) | fix(network): add connect/read timeouts and disk cache to OkHttpClient (#105) | @DZTic | \ix/issue-105-okhttp-timeout-cache\ | #105 |
| [#117](https://github.com/DZTic/LocalStream/pull/117) | fix(player): optimize position updates lifecycle and handle discontinuities (#97) | @DZTic | \ix/issue-97-position-updates\ | #97 |

## 🎯 Clôture automatique des PRs et Issues

- Closes #123, Closes #122, Closes #121, Closes #120, Closes #119, Closes #118, Closes #117
- Closes #106, Closes #108, Closes #98, Closes #104, Closes #103, Closes #105, Closes #97

---
💡 *La fusion de cette PR fermera automatiquement l'ensemble des PRs et issues associées.*