### PR TITLE
fix(player): prevent bidirectional volume binding feedback loop (#99)

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
@@ -172,7 +172,10 @@ fun PlayerScreen(
             val maxVol = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
             if (maxVol > 0) {
                 val targetVol = ((uiState.volumePercent / 100f) * maxVol).roundToInt().coerceIn(0, maxVol)
-                am.setStreamVolume(AudioManager.STREAM_MUSIC, targetVol, 0)
+                val curVol = am.getStreamVolume(AudioManager.STREAM_MUSIC)
+                if (curVol != targetVol) {
+                    am.setStreamVolume(AudioManager.STREAM_MUSIC, targetVol, 0)
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #99 - Fixes bidirectional volume synchronization by checking current stream volume before setting, preventing feedback loops and redundant AudioManager writes.