### PR TITLE
ci: automate test and detekt execution on rollup PR creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
-﻿name: CI
+name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - 'main'
+      - 'rollup/**'
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -36,6 +36,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   combine:
@@ -79,3 +80,23 @@ jobs:
           fi
           
           python .github/scripts/combine_prs.py $ARGS
+
+      - name: Setup JDK 17
+        if: ${{ inputs.dry_run != true }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Android SDK
+        if: ${{ inputs.dry_run != true }}
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Gradle
+        if: ${{ inputs.dry_run != true }}
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Exécuter les tests et l'analyse statique sur la PR consolidée
+        if: ${{ inputs.dry_run != true }}
+        working-directory: native
+        run: ./gradlew testDebugUnitTest detekt --no-daemon --stacktrace


### PR DESCRIPTION
Runs unit tests and detekt automatically during the rollup workflow execution without requiring maintainer approval, and adds push trigger on rollup branches in ci.yml.