### PR TITLE
fix(tmdb): support v3 api keys and v4 bearer tokens and improve test feedback in settings

### DIFF
--- a/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbApi.kt
+++ b/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbApi.kt
@@ -4,6 +4,7 @@ import com.localstream.app.data.remote.tmdb.dto.TmdbCollectionDetailsDto
 import com.localstream.app.data.remote.tmdb.dto.TmdbMovieDetailsDto
 import com.localstream.app.data.remote.tmdb.dto.TmdbSearchResponse
 import com.localstream.app.data.remote.tmdb.dto.TmdbSeasonDetailsDto
+import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -54,6 +55,11 @@ interface TmdbApi {
         @Query("language") language: String = DEFAULT_LANGUAGE,
         @Header(TmdbAuthInterceptor.HEADER_OVERRIDE_KEY) overrideKey: String? = null,
     ): TmdbSeasonDetailsDto
+
+    @GET("authentication")
+    suspend fun validateApiKey(
+        @Header(TmdbAuthInterceptor.HEADER_OVERRIDE_KEY) overrideKey: String? = null,
+    ): Response<ResponseBody>
 
     @GET("movie/popular")
     suspend fun getPopular(

--- a/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbApi.kt
+++ b/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbApi.kt
@@ -21,6 +21,7 @@ interface TmdbApi {
         @Header(TmdbAuthInterceptor.HEADER_OVERRIDE_KEY) overrideKey: String? = null,
     ): TmdbSearchResponse
 
+    @Suppress("LongParameterList")
     @GET("search/movie")
     suspend fun searchMovie(
         @Query("api_key") apiKey: String = "",

--- a/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbApi.kt
+++ b/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbApi.kt
@@ -6,6 +6,7 @@ import com.localstream.app.data.remote.tmdb.dto.TmdbSearchResponse
 import com.localstream.app.data.remote.tmdb.dto.TmdbSeasonDetailsDto
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -13,46 +14,52 @@ interface TmdbApi {
 
     @GET("search/multi")
     suspend fun searchMulti(
-        @Query("api_key") apiKey: String,
+        @Query("api_key") apiKey: String = "",
         @Query("query") query: String,
         @Query("language") language: String = DEFAULT_LANGUAGE,
+        @Header(TmdbAuthInterceptor.HEADER_OVERRIDE_KEY) overrideKey: String? = null,
     ): TmdbSearchResponse
 
     @GET("search/movie")
     suspend fun searchMovie(
-        @Query("api_key") apiKey: String,
+        @Query("api_key") apiKey: String = "",
         @Query("query") query: String,
         @Query("language") language: String = DEFAULT_LANGUAGE,
         @Query("primary_release_year") primaryReleaseYear: Int? = null,
         @Query("year") year: Int? = null,
+        @Header(TmdbAuthInterceptor.HEADER_OVERRIDE_KEY) overrideKey: String? = null,
     ): TmdbSearchResponse
 
     @GET("movie/{id}")
     suspend fun getMovieDetails(
         @Path("id") movieId: Long,
-        @Query("api_key") apiKey: String,
+        @Query("api_key") apiKey: String = "",
         @Query("language") language: String = DEFAULT_LANGUAGE,
+        @Header(TmdbAuthInterceptor.HEADER_OVERRIDE_KEY) overrideKey: String? = null,
     ): TmdbMovieDetailsDto
 
     @GET("collection/{id}")
     suspend fun getCollection(
         @Path("id") collectionId: Long,
-        @Query("api_key") apiKey: String,
+        @Query("api_key") apiKey: String = "",
         @Query("language") language: String = DEFAULT_LANGUAGE,
+        @Header(TmdbAuthInterceptor.HEADER_OVERRIDE_KEY) overrideKey: String? = null,
     ): TmdbCollectionDetailsDto
 
     @GET("tv/{tv_id}/season/{season_number}")
     suspend fun getSeason(
         @Path("tv_id") tvId: Long,
         @Path("season_number") seasonNumber: Int,
-        @Query("api_key") apiKey: String,
+        @Query("api_key") apiKey: String = "",
         @Query("language") language: String = DEFAULT_LANGUAGE,
+        @Header(TmdbAuthInterceptor.HEADER_OVERRIDE_KEY) overrideKey: String? = null,
     ): TmdbSeasonDetailsDto
 
     @GET("movie/popular")
     suspend fun getPopular(
-        @Query("api_key") apiKey: String,
+        @Query("api_key") apiKey: String = "",
         @Query("language") language: String = DEFAULT_LANGUAGE,
+        @Header(TmdbAuthInterceptor.HEADER_OVERRIDE_KEY) overrideKey: String? = null,
     ): Response<TmdbSearchResponse>
 
     companion object {

--- a/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbAuthInterceptor.kt
+++ b/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbAuthInterceptor.kt
@@ -1,0 +1,73 @@
+package com.localstream.app.data.remote.tmdb
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Intercepteur OkHttp pour l'authentification TMDB.
+ *
+ * Gère de manière transparente les deux types d'authentification TMDB :
+ * 1. Clé API v3 (32 caractères hexadécimaux) -> paramètre d'URL `api_key=<clé>`.
+ * 2. API Read Access Token v4 (jeton JWT commençant par `ey...`) -> en-tête `Authorization: Bearer <token>`.
+ *
+ * Supporte également la substitution dynamique via l'en-tête [HEADER_OVERRIDE_KEY]
+ * pour tester une clé avant son enregistrement.
+ */
+class TmdbAuthInterceptor(
+    private val apiKeyProvider: () -> String,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+        val originalUrl = originalRequest.url
+
+        val overrideKey = originalRequest.header(HEADER_OVERRIDE_KEY)
+        val explicitQueryKey = originalUrl.queryParameter("api_key")
+        val rawCandidate = overrideKey ?: apiKeyProvider().takeIf { it.isNotBlank() } ?: explicitQueryKey
+        val cleanedKey = cleanKey(rawCandidate)
+
+        val requestBuilder = originalRequest.newBuilder()
+            .removeHeader(HEADER_OVERRIDE_KEY)
+
+        if (cleanedKey.isBlank()) {
+            return chain.proceed(requestBuilder.build())
+        }
+
+        val isV4Bearer = isV4Token(cleanedKey)
+        if (isV4Bearer) {
+            // Jeton v4 JWT : injection en-tête Bearer et suppression de tout api_key dans l'URL
+            val newUrl = originalUrl.newBuilder()
+                .removeAllQueryParameters("api_key")
+                .build()
+            requestBuilder
+                .url(newUrl)
+                .header("Authorization", "Bearer $cleanedKey")
+        } else {
+            // Clé API v3 : paramètre api_key dans l'URL
+            val newUrl = originalUrl.newBuilder()
+                .setQueryParameter("api_key", cleanedKey)
+                .build()
+            requestBuilder.url(newUrl)
+        }
+
+        return chain.proceed(requestBuilder.build())
+    }
+
+    companion object {
+        const val HEADER_OVERRIDE_KEY = "X-Tmdb-Override-Key"
+
+        fun cleanKey(key: String?): String {
+            if (key == null) return ""
+            return key.trim()
+                .removePrefix("Bearer ")
+                .removePrefix("bearer ")
+                .removePrefix("BEARER ")
+                .trim()
+        }
+
+        fun isV4Token(key: String): Boolean {
+            val cleaned = cleanKey(key)
+            return cleaned.startsWith("ey") || cleaned.length > 40
+        }
+    }
+}

--- a/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbAuthInterceptor.kt
+++ b/native/app/src/main/java/com/localstream/app/data/remote/tmdb/TmdbAuthInterceptor.kt
@@ -58,11 +58,17 @@ class TmdbAuthInterceptor(
 
         fun cleanKey(key: String?): String {
             if (key == null) return ""
-            return key.trim()
-                .removePrefix("Bearer ")
-                .removePrefix("bearer ")
-                .removePrefix("BEARER ")
-                .trim()
+            var cleaned = key.trim()
+            if (cleaned.startsWith("bearer ", ignoreCase = true)) {
+                cleaned = cleaned.substring(7).trim()
+            } else if (cleaned.startsWith("bearer", ignoreCase = true)) {
+                cleaned = cleaned.substring(6).trim()
+            }
+            return cleaned
+                .replace("\n", "")
+                .replace("\r", "")
+                .replace(" ", "")
+                .replace("\t", "")
         }
 
         fun isV4Token(key: String): Boolean {

--- a/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
@@ -60,9 +60,7 @@ open class TmdbRepository(
             return Result.failure(IllegalArgumentException("Veuillez saisir une clé API TMDB"))
         }
         return try {
-            val response = executeWithRetryAndThrottling {
-                tmdbApi.getPopular(overrideKey = apiKey)
-            }
+            val response = tmdbApi.getPopular(overrideKey = apiKey)
             if (response.isSuccessful) {
                 Result.success(true)
             } else if (response.code() == HTTP_UNAUTHORIZED) {

--- a/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
@@ -60,7 +60,7 @@ open class TmdbRepository(
             return Result.failure(IllegalArgumentException("Veuillez saisir une clé API TMDB"))
         }
         return try {
-            val response = tmdbApi.getPopular(overrideKey = apiKey)
+            val response = tmdbApi.validateApiKey(overrideKey = apiKey)
             if (response.isSuccessful) {
                 Result.success(true)
             } else if (response.code() == HTTP_UNAUTHORIZED) {

--- a/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
@@ -20,6 +20,8 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import retrofit2.HttpException
 
+import com.localstream.app.data.remote.tmdb.TmdbAuthInterceptor
+
 class TmdbAuthException(message: String = "Clé API TMDB invalide") : Exception(message)
 
 @Suppress(
@@ -31,7 +33,7 @@ class TmdbAuthException(message: String = "Clé API TMDB invalide") : Exception(
     "SwallowedException",
     "ReturnCount"
 )
-class TmdbRepository(
+open class TmdbRepository(
     private val tmdbApi: TmdbApi,
     private val tmdbMetadataDao: TmdbMetadataDao,
     private val settingsRepository: SettingsRepository,
@@ -51,19 +53,22 @@ class TmdbRepository(
         peakConcurrentRequests.set(0)
     }
 
-    suspend fun testApiKey(apiKeyOverride: String? = null): Result<Boolean> {
-        val apiKey = apiKeyOverride ?: settingsRepository.getTmdbApiKey()
-        if (apiKey.isBlank()) return Result.success(false)
+    open suspend fun testApiKey(apiKeyOverride: String? = null): Result<Boolean> {
+        val rawCandidate = apiKeyOverride ?: settingsRepository.getTmdbApiKey()
+        val apiKey = TmdbAuthInterceptor.cleanKey(rawCandidate)
+        if (apiKey.isBlank()) {
+            return Result.failure(IllegalArgumentException("Veuillez saisir une clé API TMDB"))
+        }
         return try {
             val response = executeWithRetryAndThrottling {
-                tmdbApi.getPopular(apiKey)
+                tmdbApi.getPopular(overrideKey = apiKey)
             }
             if (response.isSuccessful) {
                 Result.success(true)
             } else if (response.code() == HTTP_UNAUTHORIZED) {
-                Result.failure(TmdbAuthException())
+                Result.failure(TmdbAuthException("Clé API TMDB invalide (erreur 401)"))
             } else {
-                Result.success(false)
+                Result.failure(IllegalStateException("Erreur HTTP ${response.code()} lors du test TMDB"))
             }
         } catch (e: TmdbAuthException) {
             Result.failure(e)

--- a/native/app/src/main/java/com/localstream/app/di/AppContainer.kt
+++ b/native/app/src/main/java/com/localstream/app/di/AppContainer.kt
@@ -8,6 +8,7 @@ import com.localstream.app.data.local.UserPreferencesDataStore
 import com.localstream.app.data.remote.opensubtitles.OpenSubtitlesApi
 import com.localstream.app.data.remote.opensubtitles.OpenSubtitlesInterceptor
 import com.localstream.app.data.remote.tmdb.TmdbApi
+import com.localstream.app.data.remote.tmdb.TmdbAuthInterceptor
 import com.localstream.app.data.repository.OpenSubtitlesRepository
 import com.localstream.app.data.repository.PlaylistRepository
 import com.localstream.app.data.repository.SettingsRepository
@@ -60,12 +61,17 @@ open class AppContainer(
     }
 
     private val tmdbApi: TmdbApi by lazy {
-        if (appContext == null) NoOpTmdbApi() else Retrofit.Builder()
-            .baseUrl(TmdbApi.BASE_URL)
-            .client(okHttpClient)
-            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-            .build()
-            .create(TmdbApi::class.java)
+        if (appContext == null) NoOpTmdbApi() else {
+            val client = okHttpClient.newBuilder()
+                .addInterceptor(TmdbAuthInterceptor { settingsRepository.getTmdbApiKey() })
+                .build()
+            Retrofit.Builder()
+                .baseUrl(TmdbApi.BASE_URL)
+                .client(client)
+                .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+                .build()
+                .create(TmdbApi::class.java)
+        }
     }
 
     private val openSubtitlesApi: OpenSubtitlesApi by lazy {

--- a/native/app/src/main/java/com/localstream/app/di/NoOpTestDoubles.kt
+++ b/native/app/src/main/java/com/localstream/app/di/NoOpTestDoubles.kt
@@ -103,6 +103,7 @@ class NoOpTmdbApi : TmdbApi {
     override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String, overrideKey: String?): TmdbMovieDetailsDto = unused()
     override suspend fun getCollection(collectionId: Long, apiKey: String, language: String, overrideKey: String?): TmdbCollectionDetailsDto = unused()
     override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String, overrideKey: String?): TmdbSeasonDetailsDto = unused()
+    override suspend fun validateApiKey(overrideKey: String?): Response<ResponseBody> = unused()
     override suspend fun getPopular(apiKey: String, language: String, overrideKey: String?): Response<TmdbSearchResponse> = unused()
 }
 

--- a/native/app/src/main/java/com/localstream/app/di/NoOpTestDoubles.kt
+++ b/native/app/src/main/java/com/localstream/app/di/NoOpTestDoubles.kt
@@ -91,18 +91,19 @@ class NoOpPlaylistDao : PlaylistDao {
 
 class NoOpTmdbApi : TmdbApi {
     private fun unused(): Nothing = throw UnsupportedOperationException("NoOp")
-    override suspend fun searchMulti(apiKey: String, query: String, language: String): TmdbSearchResponse = unused()
+    override suspend fun searchMulti(apiKey: String, query: String, language: String, overrideKey: String?): TmdbSearchResponse = unused()
     override suspend fun searchMovie(
         apiKey: String,
         query: String,
         language: String,
         primaryReleaseYear: Int?,
         year: Int?,
+        overrideKey: String?,
     ): TmdbSearchResponse = unused()
-    override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String): TmdbMovieDetailsDto = unused()
-    override suspend fun getCollection(collectionId: Long, apiKey: String, language: String): TmdbCollectionDetailsDto = unused()
-    override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String): TmdbSeasonDetailsDto = unused()
-    override suspend fun getPopular(apiKey: String, language: String): Response<TmdbSearchResponse> = unused()
+    override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String, overrideKey: String?): TmdbMovieDetailsDto = unused()
+    override suspend fun getCollection(collectionId: Long, apiKey: String, language: String, overrideKey: String?): TmdbCollectionDetailsDto = unused()
+    override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String, overrideKey: String?): TmdbSeasonDetailsDto = unused()
+    override suspend fun getPopular(apiKey: String, language: String, overrideKey: String?): Response<TmdbSearchResponse> = unused()
 }
 
 class NoOpOpenSubtitlesApi : OpenSubtitlesApi {

--- a/native/app/src/main/java/com/localstream/app/ui/screens/SettingsScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/SettingsScreen.kt
@@ -9,10 +9,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Movie
 import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material.icons.filled.Subtitles
@@ -145,30 +148,56 @@ fun SettingsScreen(
 
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         Button(
                             onClick = { viewModel.testTmdbApiKey(tmdbKeyInput) },
-                            colors = ButtonDefaults.buttonColors(containerColor = Red600),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = Red600,
+                                disabledContainerColor = Red600.copy(alpha = 0.5f),
+                                disabledContentColor = White,
+                            ),
                             shape = RoundedCornerShape(4.dp),
                             enabled = !uiState.isTestingTmdbKey,
                         ) {
                             if (uiState.isTestingTmdbKey) {
-                                CircularProgressIndicator(color = White, modifier = Modifier.height(16.dp))
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    CircularProgressIndicator(
+                                        color = White,
+                                        strokeWidth = 2.dp,
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                    Text("Test...", color = White)
+                                }
                             } else {
                                 Text(stringResource(R.string.settings_tmdb_test_key_button), color = White)
                             }
                         }
 
                         uiState.tmdbTestResult?.let { msg ->
-                            val isOk = msg.contains("valide")
-                            Text(
-                                text = msg,
-                                color = if (isOk) White else Red600,
-                                style = MaterialTheme.typography.bodySmall,
-                                fontWeight = FontWeight.Bold,
-                            )
+                            val isSuccess = uiState.tmdbTestSuccess == true
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                modifier = Modifier.weight(1f, fill = false),
+                            ) {
+                                Icon(
+                                    imageVector = if (isSuccess) Icons.Filled.CheckCircle else Icons.Filled.Error,
+                                    contentDescription = null,
+                                    tint = if (isSuccess) White else Red600,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                                Text(
+                                    text = msg,
+                                    color = if (isSuccess) White else Red600,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                            }
                         }
                     }
                 }

--- a/native/app/src/main/java/com/localstream/app/ui/settings/SettingsViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/settings/SettingsViewModel.kt
@@ -111,16 +111,22 @@ class SettingsViewModel(
             isTestingTmdbFlow.value = true
             tmdbTestResultFlow.value = null
             tmdbTestSuccessFlow.value = null
-            val result = container.tmdbRepository.testApiKey(apiKeyOverride)
-            if (result.isSuccess && result.getOrDefault(false)) {
-                tmdbTestResultFlow.value = "Clé API valide !"
-                tmdbTestSuccessFlow.value = true
-            } else {
-                val error = result.exceptionOrNull()?.message ?: "Clé API TMDB invalide"
-                tmdbTestResultFlow.value = error
+            try {
+                val result = container.tmdbRepository.testApiKey(apiKeyOverride)
+                if (result.isSuccess && result.getOrDefault(false)) {
+                    tmdbTestResultFlow.value = "Clé API valide !"
+                    tmdbTestSuccessFlow.value = true
+                } else {
+                    val error = result.exceptionOrNull()?.message ?: "Clé API TMDB invalide"
+                    tmdbTestResultFlow.value = error
+                    tmdbTestSuccessFlow.value = false
+                }
+            } catch (e: Exception) {
+                tmdbTestResultFlow.value = e.message ?: "Erreur inattendue"
                 tmdbTestSuccessFlow.value = false
+            } finally {
+                isTestingTmdbFlow.value = false
             }
-            isTestingTmdbFlow.value = false
         }
     }
 

--- a/native/app/src/main/java/com/localstream/app/ui/settings/SettingsViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/settings/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import android.provider.Settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.localstream.app.data.remote.tmdb.TmdbAuthInterceptor
 import com.localstream.app.di.AppContainer
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,6 +27,7 @@ data class SettingsUiState(
     val tmdbApiKey: String = "",
     val isTestingTmdbKey: Boolean = false,
     val tmdbTestResult: String? = null,
+    val tmdbTestSuccess: Boolean? = null,
     val osApiKey: String = "",
     val osUsername: String = "",
     val osPassword: String = "",
@@ -43,6 +45,7 @@ class SettingsViewModel(
 
     private val isTestingTmdbFlow = MutableStateFlow(false)
     private val tmdbTestResultFlow = MutableStateFlow<String?>(null)
+    private val tmdbTestSuccessFlow = MutableStateFlow<Boolean?>(null)
     private val isLoggingInOsFlow = MutableStateFlow(false)
     private val osLoginStatusFlow = MutableStateFlow("Non connecté")
     private val installedPlayersFlow = MutableStateFlow<List<ExternalPlayerInfo>>(emptyList())
@@ -53,6 +56,7 @@ class SettingsViewModel(
             container.settingsRepository.observeExternalPlayer,
             isTestingTmdbFlow,
             tmdbTestResultFlow,
+            tmdbTestSuccessFlow,
             isLoggingInOsFlow,
             osLoginStatusFlow,
             installedPlayersFlow,
@@ -62,9 +66,10 @@ class SettingsViewModel(
         val extPlayer = args[1] as String
         val testingTmdb = args[2] as Boolean
         val tmdbRes = args[3] as String?
-        val loggingOs = args[4] as Boolean
-        val osStatus = args[5] as String
-        val installed = args[6] as List<ExternalPlayerInfo>
+        val tmdbSuccess = args[4] as Boolean?
+        val loggingOs = args[5] as Boolean
+        val osStatus = args[6] as String
+        val installed = args[7] as List<ExternalPlayerInfo>
 
         val tmdbKey = container.settingsRepository.getTmdbApiKey()
         val osKey = container.settingsRepository.getOpenSubtitlesApiKey()
@@ -78,6 +83,7 @@ class SettingsViewModel(
             tmdbApiKey = tmdbKey,
             isTestingTmdbKey = testingTmdb,
             tmdbTestResult = tmdbRes,
+            tmdbTestSuccess = tmdbSuccess,
             osApiKey = osKey,
             osUsername = osUser,
             osPassword = osPass,
@@ -95,7 +101,8 @@ class SettingsViewModel(
 
     fun saveTmdbApiKey(key: String) {
         viewModelScope.launch {
-            container.settingsRepository.saveTmdbApiKey(key.trim())
+            val cleaned = TmdbAuthInterceptor.cleanKey(key)
+            container.settingsRepository.saveTmdbApiKey(cleaned)
         }
     }
 
@@ -103,11 +110,15 @@ class SettingsViewModel(
         viewModelScope.launch {
             isTestingTmdbFlow.value = true
             tmdbTestResultFlow.value = null
+            tmdbTestSuccessFlow.value = null
             val result = container.tmdbRepository.testApiKey(apiKeyOverride)
             if (result.isSuccess && result.getOrDefault(false)) {
                 tmdbTestResultFlow.value = "Clé API valide !"
+                tmdbTestSuccessFlow.value = true
             } else {
-                tmdbTestResultFlow.value = result.exceptionOrNull()?.message ?: "Clé API TMDB invalide"
+                val error = result.exceptionOrNull()?.message ?: "Clé API TMDB invalide"
+                tmdbTestResultFlow.value = error
+                tmdbTestSuccessFlow.value = false
             }
             isTestingTmdbFlow.value = false
         }

--- a/native/app/src/main/java/com/localstream/app/ui/settings/SettingsViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/settings/SettingsViewModel.kt
@@ -121,9 +121,6 @@ class SettingsViewModel(
                     tmdbTestResultFlow.value = error
                     tmdbTestSuccessFlow.value = false
                 }
-            } catch (e: Exception) {
-                tmdbTestResultFlow.value = e.message ?: "Erreur inattendue"
-                tmdbTestSuccessFlow.value = false
             } finally {
                 isTestingTmdbFlow.value = false
             }

--- a/native/app/src/test/java/com/localstream/app/data/remote/tmdb/TmdbAuthInterceptorTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/remote/tmdb/TmdbAuthInterceptorTest.kt
@@ -1,0 +1,88 @@
+package com.localstream.app.data.remote.tmdb
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class TmdbAuthInterceptorTest {
+
+    private lateinit var mockWebServer: MockWebServer
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `v3 api key injects query parameter`() {
+        mockWebServer.enqueue(MockResponse().setBody("{}"))
+
+        val client = OkHttpClient.Builder()
+            .addInterceptor(TmdbAuthInterceptor { "1234567890abcdef1234567890abcdef" })
+            .build()
+
+        val request = Request.Builder()
+            .url(mockWebServer.url("/3/movie/popular"))
+            .build()
+
+        client.newCall(request).execute().close()
+
+        val recorded = mockWebServer.takeRequest()
+        assertEquals("1234567890abcdef1234567890abcdef", recorded.requestUrl?.queryParameter("api_key"))
+        assertNull(recorded.getHeader("Authorization"))
+    }
+
+    @Test
+    fun `v4 JWT token injects Authorization Bearer header and removes api_key query param`() {
+        mockWebServer.enqueue(MockResponse().setBody("{}"))
+
+        val jwtToken = "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIxMjM0NTY3ODkwIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.signature"
+        val client = OkHttpClient.Builder()
+            .addInterceptor(TmdbAuthInterceptor { jwtToken })
+            .build()
+
+        val request = Request.Builder()
+            .url(mockWebServer.url("/3/movie/popular?api_key=old_key"))
+            .build()
+
+        client.newCall(request).execute().close()
+
+        val recorded = mockWebServer.takeRequest()
+        assertEquals("Bearer $jwtToken", recorded.getHeader("Authorization"))
+        assertNull(recorded.requestUrl?.queryParameter("api_key"))
+    }
+
+    @Test
+    fun `override header takes precedence and is cleaned`() {
+        mockWebServer.enqueue(MockResponse().setBody("{}"))
+
+        val jwtToken = "eyJhbGciOiJIUzI1NiJ9.override"
+        val client = OkHttpClient.Builder()
+            .addInterceptor(TmdbAuthInterceptor { "default_v3_key" })
+            .build()
+
+        val request = Request.Builder()
+            .url(mockWebServer.url("/3/movie/popular"))
+            .header(TmdbAuthInterceptor.HEADER_OVERRIDE_KEY, "  Bearer $jwtToken  ")
+            .build()
+
+        client.newCall(request).execute().close()
+
+        val recorded = mockWebServer.takeRequest()
+        assertEquals("Bearer $jwtToken", recorded.getHeader("Authorization"))
+        assertNull(recorded.getHeader(TmdbAuthInterceptor.HEADER_OVERRIDE_KEY))
+        assertNull(recorded.requestUrl?.queryParameter("api_key"))
+    }
+}

--- a/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
@@ -23,6 +23,9 @@ import org.junit.Test
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
+import com.localstream.app.data.remote.tmdb.TmdbAuthInterceptor
+import okhttp3.OkHttpClient
+
 @Suppress("MaxLineLength", "TooManyFunctions", "LargeClass", "MagicNumber")
 class TmdbRepositoryTest {
 
@@ -39,15 +42,20 @@ class TmdbRepositoryTest {
         mockWebServer = MockWebServer()
         mockWebServer.start()
 
+        settingsRepository = FakeSettingsRepository("test_api_key")
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(TmdbAuthInterceptor { settingsRepository.getTmdbApiKey() })
+            .build()
+
         val contentType = "application/json".toMediaType()
         val retrofit = Retrofit.Builder()
             .baseUrl(mockWebServer.url("/"))
+            .client(okHttpClient)
             .addConverterFactory(json.asConverterFactory(contentType))
             .build()
 
         tmdbApi = retrofit.create(TmdbApi::class.java)
         fakeDao = FakeTmdbMetadataDao()
-        settingsRepository = FakeSettingsRepository("test_api_key")
 
         repository = TmdbRepository(
             tmdbApi = tmdbApi,
@@ -426,6 +434,27 @@ class TmdbRepositoryTest {
         val invalidResult = repository.testApiKey("invalid_key")
         assertTrue(invalidResult.isFailure)
         assertTrue(invalidResult.exceptionOrNull() is TmdbAuthException)
+    }
+
+    @Test
+    fun testTestApiKeyWithV4BearerToken() = runTest {
+        val popularJson = """{"results": [{"id": 1, "title": "Popular Movie"}]}"""
+        mockWebServer.enqueue(jsonResponse(popularJson))
+
+        val v4Token = "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIxMjM0NTY3ODkwIiwic3ViIjoiMTIzNDU2Nzg5MCJ9.signature"
+        val result = repository.testApiKey("  Bearer $v4Token  ")
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull() == true)
+
+        val recorded = mockWebServer.takeRequest()
+        assertEquals("Bearer $v4Token", recorded.getHeader("Authorization"))
+    }
+
+    @Test
+    fun testTestApiKeyWithBlankKeyReturnsFailure() = runTest {
+        val result = repository.testApiKey("   ")
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
     }
 }
 

--- a/native/app/src/test/java/com/localstream/app/ui/details/DetailsViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/details/DetailsViewModelTest.kt
@@ -277,6 +277,7 @@ class DetailsViewModelTest {
         override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String, overrideKey: String?): TmdbMovieDetailsDto = unused()
         override suspend fun getCollection(collectionId: Long, apiKey: String, language: String, overrideKey: String?): TmdbCollectionDetailsDto = unused()
         override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String, overrideKey: String?): TmdbSeasonDetailsDto = unused()
+        override suspend fun validateApiKey(overrideKey: String?): Response<ResponseBody> = unused()
         override suspend fun getPopular(apiKey: String, language: String, overrideKey: String?): Response<TmdbSearchResponse> = unused()
     }
 

--- a/native/app/src/test/java/com/localstream/app/ui/details/DetailsViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/details/DetailsViewModelTest.kt
@@ -265,18 +265,19 @@ class DetailsViewModelTest {
 
     private class UnusedTmdbApi : TmdbApi {
         private fun unused(): Nothing = throw UnsupportedOperationException("appel inattendu")
-        override suspend fun searchMulti(apiKey: String, query: String, language: String): TmdbSearchResponse = unused()
+        override suspend fun searchMulti(apiKey: String, query: String, language: String, overrideKey: String?): TmdbSearchResponse = unused()
         override suspend fun searchMovie(
             apiKey: String,
             query: String,
             language: String,
             primaryReleaseYear: Int?,
             year: Int?,
+            overrideKey: String?,
         ): TmdbSearchResponse = unused()
-        override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String): TmdbMovieDetailsDto = unused()
-        override suspend fun getCollection(collectionId: Long, apiKey: String, language: String): TmdbCollectionDetailsDto = unused()
-        override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String): TmdbSeasonDetailsDto = unused()
-        override suspend fun getPopular(apiKey: String, language: String): Response<TmdbSearchResponse> = unused()
+        override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String, overrideKey: String?): TmdbMovieDetailsDto = unused()
+        override suspend fun getCollection(collectionId: Long, apiKey: String, language: String, overrideKey: String?): TmdbCollectionDetailsDto = unused()
+        override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String, overrideKey: String?): TmdbSeasonDetailsDto = unused()
+        override suspend fun getPopular(apiKey: String, language: String, overrideKey: String?): Response<TmdbSearchResponse> = unused()
     }
 
     private class UnusedOsApi : OpenSubtitlesApi {

--- a/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
@@ -15,6 +15,7 @@ import com.localstream.app.data.repository.SettingsRepository
 import com.localstream.app.data.repository.TmdbRepository
 import com.localstream.app.data.repository.VideoRepository
 import com.localstream.app.data.repository.WatchStateRepository
+import okhttp3.ResponseBody
 import retrofit2.Response
 import com.localstream.app.data.scanner.MediaScanner
 import com.localstream.app.domain.model.MovieCollection
@@ -259,6 +260,7 @@ class LibraryViewModelTest {
         override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String, overrideKey: String?): TmdbMovieDetailsDto = unused()
         override suspend fun getCollection(collectionId: Long, apiKey: String, language: String, overrideKey: String?): TmdbCollectionDetailsDto = unused()
         override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String, overrideKey: String?): TmdbSeasonDetailsDto = unused()
+        override suspend fun validateApiKey(overrideKey: String?): Response<ResponseBody> = unused()
         override suspend fun getPopular(apiKey: String, language: String, overrideKey: String?): Response<TmdbSearchResponse> = unused()
     }
 }

--- a/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
@@ -247,17 +247,18 @@ class LibraryViewModelTest {
     /** Sans clé API configurée, aucune méthode distante ne doit être appelée. */
     private class UnusedTmdbApi : TmdbApi {
         private fun unused(): Nothing = throw UnsupportedOperationException("appel réseau inattendu")
-        override suspend fun searchMulti(apiKey: String, query: String, language: String): TmdbSearchResponse = unused()
+        override suspend fun searchMulti(apiKey: String, query: String, language: String, overrideKey: String?): TmdbSearchResponse = unused()
         override suspend fun searchMovie(
             apiKey: String,
             query: String,
             language: String,
             primaryReleaseYear: Int?,
             year: Int?,
+            overrideKey: String?,
         ): TmdbSearchResponse = unused()
-        override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String): TmdbMovieDetailsDto = unused()
-        override suspend fun getCollection(collectionId: Long, apiKey: String, language: String): TmdbCollectionDetailsDto = unused()
-        override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String): TmdbSeasonDetailsDto = unused()
-        override suspend fun getPopular(apiKey: String, language: String): Response<TmdbSearchResponse> = unused()
+        override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String, overrideKey: String?): TmdbMovieDetailsDto = unused()
+        override suspend fun getCollection(collectionId: Long, apiKey: String, language: String, overrideKey: String?): TmdbCollectionDetailsDto = unused()
+        override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String, overrideKey: String?): TmdbSeasonDetailsDto = unused()
+        override suspend fun getPopular(apiKey: String, language: String, overrideKey: String?): Response<TmdbSearchResponse> = unused()
     }
 }

--- a/native/app/src/test/java/com/localstream/app/ui/settings/SettingsViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/settings/SettingsViewModelTest.kt
@@ -11,6 +11,9 @@ import com.localstream.app.data.repository.OpenSubtitlesRepository
 import com.localstream.app.data.repository.SettingsRepository
 import com.localstream.app.data.repository.TmdbRepository
 import com.localstream.app.di.AppContainer
+import com.localstream.app.di.NoOpOpenSubtitlesApi
+import com.localstream.app.di.NoOpTmdbApi
+import com.localstream.app.di.NoOpTmdbMetadataDao
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,12 +24,10 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import okhttp3.ResponseBody
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingsViewModelTest {
@@ -46,7 +47,7 @@ class SettingsViewModelTest {
     @Test
     fun `saveTmdbApiKey mémorise la clé API`() = runTest(testDispatcher) {
         val settingsRepo = SettingsRepository(dataStore = null)
-        val osRepo = OpenSubtitlesRepository(UnusedOsApi(), settingsRepo, SubtitleCache(File("/tmp")))
+        val osRepo = OpenSubtitlesRepository(NoOpOpenSubtitlesApi(), settingsRepo, SubtitleCache(File("/tmp")))
         val dummyContainer = DummyContainer(settingsRepo, osRepo)
         val viewModel = SettingsViewModel(dummyContainer)
 
@@ -59,7 +60,7 @@ class SettingsViewModelTest {
     @Test
     fun `testTmdbApiKey met à jour l'état de succès et d'échec`() = runTest(testDispatcher) {
         val settingsRepo = SettingsRepository(dataStore = null)
-        val osRepo = OpenSubtitlesRepository(UnusedOsApi(), settingsRepo, SubtitleCache(File("/tmp")))
+        val osRepo = OpenSubtitlesRepository(NoOpOpenSubtitlesApi(), settingsRepo, SubtitleCache(File("/tmp")))
         val fakeTmdbRepo = FakeTestTmdbRepo(settingsRepo)
         val dummyContainer = DummyContainer(settingsRepo, osRepo, fakeTmdbRepo)
         val viewModel = SettingsViewModel(dummyContainer)
@@ -96,8 +97,8 @@ class SettingsViewModelTest {
     )
 
     private class FakeTestTmdbRepo(settingsRepo: SettingsRepository) : TmdbRepository(
-        tmdbApi = UnusedTmdbApi(),
-        tmdbMetadataDao = FakeDao(),
+        tmdbApi = NoOpTmdbApi(),
+        tmdbMetadataDao = NoOpTmdbMetadataDao(),
         settingsRepository = settingsRepo,
     ) {
         var shouldSucceed = true
@@ -106,32 +107,5 @@ class SettingsViewModelTest {
         override suspend fun testApiKey(apiKeyOverride: String?): Result<Boolean> {
             return if (shouldSucceed) Result.success(true) else Result.failure(Exception(errorMessage))
         }
-    }
-
-    private class FakeDao : com.localstream.app.data.db.dao.TmdbMetadataDao {
-        override suspend fun getMetadata(queryKey: String): com.localstream.app.data.db.entity.TmdbMetadataEntity? = null
-        override suspend fun insertMetadata(entity: com.localstream.app.data.db.entity.TmdbMetadataEntity) {}
-        override suspend fun deleteMetadata(queryKey: String) {}
-        override suspend fun clearAll() {}
-        override suspend fun getAll(): List<com.localstream.app.data.db.entity.TmdbMetadataEntity> = emptyList()
-    }
-
-    private class UnusedTmdbApi : com.localstream.app.data.remote.tmdb.TmdbApi {
-        private fun unused(): Nothing = throw UnsupportedOperationException("appel inattendu")
-        override suspend fun searchMulti(apiKey: String, query: String, language: String, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbSearchResponse = unused()
-        override suspend fun searchMovie(apiKey: String, query: String, language: String, primaryReleaseYear: Int?, year: Int?, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbSearchResponse = unused()
-        override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbMovieDetailsDto = unused()
-        override suspend fun getCollection(collectionId: Long, apiKey: String, language: String, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbCollectionDetailsDto = unused()
-        override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbSeasonDetailsDto = unused()
-        override suspend fun validateApiKey(overrideKey: String?): Response<ResponseBody> = unused()
-        override suspend fun getPopular(apiKey: String, language: String, overrideKey: String?): Response<com.localstream.app.data.remote.tmdb.dto.TmdbSearchResponse> = unused()
-    }
-
-    private class UnusedOsApi : OpenSubtitlesApi {
-        private fun unused(): Nothing = throw UnsupportedOperationException("appel inattendu")
-        override suspend fun login(body: OsLoginRequest): OsLoginResponse = unused()
-        override suspend fun search(query: String, languages: String): OsSearchResponse = unused()
-        override suspend fun requestDownload(body: OsDownloadRequest, authorization: String): Response<OsDownloadResponse> = unused()
-        override suspend fun downloadFile(url: String): Response<ResponseBody> = unused()
     }
 }

--- a/native/app/src/test/java/com/localstream/app/ui/settings/SettingsViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/settings/SettingsViewModelTest.kt
@@ -123,6 +123,7 @@ class SettingsViewModelTest {
         override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbMovieDetailsDto = unused()
         override suspend fun getCollection(collectionId: Long, apiKey: String, language: String, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbCollectionDetailsDto = unused()
         override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbSeasonDetailsDto = unused()
+        override suspend fun validateApiKey(overrideKey: String?): Response<ResponseBody> = unused()
         override suspend fun getPopular(apiKey: String, language: String, overrideKey: String?): Response<com.localstream.app.data.remote.tmdb.dto.TmdbSearchResponse> = unused()
     }
 

--- a/native/app/src/test/java/com/localstream/app/ui/settings/SettingsViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/settings/SettingsViewModelTest.kt
@@ -9,10 +9,13 @@ import com.localstream.app.data.remote.opensubtitles.dto.OsLoginResponse
 import com.localstream.app.data.remote.opensubtitles.dto.OsSearchResponse
 import com.localstream.app.data.repository.OpenSubtitlesRepository
 import com.localstream.app.data.repository.SettingsRepository
+import com.localstream.app.data.repository.TmdbRepository
 import com.localstream.app.di.AppContainer
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -47,20 +50,81 @@ class SettingsViewModelTest {
         val dummyContainer = DummyContainer(settingsRepo, osRepo)
         val viewModel = SettingsViewModel(dummyContainer)
 
-        viewModel.saveTmdbApiKey("my_secret_tmdb_key")
+        viewModel.saveTmdbApiKey("  my_secret_tmdb_key  ")
         advanceUntilIdle()
 
         assertEquals("my_secret_tmdb_key", settingsRepo.getTmdbApiKey())
     }
 
+    @Test
+    fun `testTmdbApiKey met à jour l'état de succès et d'échec`() = runTest(testDispatcher) {
+        val settingsRepo = SettingsRepository(dataStore = null)
+        val osRepo = OpenSubtitlesRepository(UnusedOsApi(), settingsRepo, SubtitleCache(File("/tmp")))
+        val fakeTmdbRepo = FakeTestTmdbRepo(settingsRepo)
+        val dummyContainer = DummyContainer(settingsRepo, osRepo, fakeTmdbRepo)
+        val viewModel = SettingsViewModel(dummyContainer)
+
+        val collectJob = launch { viewModel.uiState.collect() }
+
+        fakeTmdbRepo.shouldSucceed = true
+        viewModel.testTmdbApiKey("valid_key")
+        advanceUntilIdle()
+
+        assertEquals("Clé API valide !", viewModel.uiState.value.tmdbTestResult)
+        assertEquals(true, viewModel.uiState.value.tmdbTestSuccess)
+
+        fakeTmdbRepo.shouldSucceed = false
+        fakeTmdbRepo.errorMessage = "Clé API TMDB invalide (erreur 401)"
+        viewModel.testTmdbApiKey("invalid_key")
+        advanceUntilIdle()
+
+        assertEquals("Clé API TMDB invalide (erreur 401)", viewModel.uiState.value.tmdbTestResult)
+        assertEquals(false, viewModel.uiState.value.tmdbTestSuccess)
+
+        collectJob.cancel()
+    }
+
     private class DummyContainer(
         overrideSettingsRepo: SettingsRepository,
         overrideOsRepo: OpenSubtitlesRepository,
+        overrideTmdbRepo: TmdbRepository? = null,
     ) : AppContainer(
         context = null,
         overrideSettingsRepository = overrideSettingsRepo,
         overrideOpenSubtitlesRepository = overrideOsRepo,
+        overrideTmdbRepository = overrideTmdbRepo,
     )
+
+    private class FakeTestTmdbRepo(settingsRepo: SettingsRepository) : TmdbRepository(
+        tmdbApi = UnusedTmdbApi(),
+        tmdbMetadataDao = FakeDao(),
+        settingsRepository = settingsRepo,
+    ) {
+        var shouldSucceed = true
+        var errorMessage = "Clé API TMDB invalide"
+
+        override suspend fun testApiKey(apiKeyOverride: String?): Result<Boolean> {
+            return if (shouldSucceed) Result.success(true) else Result.failure(Exception(errorMessage))
+        }
+    }
+
+    private class FakeDao : com.localstream.app.data.db.dao.TmdbMetadataDao {
+        override suspend fun getMetadata(queryKey: String): com.localstream.app.data.db.entity.TmdbMetadataEntity? = null
+        override suspend fun insertMetadata(entity: com.localstream.app.data.db.entity.TmdbMetadataEntity) {}
+        override suspend fun deleteMetadata(queryKey: String) {}
+        override suspend fun clearAll() {}
+        override suspend fun getAll(): List<com.localstream.app.data.db.entity.TmdbMetadataEntity> = emptyList()
+    }
+
+    private class UnusedTmdbApi : com.localstream.app.data.remote.tmdb.TmdbApi {
+        private fun unused(): Nothing = throw UnsupportedOperationException("appel inattendu")
+        override suspend fun searchMulti(apiKey: String, query: String, language: String, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbSearchResponse = unused()
+        override suspend fun searchMovie(apiKey: String, query: String, language: String, primaryReleaseYear: Int?, year: Int?, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbSearchResponse = unused()
+        override suspend fun getMovieDetails(movieId: Long, apiKey: String, language: String, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbMovieDetailsDto = unused()
+        override suspend fun getCollection(collectionId: Long, apiKey: String, language: String, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbCollectionDetailsDto = unused()
+        override suspend fun getSeason(tvId: Long, seasonNumber: Int, apiKey: String, language: String, overrideKey: String?): com.localstream.app.data.remote.tmdb.dto.TmdbSeasonDetailsDto = unused()
+        override suspend fun getPopular(apiKey: String, language: String, overrideKey: String?): Response<com.localstream.app.data.remote.tmdb.dto.TmdbSearchResponse> = unused()
+    }
 
     private class UnusedOsApi : OpenSubtitlesApi {
         private fun unused(): Nothing = throw UnsupportedOperationException("appel inattendu")


### PR DESCRIPTION
## Description
Cette PR resout le probleme ou le bouton de test de la cle API TMDB restait grise ou echouait sans afficher de confirmation.

### Changements apportes
1. **Support complet TMDB v3 et v4 (Read Access Token)** :
   - Ajout de TmdbAuthInterceptor qui detecte automatiquement le format de la cle (cle API v3 en parametre d'URL pi_key ou jeton JWT v4 en en-tete HTTP Authorization: Bearer <token>).
   - Nettoyage automatique des espaces, retours a la ligne et prefixes Bearer .
   - Support de la substitution de cle via l'en-tete X-Tmdb-Override-Key pour tester dynamiquement la cle avant son enregistrement.
2. **Interface utilisateur et feedback visuel dans l'ecran Parametres** :
   - Ajout d'un champ 	mdbTestSuccess dans SettingsUiState pour separer explicitement le succes de l'echec.
   - Correction de la condition d'affichage (msg.contains("valide") traitait "Cle API TMDB invalide" comme valide).
   - Ajout d'icones d'etat (CheckCircle blanche / Error rouge) et d'un indicateur de progression pendant le test.
   - Amelioration de l'etat visuel du bouton Tester la cle pendant le test (disabledContainerColor semi-transparent).
3. **Tests unitaires** :
   - Ajout de TmdbAuthInterceptorTest couvrant les cles v3, les jetons v4 JWT et le header d'override.
   - Ajout de tests dans TmdbRepositoryTest et SettingsViewModelTest.

### Validation
- Tests unitaires reussis avec succes (./gradlew test).
- APK compile et teste sur appareil physique.
