### PR TITLE
build: definir une signingConfig release avant toute distribution publique

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -3,6 +3,8 @@ name: Build APK
 on:
   push:
     branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
 
 concurrency:
   group: build-apk-${{ github.ref }}
@@ -39,3 +41,47 @@ jobs:
           name: localstream-debug-${{ github.run_number }}
           path: native/app/build/outputs/apk/debug/*.apk
           retention-days: 14
+
+  build-release-apk:
+    name: Build release APK
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode Keystore
+        if: env.RELEASE_KEYSTORE_BASE64 != ''
+        run: echo "$RELEASE_KEYSTORE_BASE64" | base64 -d > native/release.keystore
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+
+      - name: Assemble release APK
+        working-directory: native
+        env:
+          RELEASE_KEYSTORE_PATH: release.keystore
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: ./gradlew assembleRelease --no-daemon --stacktrace
+
+      - name: Upload release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: localstream-release-${{ github.run_number }}
+          path: native/app/build/outputs/apk/release/*.apk
+          retention-days: 30
+

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ android/local.properties
 android/app/build/
 android/app/src/main/assets/public/
 android/.kotlin/
+*.jks
+release.keystore
+native/release.keystore
 
 .gradle-home/
 .claude/

--- a/native/app/build.gradle.kts
+++ b/native/app/build.gradle.kts
@@ -18,6 +18,25 @@ android {
             keyAlias = "androiddebugkey"
             keyPassword = "android"
         }
+        create("release") {
+            val releaseStoreFilePath = System.getenv("RELEASE_KEYSTORE_PATH")
+                ?: System.getenv("KEYSTORE_PATH")
+                ?: "${rootDir}/release.keystore"
+            val releaseStoreFile = file(releaseStoreFilePath)
+
+            if (releaseStoreFile.exists()) {
+                storeFile = releaseStoreFile
+                storePassword = System.getenv("RELEASE_STORE_PASSWORD") ?: System.getenv("KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("RELEASE_KEY_ALIAS") ?: System.getenv("KEY_ALIAS")
+                keyPassword = System.getenv("RELEASE_KEY_PASSWORD") ?: System.getenv("KEY_PASSWORD")
+            } else {
+                // Fallback vers le debug keystore si aucune clé release n'est fournie (permet le build local)
+                storeFile = file("${rootDir}/debug.keystore")
+                storePassword = "android"
+                keyAlias = "androiddebugkey"
+                keyPassword = "android"
+            }
+        }
     }
 
     defaultConfig {
@@ -35,6 +54,7 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",


### PR DESCRIPTION
## Description
Ajoute une signingConfig release et configure la CI pour les builds signes.

Fixes #136

## Changements
- Ajout de signingConfig release dans native/app/build.gradle.kts.
- Regles d'exclusion dans .gitignore.
- Job build-release-apk dans .github/workflows/build-apk.yml.
