### PR TITLE
security: exclure les preferences chiffrees du auto-backup Android

### DIFF
--- a/native/app/src/main/AndroidManifest.xml
+++ b/native/app/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
     <application
         android:name=".LocalStreamApplication"
         android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:extractNativeLibs="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/native/app/src/main/res/xml/backup_rules.xml
+++ b/native/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="sharedpref" path="localstream_secure_prefs.xml" />
+</full-backup-content>

--- a/native/app/src/main/res/xml/data_extraction_rules.xml
+++ b/native/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="sharedpref" path="localstream_secure_prefs.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="sharedpref" path="localstream_secure_prefs.xml" />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
## Description
Exclut explicitement le fichier de preferences chiffrees (\localstream_secure_prefs.xml\) du mecanisme d'auto-backup Android pour eviter l'invalidation silencieuse des credentials suite a une restauration sur un autre appareil.

Fixes #137

## Changements
- Ajout de \data_extraction_rules.xml\ pour Android 12+ (API 31+).
- Ajout de \ackup_rules.xml\ pour les versions precedentes d'Android.
- Reference de ces regles dans \AndroidManifest.xml\.
