### PR TITLE
docs: mettre a jour native/README.md (references obsoletes a l'app Capacitor)

### DIFF
--- a/native/README.md
+++ b/native/README.md
@@ -1,26 +1,27 @@
-# LocalStream — module natif Android
+# LocalStream — Application Android Native
 
-Réécriture **100 % native** (Kotlin + Jetpack Compose) de LocalStream, menée en
-parallèle de l'app Capacitor existante (`../android/`). Ce dossier est un projet
-Gradle **indépendant** : il ne partage ni configuration ni build avec l'app Capacitor,
-qui est remplacée par le module natif en Phase 10.
+Application **100 % native** (Kotlin + Jetpack Compose + Material 3) de LocalStream pour Android.
 
-> ✅ `applicationId` **final** : `com.localstream.app` (Phase 10 — reprise de l'identifiant afin d'hériter des installations existantes).
+> `applicationId` : `com.localstream.app`
 
-## Stack
+## Stack technique
 
 | Élément        | Choix                                             |
 | -------------- | ------------------------------------------------- |
 | Langage        | Kotlin 2.0                                         |
 | UI             | Jetpack Compose + Material 3, thème sombre unique  |
 | Lecteur Vidéo  | ExoPlayer (androidx.media3)                        |
-| Architecture   | MVVM simple — `ui/` (screens, composables), `domain/` et `data/` |
+| Base de données| Room (androidx.room)                              |
+| Persistance    | Jetpack DataStore & EncryptedSharedPreferences     |
+| Réseau / API   | Retrofit, OkHttp, kotlinx.serialization            |
+| Images         | Coil Compose                                       |
+| Architecture   | MVVM — `ui/` (screens, composables), `domain/` et `data/` |
 | DI             | Injection manuelle via `AppContainer`              |
 | Navigation     | Navigation Compose                                 |
 | minSdk         | 24                                                 |
 | compileSdk / targetSdk | 36                                         |
 
-## Builder
+## Build & Commandes Gradle
 
 Depuis ce dossier (`native/`) :
 
@@ -31,35 +32,28 @@ Depuis ce dossier (`native/`) :
 # Tests unitaires JVM
 ./gradlew testDebugUnitTest
 
-# Analyse statique
+# Analyse statique (Detekt)
 ./gradlew detekt
 
-# Tout (comme la CI)
+# Tout exécuter (comme la CI)
 ./gradlew assembleDebug testDebugUnitTest detekt
 ```
 
-L'APK est généré dans `app/build/outputs/apk/debug/`.
+L'APK debug est généré dans `app/build/outputs/apk/debug/`.
 
-Prérequis : JDK 17 et un Android SDK (via Android Studio ou `ANDROID_HOME`).
+Prérequis : JDK 17 et Android SDK (configuré via `ANDROID_HOME` ou Android Studio).
 
-## Navigation
+## Navigation & Écrans
 
-`NavHost` (voir `ui/navigation/`) avec les routes : `home`, `search`, `library`,
-`playlists`, `history`, `details/{id}`, `player/{id}`, `settings`.
+Le routage est géré par `NavHost` (`ui/navigation/`) avec une barre de navigation (`LocalStreamBottomBar`) donnant accès aux écrans principaux :
 
-La barre basse (`LocalStreamBottomBar`) reproduit `src/components/BottomNav.tsx`
-avec 4 onglets de premier niveau (masquée pendant la lecture vidéo).
-
-## Cartographie des écrans
-
-| Écran natif (route)      | Source web (`src/`)                         | Onglet       | Statut       |
-| ------------------------ | ------------------------------------------- | ------------ | ------------ |
-| `home`                   | `components/screens/HomeScreen.tsx`         | Accueil      | Phase 7 ✅   |
-| `library`                | `components/screens/LibraryScreen.tsx`      | Bibliothèque | Phase 7 ✅   |
-| `playlists`              | `components/screens/PlaylistsScreen.tsx`    | Listes       | Phase 8 ✅   |
-| `history`                | `components/screens/HistoryScreen.tsx`      | Historique   | Phase 8 ✅   |
-| `search`                 | `components/screens/SearchScreen.tsx`       | —            | Phase 7 ✅   |
-| `settings`               | `components/SettingsModal.tsx`              | —            | Phase 8 ✅   |
-| `details/{id}`           | vue Héro / détails                          | —            | Phase 8 ✅   |
-| `player/{id}`            | `components/WebPlayer.tsx` / `PlayerActivity`| —            | Phase 9 ✅   |
-
+| Route            | Composable / Écran natif                       | Onglet / Description              |
+| ---------------- | ---------------------------------------------- | --------------------------------- |
+| `home`           | `com.localstream.app.ui.screens.HomeScreen`     | Accueil (Hero, reprises, récents) |
+| `library`        | `com.localstream.app.ui.screens.LibraryScreen`  | Bibliothèque (Films / Séries)     |
+| `playlists`      | `com.localstream.app.ui.screens.PlaylistsScreen`| Listes de lecture utilisateur     |
+| `history`        | `com.localstream.app.ui.screens.HistoryScreen`  | Historique de visionnage          |
+| `search`         | `com.localstream.app.ui.screens.SearchScreen`   | Recherche locale et filtres       |
+| `settings`       | `com.localstream.app.ui.screens.SettingsScreen` | Paramètres & clés API             |
+| `details/{id}`   | `com.localstream.app.ui.screens.DetailsScreen`  | Fiche détaillée film / série      |
+| `player/{id}`    | `com.localstream.app.ui.player.PlayerScreen`    | Lecteur vidéo ExoPlayer plein écran |


### PR DESCRIPTION
## Description
Met a jour la documentation dans \
ative/README.md\ pour supprimer les references obsoletes a l'ancienne application Capacitor (\../android/\ et fichiers \.tsx\) et documenter l'architecture 100% native (Compose / MVVM / Media3).

Fixes #138

## Changements
- Suppression des mentions d'un developpement parallele avec Capacitor.
- Mise a jour du tableau de navigation et cartographie des ecrans vers les classes et composables Kotlin existants.
