### PR TITLE
perf(scanner): éliminer le double scan MediaStore au démarrage et optimiser la requête sous-titres

### DIFF
--- a/native/app/src/main/java/com/localstream/app/data/repository/VideoRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/VideoRepository.kt
@@ -33,6 +33,7 @@ class VideoRepository(
             whitelistedVideos = whitelistedVideos,
             movieCollections = movieCollections,
             releaseDates = releaseDates,
+            rawVideos = rawVideos,
         )
         _videosFlow.value = groupedVideos
         return groupedVideos

--- a/native/app/src/main/java/com/localstream/app/data/scanner/MediaScanner.kt
+++ b/native/app/src/main/java/com/localstream/app/data/scanner/MediaScanner.kt
@@ -13,6 +13,7 @@ interface MediaScanner {
     fun scanAndGroup(
         whitelistedVideos: Set<String> = emptySet(),
         movieCollections: Map<String, MovieCollection> = emptyMap(),
-        releaseDates: Map<String, String> = emptyMap()
+        releaseDates: Map<String, String> = emptyMap(),
+        rawVideos: List<VideoItem>? = null,
     ): List<VideoItem>
 }

--- a/native/app/src/main/java/com/localstream/app/data/scanner/MediaStoreScanner.kt
+++ b/native/app/src/main/java/com/localstream/app/data/scanner/MediaStoreScanner.kt
@@ -172,7 +172,10 @@ class MediaStoreScanner(
             MediaStore.Files.FileColumns.DISPLAY_NAME
         )
 
-        val selection = "${MediaStore.Files.FileColumns.DATA} LIKE '%.srt' OR ${MediaStore.Files.FileColumns.DATA} LIKE '%.vtt'"
+        val selection = "${MediaStore.Files.FileColumns.DISPLAY_NAME} LIKE '%.srt' OR " +
+            "${MediaStore.Files.FileColumns.DISPLAY_NAME} LIKE '%.vtt' OR " +
+            "${MediaStore.Files.FileColumns.DISPLAY_NAME} LIKE '%.ass' OR " +
+            "${MediaStore.Files.FileColumns.DISPLAY_NAME} LIKE '%.ssa'"
 
         val cursor = resolver.query(
             MediaStore.Files.getContentUri("external"),
@@ -205,13 +208,14 @@ class MediaStoreScanner(
     override fun scanAndGroup(
         whitelistedVideos: Set<String>,
         movieCollections: Map<String, MovieCollection>,
-        releaseDates: Map<String, String>
+        releaseDates: Map<String, String>,
+        rawVideos: List<VideoItem>?,
     ): List<VideoItem> {
-        val rawVideos = scanVideoFiles()
+        val videos = rawVideos ?: scanVideoFiles()
         val subtitles = scanSubtitleFiles()
         val subIndex = VideoNameParser.buildSubtitleIndex(subtitles)
 
-        val videosWithSubtitles = rawVideos.map { video ->
+        val videosWithSubtitles = videos.map { video ->
             val folder = VideoNameParser.parentFolder(video.path)
             val matchedSub = VideoNameParser.matchSubtitle(subIndex, video.name, folder)
             if (matchedSub != null) {

--- a/native/app/src/main/java/com/localstream/app/di/NoOpTestDoubles.kt
+++ b/native/app/src/main/java/com/localstream/app/di/NoOpTestDoubles.kt
@@ -37,6 +37,7 @@ class NoOpScanner : MediaScanner {
         whitelistedVideos: Set<String>,
         movieCollections: Map<String, MovieCollection>,
         releaseDates: Map<String, String>,
+        rawVideos: List<VideoItem>?,
     ): List<VideoItem> = emptyList()
 }
 

--- a/native/app/src/test/java/com/localstream/app/data/MediaStoreScannerTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/MediaStoreScannerTest.kt
@@ -87,4 +87,31 @@ class MediaStoreScannerTest {
         }
         assertEquals(2, result.size)
     }
+
+    @Test
+    fun scanSubtitleFiles_findsAssAndSsa() {
+        File(tempDir, "Anime.ass").createNewFile()
+        File(tempDir, "Anime.ssa").createNewFile()
+
+        val scanner = MediaStoreScanner(context = null, customDirectories = listOf(tempDir))
+        val subs = scanner.scanSubtitleFiles()
+
+        assertEquals(2, subs.size)
+        assertTrue(subs.any { it.name == "Anime.ass" })
+        assertTrue(subs.any { it.name == "Anime.ssa" })
+    }
+
+    @Test
+    fun scanAndGroup_withRawVideos_reusesPassedVideos() {
+        val preScanned = listOf(
+            VideoItem(url = "file://custom/Item1.mkv", name = "Item1.mkv"),
+            VideoItem(url = "file://custom/Item2.mkv", name = "Item2.mkv"),
+        )
+        val scanner = MediaStoreScanner(context = null, customDirectories = listOf(tempDir))
+        val result = scanner.scanAndGroup(rawVideos = preScanned)
+
+        assertEquals(2, result.size)
+        assertTrue(result.any { it.name == "Item1.mkv" })
+        assertTrue(result.any { it.name == "Item2.mkv" })
+    }
 }

--- a/native/app/src/test/java/com/localstream/app/data/VideoRepositoryTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/VideoRepositoryTest.kt
@@ -53,6 +53,30 @@ class VideoRepositoryTest {
         val emptyRepo = VideoRepository(FakeMediaScanner(emptyList()))
         assertEquals(0, emptyRepo.scanAndLoad().size)
     }
+
+    @Test
+    fun scanAndLoad_callsScanVideoFilesOnlyOnce() {
+        var scanCount = 0
+        val countingScanner = object : MediaScanner {
+            override fun scanVideoFiles(): List<VideoItem> {
+                scanCount++
+                return listOf(VideoItem(url = "file://test.mp4", name = "Test.mp4"))
+            }
+            override fun scanSubtitleFiles() = emptyList<SubtitleEntry>()
+            override fun scanAndGroup(
+                whitelistedVideos: Set<String>,
+                movieCollections: Map<String, MovieCollection>,
+                releaseDates: Map<String, String>,
+                rawVideos: List<VideoItem>?,
+            ): List<VideoItem> {
+                val list = rawVideos ?: scanVideoFiles()
+                return list
+            }
+        }
+        val repo = VideoRepository(countingScanner)
+        repo.scanAndLoad()
+        assertEquals(1, scanCount)
+    }
 }
 
 private class FakeMediaScanner(private val videos: List<VideoItem>) : MediaScanner {
@@ -62,8 +86,9 @@ private class FakeMediaScanner(private val videos: List<VideoItem>) : MediaScann
         whitelistedVideos: Set<String>,
         movieCollections: Map<String, MovieCollection>,
         releaseDates: Map<String, String>,
+        rawVideos: List<VideoItem>?,
     ): List<VideoItem> {
-        // Regroupement minimal pour les tests (utilise le VideoGrouper r\u00e9el)
-        return com.localstream.app.domain.VideoGrouper.groupVideos(videos, movieCollections, releaseDates, whitelistedVideos)
+        // Regroupement minimal pour les tests (utilise le VideoGrouper réel)
+        return com.localstream.app.domain.VideoGrouper.groupVideos(rawVideos ?: videos, movieCollections, releaseDates, whitelistedVideos)
     }
 }

--- a/native/app/src/test/java/com/localstream/app/ui/details/DetailsViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/details/DetailsViewModelTest.kt
@@ -179,6 +179,7 @@ class DetailsViewModelTest {
             whitelistedVideos: Set<String>,
             movieCollections: Map<String, MovieCollection>,
             releaseDates: Map<String, String>,
+            rawVideos: List<VideoItem>?,
         ): List<VideoItem> = groupedVideos
     }
 

--- a/native/app/src/test/java/com/localstream/app/ui/history/HistoryViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/history/HistoryViewModelTest.kt
@@ -92,6 +92,7 @@ class HistoryViewModelTest {
             whitelistedVideos: Set<String>,
             movieCollections: Map<String, MovieCollection>,
             releaseDates: Map<String, String>,
+            rawVideos: List<VideoItem>?,
         ): List<VideoItem> = emptyList()
     }
 

--- a/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
@@ -192,6 +192,7 @@ class LibraryViewModelTest {
             whitelistedVideos: Set<String>,
             movieCollections: Map<String, MovieCollection>,
             releaseDates: Map<String, String>,
+            rawVideos: List<VideoItem>?,
         ): List<VideoItem> = groupedVideos
     }
 

--- a/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
@@ -434,6 +434,7 @@ class PlayerViewModelTest {
             whitelistedVideos: Set<String>,
             movieCollections: Map<String, MovieCollection>,
             releaseDates: Map<String, String>,
+            rawVideos: List<VideoItem>?,
         ): List<VideoItem> = grouped
     }
 

--- a/native/app/src/test/java/com/localstream/app/ui/playlists/PlaylistsViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/playlists/PlaylistsViewModelTest.kt
@@ -98,6 +98,7 @@ class PlaylistsViewModelTest {
             whitelistedVideos: Set<String>,
             movieCollections: Map<String, MovieCollection>,
             releaseDates: Map<String, String>,
+            rawVideos: List<VideoItem>?,
         ): List<VideoItem> = emptyList()
     }
 


### PR DESCRIPTION
Closes #146

### Changements apportés
- Élimination du double scan MediaStore lors de VideoRepository.scanAndLoad() en passant awVideos directement à scanAndGroup().
- Optimisation de la requête scanSubtitleFiles() via MediaStore.Files.FileColumns.DISPLAY_NAME et support des extensions .ass / .ssa pour éviter le full table scan non-indexé sur _data.
- Mise à jour des tests unitaires et ajout de tests de non-redondance du scan.