### PR TITLE
perf(player): découpler la synchronisation de position pour éviter la recomposition globale du PlayerScreen

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/BottomPlayerBar.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/BottomPlayerBar.kt
@@ -100,12 +100,6 @@ fun BottomPlayerBar(
             }
         }
 
-        val sliderValue = if (durationMs > 0L) {
-            displayPos.coerceIn(0L, durationMs).toFloat()
-        } else {
-            0f
-        }
-
         Slider(
             value = sliderValue,
             onValueChange = {

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerControlsOverlay.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerControlsOverlay.kt
@@ -11,6 +11,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.StateFlow
+
 @Composable
 fun PlayerControlsOverlay(
     isVisible: Boolean,
@@ -20,7 +24,6 @@ fun PlayerControlsOverlay(
     playbackSpeed: Float,
     isPlaying: Boolean,
     hasNextVideo: Boolean,
-    positionMs: Long,
     durationMs: Long,
     onBack: () -> Unit,
     onOpenTracks: () -> Unit,
@@ -34,7 +37,16 @@ fun PlayerControlsOverlay(
     onToggleLock: () -> Unit,
     onEnterPip: () -> Unit,
     modifier: Modifier = Modifier,
+    positionMs: Long = 0L,
+    positionMsFlow: StateFlow<Long>? = null,
 ) {
+    val currentPosition = if (positionMsFlow != null) {
+        val pos by positionMsFlow.collectAsStateWithLifecycle()
+        pos
+    } else {
+        positionMs
+    }
+
     AnimatedVisibility(
         visible = isVisible && !isLocked,
         enter = fadeIn(),
@@ -68,7 +80,7 @@ fun PlayerControlsOverlay(
             )
 
             BottomPlayerBar(
-                positionMs = positionMs,
+                positionMs = currentPosition,
                 durationMs = durationMs,
                 isLocked = isLocked,
                 onSeek = onSeek,

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
@@ -605,7 +605,7 @@ fun PlayerScreen(
             playbackSpeed = uiState.playbackSpeed,
             isPlaying = uiState.isPlaying,
             hasNextVideo = uiState.nextVideo != null,
-            positionMs = uiState.positionMs,
+            positionMsFlow = viewModel.positionMs,
             durationMs = uiState.durationMs,
             onBack = onBack,
             onOpenTracks = { showTracksSheet = true },

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -90,6 +90,9 @@ class PlayerViewModel(
     private val _uiState = MutableStateFlow(PlayerUiState())
     val uiState: StateFlow<PlayerUiState> = _uiState.asStateFlow()
 
+    private val _positionMs = MutableStateFlow(0L)
+    val positionMs: StateFlow<Long> = _positionMs.asStateFlow()
+
     private data class SavePositionRequest(
         val videoName: String,
         val positionMs: Long,
@@ -144,6 +147,7 @@ class PlayerViewModel(
                 val pct = state?.progressPct ?: 0.0
                 val pos = if (isFinished(isWatched, pct, rawPos, targetVideo.duration * 1000L)) 0L else rawPos
 
+                _positionMs.value = pos
                 _uiState.update {
                     it.copy(
                         initialPositionMs = pos,
@@ -174,6 +178,7 @@ class PlayerViewModel(
                 0L
             }
 
+            _positionMs.value = pos
             _uiState.update {
                 it.copy(
                     initialPositionMs = pos,
@@ -258,9 +263,9 @@ class PlayerViewModel(
     }
 
     fun onPositionChanged(positionMs: Long, durationMs: Long) {
-        _uiState.update { state ->
-            val newDur = if (durationMs > 0L) durationMs else state.durationMs
-            state.copy(positionMs = positionMs, durationMs = newDur)
+        _positionMs.value = positionMs
+        if (durationMs > 0L && durationMs != _uiState.value.durationMs) {
+            _uiState.update { it.copy(durationMs = durationMs) }
         }
         val video = _uiState.value.currentVideo ?: return
 
@@ -288,7 +293,7 @@ class PlayerViewModel(
 
     private fun saveCurrentPosition() {
         val video = _uiState.value.currentVideo ?: return
-        val pos = _uiState.value.positionMs
+        val pos = _positionMs.value
         val dur = _uiState.value.durationMs
         if (pos > 0L) {
             viewModelScope.launch {
@@ -414,8 +419,10 @@ class PlayerViewModel(
     }
 
     fun seekBy(deltaMs: Long) {
-        val state = _uiState.value
-        val newPos = (state.positionMs + deltaMs).coerceIn(0L, state.durationMs.coerceAtLeast(1L))
+        val curPos = _positionMs.value
+        val dur = _uiState.value.durationMs
+        val newPos = (curPos + deltaMs).coerceIn(0L, dur.coerceAtLeast(1L))
+        _positionMs.value = newPos
         val type = if (deltaMs >= 0) FeedbackType.SEEK_FORWARD else FeedbackType.SEEK_REWIND
         val text = if (deltaMs >= 0) "+10s" else "-10s"
         _uiState.update {
@@ -523,6 +530,7 @@ class PlayerViewModel(
                 0L
             }
 
+            _positionMs.value = pos
             _uiState.update {
                 it.copy(
                     initialPositionMs = pos,

--- a/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
@@ -422,6 +422,19 @@ class PlayerViewModelTest {
         assertEquals(ep2.name, state.nextVideo?.name)
     }
 
+    @Test
+    fun `onPositionChanged updates positionMs StateFlow`() = runTest {
+        val viewModel = PlayerViewModel(video1.name, container)
+        backgroundScope.launch { viewModel.uiState.collect {} }
+        backgroundScope.launch { viewModel.positionMs.collect {} }
+        advanceUntilIdle()
+
+        viewModel.onPositionChanged(positionMs = 42000L, durationMs = 100000L)
+        advanceUntilIdle()
+
+        assertEquals(42000L, viewModel.positionMs.value)
+    }
+
     // -------- Fakes --------
 
     private class FakeScanner(


### PR DESCRIPTION
Closes #149

### Changements apportés
- Isolation de la position haute fréquence (250ms) dans un StateFlow<Long> dédié (positionMs) au sein de PlayerViewModel.
- Élimination de la mise à jour de _uiState à chaque tick afin d'éviter la recomposition racine de PlayerScreen et de AndroidView(PlayerView).
- Observation ciblée de positionMsFlow dans PlayerControlsOverlay et BottomPlayerBar.
- Nettoyage de la double déclaration et du recalcul masqué de sliderValue dans BottomPlayerBar.