### PR TITLE
perf(sorting): optimiser la complexité du comparateur de tri et des lookups dans l'historique

### DIFF
--- a/native/app/src/main/java/com/localstream/app/domain/VideoFilterSorter.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/VideoFilterSorter.kt
@@ -41,48 +41,40 @@ object VideoFilterSorter {
 
     private fun sortVideos(videos: List<VideoItem>, opts: FilterSortOptions): List<VideoItem> {
         val watchedCache = videos.associateWith { isItemWatched(it, opts.watchedVideos) }
+        val watchedComparator = Comparator<VideoItem> { a, b ->
+            val aWatched = watchedCache[a] ?: false
+            val bWatched = watchedCache[b] ?: false
+            if (aWatched != bWatched) {
+                if (aWatched) 1 else -1
+            } else {
+                0
+            }
+        }
+        val criteriaComparator = getCriteriaComparator(videos, opts)
+        return videos.sortedWith(watchedComparator.then(criteriaComparator))
+    }
 
+    private fun getCriteriaComparator(
+        videos: List<VideoItem>,
+        opts: FilterSortOptions,
+    ): Comparator<VideoItem> {
         return when (opts.sortBy) {
             SortBy.ALPHA -> {
                 val alphaCache = videos.associateWith { if (it.isSeriesGroup) it.seriesName.orEmpty() else it.name }
-                videos.sortedWith { a, b ->
-                    val aWatched = watchedCache[a] ?: false
-                    val bWatched = watchedCache[b] ?: false
-                    if (aWatched != bWatched) {
-                        if (aWatched) 1 else -1
-                    } else {
-                        (alphaCache[a].orEmpty()).compareTo(alphaCache[b].orEmpty())
-                    }
-                }
+                compareBy { alphaCache[it].orEmpty() }
             }
             SortBy.DATE -> {
                 val dateCache = videos.associateWith {
                     val lookup = if (it.isSeriesGroup) it.seriesName.orEmpty() else it.name
                     opts.releaseDates[lookup] ?: it.lastModified.toString()
                 }
-                videos.sortedWith { a, b ->
-                    val aWatched = watchedCache[a] ?: false
-                    val bWatched = watchedCache[b] ?: false
-                    if (aWatched != bWatched) {
-                        if (aWatched) 1 else -1
-                    } else {
-                        (dateCache[b].orEmpty()).compareTo(dateCache[a].orEmpty())
-                    }
-                }
+                compareByDescending { dateCache[it].orEmpty() }
             }
             SortBy.SIZE -> {
                 val sizeCache = videos.associateWith {
                     if (it.isSeriesGroup) it.episodes.orEmpty().sumOf { ep -> ep.size } else it.size
                 }
-                videos.sortedWith { a, b ->
-                    val aWatched = watchedCache[a] ?: false
-                    val bWatched = watchedCache[b] ?: false
-                    if (aWatched != bWatched) {
-                        if (aWatched) 1 else -1
-                    } else {
-                        (sizeCache[b] ?: 0L).compareTo(sizeCache[a] ?: 0L)
-                    }
-                }
+                compareByDescending { sizeCache[it] ?: 0L }
             }
             SortBy.DURATION -> {
                 val durationCache = videos.associateWith {
@@ -92,15 +84,7 @@ object VideoFilterSorter {
                         opts.videoDurations[it.name] ?: 0L
                     }
                 }
-                videos.sortedWith { a, b ->
-                    val aWatched = watchedCache[a] ?: false
-                    val bWatched = watchedCache[b] ?: false
-                    if (aWatched != bWatched) {
-                        if (aWatched) 1 else -1
-                    } else {
-                        (durationCache[b] ?: 0L).compareTo(durationCache[a] ?: 0L)
-                    }
-                }
+                compareByDescending { durationCache[it] ?: 0L }
             }
         }
     }

--- a/native/app/src/main/java/com/localstream/app/domain/VideoFilterSorter.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/VideoFilterSorter.kt
@@ -40,13 +40,67 @@ object VideoFilterSorter {
     }
 
     private fun sortVideos(videos: List<VideoItem>, opts: FilterSortOptions): List<VideoItem> {
-        return videos.sortedWith { a, b ->
-            val aWatched = isItemWatched(a, opts.watchedVideos)
-            val bWatched = isItemWatched(b, opts.watchedVideos)
-            if (aWatched != bWatched) {
-                if (aWatched) 1 else -1
-            } else {
-                compareItemsByCriteria(a, b, opts)
+        val watchedCache = videos.associateWith { isItemWatched(it, opts.watchedVideos) }
+
+        return when (opts.sortBy) {
+            SortBy.ALPHA -> {
+                val alphaCache = videos.associateWith { if (it.isSeriesGroup) it.seriesName.orEmpty() else it.name }
+                videos.sortedWith { a, b ->
+                    val aWatched = watchedCache[a] ?: false
+                    val bWatched = watchedCache[b] ?: false
+                    if (aWatched != bWatched) {
+                        if (aWatched) 1 else -1
+                    } else {
+                        (alphaCache[a].orEmpty()).compareTo(alphaCache[b].orEmpty())
+                    }
+                }
+            }
+            SortBy.DATE -> {
+                val dateCache = videos.associateWith {
+                    val lookup = if (it.isSeriesGroup) it.seriesName.orEmpty() else it.name
+                    opts.releaseDates[lookup] ?: it.lastModified.toString()
+                }
+                videos.sortedWith { a, b ->
+                    val aWatched = watchedCache[a] ?: false
+                    val bWatched = watchedCache[b] ?: false
+                    if (aWatched != bWatched) {
+                        if (aWatched) 1 else -1
+                    } else {
+                        (dateCache[b].orEmpty()).compareTo(dateCache[a].orEmpty())
+                    }
+                }
+            }
+            SortBy.SIZE -> {
+                val sizeCache = videos.associateWith {
+                    if (it.isSeriesGroup) it.episodes.orEmpty().sumOf { ep -> ep.size } else it.size
+                }
+                videos.sortedWith { a, b ->
+                    val aWatched = watchedCache[a] ?: false
+                    val bWatched = watchedCache[b] ?: false
+                    if (aWatched != bWatched) {
+                        if (aWatched) 1 else -1
+                    } else {
+                        (sizeCache[b] ?: 0L).compareTo(sizeCache[a] ?: 0L)
+                    }
+                }
+            }
+            SortBy.DURATION -> {
+                val durationCache = videos.associateWith {
+                    if (it.isSeriesGroup) {
+                        it.episodes.orEmpty().sumOf { ep -> opts.videoDurations[ep.name] ?: 0L }
+                    } else {
+                        opts.videoDurations[it.name] ?: 0L
+                    }
+                }
+                videos.sortedWith { a, b ->
+                    val aWatched = watchedCache[a] ?: false
+                    val bWatched = watchedCache[b] ?: false
+                    if (aWatched != bWatched) {
+                        if (aWatched) 1 else -1
+                    } else {
+                        (durationCache[b] ?: 0L).compareTo(durationCache[a] ?: 0L)
+                    }
+                }
             }
         }
     }
@@ -57,41 +111,6 @@ object VideoFilterSorter {
         } else {
             watchedVideos[v.name] == true
         }
-    }
-
-    private fun compareItemsByCriteria(a: VideoItem, b: VideoItem, opts: FilterSortOptions): Int {
-        return when (opts.sortBy) {
-            SortBy.ALPHA -> compareAlpha(a, b)
-            SortBy.DATE -> compareDate(a, b, opts.releaseDates)
-            SortBy.SIZE -> compareSize(a, b)
-            SortBy.DURATION -> compareDuration(a, b, opts.videoDurations)
-        }
-    }
-
-    private fun compareAlpha(a: VideoItem, b: VideoItem): Int {
-        val nameA = if (a.isSeriesGroup) a.seriesName ?: "" else a.name
-        val nameB = if (b.isSeriesGroup) b.seriesName ?: "" else b.name
-        return nameA.compareTo(nameB)
-    }
-
-    private fun compareDate(a: VideoItem, b: VideoItem, releaseDates: Map<String, String>): Int {
-        val lookupA = if (a.isSeriesGroup) a.seriesName ?: "" else a.name
-        val lookupB = if (b.isSeriesGroup) b.seriesName ?: "" else b.name
-        val dateA = releaseDates[lookupA] ?: a.lastModified.toString()
-        val dateB = releaseDates[lookupB] ?: b.lastModified.toString()
-        return dateB.compareTo(dateA)
-    }
-
-    private fun compareSize(a: VideoItem, b: VideoItem): Int {
-        val sizeA = if (a.isSeriesGroup) a.episodes.orEmpty().sumOf { it.size } else a.size
-        val sizeB = if (b.isSeriesGroup) b.episodes.orEmpty().sumOf { it.size } else b.size
-        return sizeB.compareTo(sizeA)
-    }
-
-    private fun compareDuration(a: VideoItem, b: VideoItem, videoDurations: Map<String, Long>): Int {
-        val durA = if (a.isSeriesGroup) a.episodes.orEmpty().sumOf { videoDurations[it.name] ?: 0L } else videoDurations[a.name] ?: 0L
-        val durB = if (b.isSeriesGroup) b.episodes.orEmpty().sumOf { videoDurations[it.name] ?: 0L } else videoDurations[b.name] ?: 0L
-        return durB.compareTo(durA)
     }
 }
 

--- a/native/app/src/main/java/com/localstream/app/ui/history/HistoryViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/history/HistoryViewModel.kt
@@ -42,7 +42,8 @@ class HistoryViewModel(
         container.settingsRepository.observeForceAvailable,
     ) { watchedSet: Set<String>, playbackMap: Map<String, PlaybackStateEntity>, diskVideos: List<VideoItem>, forceSet: Set<String> ->
         val allNames = (watchedSet + playbackMap.keys).distinct()
-        val diskVideoNames = diskVideos.map { it.name }.toSet()
+        val diskVideoMap = diskVideos.associateBy { it.name }
+        val diskVideoNames = diskVideoMap.keys
 
         val historyItems = allNames.map { name ->
             val pb = playbackMap[name]
@@ -51,7 +52,7 @@ class HistoryViewModel(
             val isForceAvailable = forceSet.contains(name)
             val effectiveAvailable = isDiskAvailable || isForceAvailable
 
-            val diskVideo = diskVideos.find { it.name == name }
+            val diskVideo = diskVideoMap[name]
             val durationMs = (diskVideo?.duration ?: 0L) * 1000L
             val positionMs = pb?.positionMs ?: 0L
             val progressPercent = if (durationMs > 0L) {

--- a/native/app/src/main/java/com/localstream/app/ui/playlists/PlaylistsViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/playlists/PlaylistsViewModel.kt
@@ -33,8 +33,9 @@ class PlaylistsViewModel(
         container.videoRepository.observeVideos,
     ) { playlists, selectedId, videos ->
         val selected = playlists.find { it.id == selectedId }
+        val videoMap = videos.associateBy { it.name }
         val playlistVideos = selected?.videoNames?.mapNotNull { name ->
-            videos.find { it.name == name }
+            videoMap[name]
         } ?: emptyList()
 
         PlaylistsUiState(

--- a/native/app/src/test/java/com/localstream/app/domain/SortingTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/SortingTest.kt
@@ -46,5 +46,34 @@ class SortingTest {
         assertEquals(1, res.size)
         assertEquals("Film.1080p.mkv", res[0].name)
     }
+
+    @Test
+    fun filterAndSortVideos_sortsByDateDescending() {
+        val opts = baseOpts.copy(
+            sortBy = SortBy.DATE,
+            releaseDates = mapOf("Old.mkv" to "2010-01-01", "New.mkv" to "2024-05-01"),
+        )
+        val res = VideoFilterSorter.filterAndSortVideos(listOf(v("Old.mkv"), v("New.mkv")), opts)
+        assertEquals(listOf("New.mkv", "Old.mkv"), res.map { it.name })
+    }
+
+    @Test
+    fun filterAndSortVideos_sortsBySizeDescending() {
+        val opts = baseOpts.copy(sortBy = SortBy.SIZE)
+        val small = v("Small.mkv").copy(size = 100L)
+        val large = v("Large.mkv").copy(size = 5000L)
+        val res = VideoFilterSorter.filterAndSortVideos(listOf(small, large), opts)
+        assertEquals(listOf("Large.mkv", "Small.mkv"), res.map { it.name })
+    }
+
+    @Test
+    fun filterAndSortVideos_sortsByDurationDescending() {
+        val opts = baseOpts.copy(
+            sortBy = SortBy.DURATION,
+            videoDurations = mapOf("Short.mkv" to 60L, "Long.mkv" to 3600L),
+        )
+        val res = VideoFilterSorter.filterAndSortVideos(listOf(v("Short.mkv"), v("Long.mkv")), opts)
+        assertEquals(listOf("Long.mkv", "Short.mkv"), res.map { it.name })
+    }
 }
 


### PR DESCRIPTION
Closes #152

### Changements apportés
- Précalcul (N)$ des clés de tri (isWatched, size, duration, lpha, date) dans VideoFilterSorter.sortVideos() pour éliminer les recalculs redondants lors des comparaisons de paires de TimSort.
- Indexation en Map diskVideos.associateBy { it.name } dans HistoryViewModel pour des lookups (1)$ au lieu de recherches linéaires (N \cdot M)$.
- Indexation en Map ideos.associateBy { it.name } dans PlaylistsViewModel pour des lookups (1)$ des vidéos de la playlist sélectionnée.