### PR TITLE
perf: restaurer le skip Compose avec VideoDisplayData et debouncer le streaming TMDB

### DIFF
--- a/native/app/src/main/java/com/localstream/app/domain/VideoUiSelectors.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/VideoUiSelectors.kt
@@ -1,6 +1,7 @@
 package com.localstream.app.domain
 
 import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoDisplayData
 import com.localstream.app.domain.model.VideoItem
 
 /**
@@ -8,6 +9,12 @@ import com.localstream.app.domain.model.VideoItem
  * Portage exact de la logique de `VideoRow.tsx` / `VideoCard.tsx` (Phase 0).
  */
 object VideoUiSelectors {
+
+    /**
+     * "Vu" d'un item via [VideoDisplayData].
+     */
+    fun isWatched(video: VideoItem, displayData: VideoDisplayData): Boolean =
+        isWatched(video, displayData.watched)
 
     /**
      * "Vu" d'un item : pour un groupe (série/saga), tous les épisodes doivent
@@ -27,6 +34,12 @@ object VideoUiSelectors {
     }
 
     /**
+     * Progression affichée (0-100) via [VideoDisplayData].
+     */
+    fun progressOf(video: VideoItem, displayData: VideoDisplayData): Double =
+        progressOf(video, displayData.progress)
+
+    /**
      * Progression affichée (0-100) : pour un groupe, la progression est stockée
      * par épisode — on retient celle du premier épisode en cours (0 < p < 100).
      */
@@ -42,6 +55,12 @@ object VideoUiSelectors {
         }
         return progress[video.name] ?: 0.0
     }
+
+    /**
+     * Identifie l'épisode actif via [VideoDisplayData].
+     */
+    fun getActiveEpisode(video: VideoItem, displayData: VideoDisplayData): VideoItem? =
+        getActiveEpisode(video, displayData.progress, displayData.watched)
 
     /**
      * Identifie l'épisode actif (en cours de lecture, ou le prochain non vu) d'une série.
@@ -78,6 +97,12 @@ object VideoUiSelectors {
     }
 
     /**
+     * Libellé d'épisode actif via [VideoDisplayData].
+     */
+    fun activeEpisodeLabel(video: VideoItem, displayData: VideoDisplayData): String? =
+        activeEpisodeLabel(video, displayData.progress, displayData.watched)
+
+    /**
      * Retourne le libellé de l'épisode actif pour l'affichage sur la carte.
      */
     @Suppress("ReturnCount")
@@ -105,6 +130,12 @@ object VideoUiSelectors {
      * (équivalent du `posterKey` web).
      */
     fun metadataKey(video: VideoItem): String = video.seriesName ?: video.name
+
+    /**
+     * URL d'affiche via [VideoDisplayData].
+     */
+    fun posterUrl(video: VideoItem, displayData: VideoDisplayData): String? =
+        posterUrl(video, displayData.metadata)
 
     /**
      * URL d'affiche avec fallback automatique pour les sagas/groupes si l'affiche

--- a/native/app/src/main/java/com/localstream/app/domain/model/VideoDisplayData.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/VideoDisplayData.kt
@@ -1,0 +1,15 @@
+﻿package com.localstream.app.domain.model
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Regroupe les données dynamiques d'affichage vidéo (métadonnées TMDB, visionnage, progression)
+ * dans une structure @Immutable pour garantir la stabilité Compose et permettre le skipping
+ * des composants VideoGrid, VideoRow et VideoCard.
+ */
+@Immutable
+data class VideoDisplayData(
+    val metadata: Map<String, TmdbMetadata> = emptyMap(),
+    val watched: Map<String, Boolean> = emptyMap(),
+    val progress: Map<String, Double> = emptyMap(),
+)

--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoGrid.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoGrid.kt
@@ -11,20 +11,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.localstream.app.domain.VideoUiSelectors
 import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoDisplayData
 import com.localstream.app.domain.model.VideoItem
 
 /**
  * Grille adaptative d'affiches (réf. grilles de `SearchScreen.tsx` /
  * `LibraryScreen.tsx` : 2 à 6 colonnes selon la largeur, minSize ~110 dp).
- * Clés stables pour limiter les recompositions.
+ * Clés stables pour limiter les recompositions et utilisation de [VideoDisplayData]
+ * (@Immutable) pour restaurer le skipping Compose.
  */
 @Suppress("LongParameterList", "FunctionNaming")
 @Composable
 fun VideoGrid(
     videos: List<VideoItem>,
-    metadata: Map<String, TmdbMetadata>,
-    watched: Map<String, Boolean>,
-    progress: Map<String, Double>,
+    displayData: VideoDisplayData,
     onOpenDetails: (VideoItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -42,14 +42,35 @@ fun VideoGrid(
         ) { video ->
             VideoCard(
                 video = video,
-                posterUrl = VideoUiSelectors.posterUrl(video, metadata),
-                isWatched = VideoUiSelectors.isWatched(video, watched),
-                progress = VideoUiSelectors.progressOf(video, progress),
-                episodeLabel = VideoUiSelectors.activeEpisodeLabel(video, progress, watched),
+                posterUrl = VideoUiSelectors.posterUrl(video, displayData),
+                isWatched = VideoUiSelectors.isWatched(video, displayData),
+                progress = VideoUiSelectors.progressOf(video, displayData),
+                episodeLabel = VideoUiSelectors.activeEpisodeLabel(video, displayData),
                 showResetProgress = false,
                 onClick = { onOpenDetails(video) },
                 onResetProgress = {},
             )
         }
     }
+}
+
+/**
+ * Surcharge de compatibilité pour [VideoGrid].
+ */
+@Suppress("LongParameterList", "FunctionNaming")
+@Composable
+fun VideoGrid(
+    videos: List<VideoItem>,
+    metadata: Map<String, TmdbMetadata>,
+    watched: Map<String, Boolean>,
+    progress: Map<String, Double>,
+    onOpenDetails: (VideoItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    VideoGrid(
+        videos = videos,
+        displayData = VideoDisplayData(metadata = metadata, watched = watched, progress = progress),
+        onOpenDetails = onOpenDetails,
+        modifier = modifier,
+    )
 }

--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoRow.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoRow.kt
@@ -15,21 +15,21 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.localstream.app.domain.VideoUiSelectors
 import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoDisplayData
 import com.localstream.app.domain.model.VideoItem
 import com.localstream.app.ui.theme.White
 
 /**
  * Carrousel horizontal d'affiches (équivalent Compose de `VideoRow.tsx`).
- * Clés stables pour éviter les recompositions inutiles au fil des mises à jour.
+ * Clés stables pour éviter les recompositions inutiles au fil des mises à jour,
+ * et utilisation de [VideoDisplayData] (@Immutable) pour restaurer le skipping Compose.
  */
 @Suppress("LongParameterList", "FunctionNaming")
 @Composable
 fun VideoRow(
     title: String,
     items: List<VideoItem>,
-    metadata: Map<String, TmdbMetadata>,
-    watched: Map<String, Boolean>,
-    progress: Map<String, Double>,
+    displayData: VideoDisplayData,
     showResetProgress: Boolean,
     onOpenDetails: (VideoItem) -> Unit,
     onResetProgress: (String) -> Unit,
@@ -56,10 +56,10 @@ fun VideoRow(
             ) { video ->
                 VideoCard(
                     video = video,
-                    posterUrl = VideoUiSelectors.posterUrl(video, metadata),
-                    isWatched = VideoUiSelectors.isWatched(video, watched),
-                    progress = VideoUiSelectors.progressOf(video, progress),
-                    episodeLabel = VideoUiSelectors.activeEpisodeLabel(video, progress, watched),
+                    posterUrl = VideoUiSelectors.posterUrl(video, displayData),
+                    isWatched = VideoUiSelectors.isWatched(video, displayData),
+                    progress = VideoUiSelectors.progressOf(video, displayData),
+                    episodeLabel = VideoUiSelectors.activeEpisodeLabel(video, displayData),
                     showResetProgress = showResetProgress,
                     onClick = { onOpenDetails(video) },
                     onResetProgress = { onResetProgress(video.name) },
@@ -68,4 +68,31 @@ fun VideoRow(
             }
         }
     }
+}
+
+/**
+ * Surcharge de compatibilité pour [VideoRow].
+ */
+@Suppress("LongParameterList", "FunctionNaming")
+@Composable
+fun VideoRow(
+    title: String,
+    items: List<VideoItem>,
+    metadata: Map<String, TmdbMetadata>,
+    watched: Map<String, Boolean>,
+    progress: Map<String, Double>,
+    showResetProgress: Boolean,
+    onOpenDetails: (VideoItem) -> Unit,
+    onResetProgress: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    VideoRow(
+        title = title,
+        items = items,
+        displayData = VideoDisplayData(metadata = metadata, watched = watched, progress = progress),
+        showResetProgress = showResetProgress,
+        onOpenDetails = onOpenDetails,
+        onResetProgress = onResetProgress,
+        modifier = modifier,
+    )
 }

--- a/native/app/src/main/java/com/localstream/app/ui/home/HomeViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/home/HomeViewModel.kt
@@ -6,8 +6,10 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.localstream.app.domain.HomeRows
 import com.localstream.app.domain.HomeRowsDeriver
 import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoDisplayData
 import com.localstream.app.domain.model.VideoItem
 import com.localstream.app.ui.library.LibraryUiState
 import com.localstream.app.ui.library.LibraryViewModel
@@ -35,11 +37,13 @@ data class HomeUiState(
     val series: List<VideoItem> = emptyList(),
     val movies: List<VideoItem> = emptyList(),
     val alphabetical: List<VideoItem> = emptyList(),
-    val metadata: Map<String, TmdbMetadata> = emptyMap(),
-    val watched: Map<String, Boolean> = emptyMap(),
-    val progress: Map<String, Double> = emptyMap(),
+    val displayData: VideoDisplayData = VideoDisplayData(),
     val showTmdbBanner: Boolean = false,
-)
+) {
+    val metadata: Map<String, TmdbMetadata> get() = displayData.metadata
+    val watched: Map<String, Boolean> get() = displayData.watched
+    val progress: Map<String, Double> get() = displayData.progress
+}
 
 /**
  * ViewModel de l'accueil (Phase 7) : dérive les rows de l'état bibliothèque
@@ -51,8 +55,62 @@ class HomeViewModel(
     computationDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
 
+    private var cachedRows: HomeRows? = null
+    private var lastGrouped: List<VideoItem>? = null
+    private var lastFilteredSorted: List<VideoItem>? = null
+    private var lastWatched: Map<String, Boolean>? = null
+    private var lastProgress: Map<String, Double>? = null
+
+    @Suppress("ComplexCondition")
+    private fun isCacheValid(state: LibraryUiState): Boolean =
+        cachedRows != null &&
+            lastGrouped === state.videos &&
+            lastFilteredSorted === state.filteredSorted &&
+            lastWatched === state.watched &&
+            lastProgress === state.progress
+
+    private fun deriveHomeUiStateWithCache(state: LibraryUiState): HomeUiState {
+        val rows = if (isCacheValid(state)) {
+            cachedRows ?: HomeRowsDeriver.derive(
+                grouped = state.videos,
+                filteredSorted = state.filteredSorted,
+                watched = state.watched,
+                progress = state.progress,
+            )
+        } else {
+            val computed = HomeRowsDeriver.derive(
+                grouped = state.videos,
+                filteredSorted = state.filteredSorted,
+                watched = state.watched,
+                progress = state.progress,
+            )
+            cachedRows = computed
+            lastGrouped = state.videos
+            lastFilteredSorted = state.filteredSorted
+            lastWatched = state.watched
+            lastProgress = state.progress
+            computed
+        }
+        return HomeUiState(
+            isLoading = state.isScanning && state.videos.isEmpty(),
+            isFetchingMetadata = state.isFetchingMetadata,
+            hasContent = state.videos.isNotEmpty(),
+            heroCandidates = rows.heroCandidates,
+            continueWatching = rows.continueWatching,
+            recentAdditions = rows.recentAdditions,
+            recommendations = rows.recommendations,
+            series = rows.series,
+            movies = rows.movies,
+            alphabetical = rows.alphabetical,
+            displayData = state.displayData,
+            showTmdbBanner = state.videos.isNotEmpty() &&
+                !state.hasTmdbKey &&
+                !state.tmdbBannerDismissed,
+        )
+    }
+
     val uiState: StateFlow<HomeUiState> = libraryUiState
-        .map { deriveHomeUiState(it) }
+        .map { deriveHomeUiStateWithCache(it) }
         .flowOn(computationDispatcher)
         .stateIn(
             scope = viewModelScope,
@@ -82,9 +140,7 @@ class HomeViewModel(
                 series = rows.series,
                 movies = rows.movies,
                 alphabetical = rows.alphabetical,
-                metadata = state.metadata,
-                watched = state.watched,
-                progress = state.progress,
+                displayData = state.displayData,
                 showTmdbBanner = state.videos.isNotEmpty() &&
                     !state.hasTmdbKey &&
                     !state.tmdbBannerDismissed,

--- a/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
@@ -18,6 +18,7 @@ import com.localstream.app.domain.model.MovieCollection
 import com.localstream.app.domain.model.ResolutionFilter
 import com.localstream.app.domain.model.SortBy
 import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoDisplayData
 import com.localstream.app.domain.model.VideoItem
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.FlowPreview
@@ -39,8 +40,7 @@ import kotlinx.coroutines.withContext
 /**
  * État de la bibliothèque partagé par les écrans Accueil / Recherche / Bibliothèque.
  * [videos] = groupé (séries + sagas) ; [filteredSorted] = après tri/filtres
- * (VideoFilterSorter, Phase 2) ; [metadata] = métadonnées TMDB indexées par clé
- * de lookup (nom de série pour les groupes, nom de fichier sinon).
+ * (VideoFilterSorter, Phase 2) ; [displayData] = métadonnées TMDB, visionnage et progression (@Immutable).
  */
 @Immutable
 data class LibraryUiState(
@@ -49,10 +49,8 @@ data class LibraryUiState(
     val isFetchingMetadata: Boolean = false,
     val videos: List<VideoItem> = emptyList(),
     val filteredSorted: List<VideoItem> = emptyList(),
-    val metadata: Map<String, TmdbMetadata> = emptyMap(),
+    val displayData: VideoDisplayData = VideoDisplayData(),
     val videoDurations: Map<String, Long> = emptyMap(),
-    val watched: Map<String, Boolean> = emptyMap(),
-    val progress: Map<String, Double> = emptyMap(),
     val sortBy: SortBy = SortBy.ALPHA,
     val filterGenre: Int? = null,
     val filterResolution: ResolutionFilter = ResolutionFilter.ALL,
@@ -60,6 +58,10 @@ data class LibraryUiState(
     val hasTmdbKey: Boolean = false,
     val tmdbBannerDismissed: Boolean = false,
 ) {
+    val metadata: Map<String, TmdbMetadata> get() = displayData.metadata
+    val watched: Map<String, Boolean> get() = displayData.watched
+    val progress: Map<String, Double> get() = displayData.progress
+
     /** Dates de sortie par clé de lookup (tri par date). */
     val releaseDates: Map<String, String>
         get() = metadata.mapNotNull { (key, meta) ->
@@ -193,9 +195,18 @@ class LibraryViewModel(
         }
     }
 
-    /** Récupère les métadonnées par paquets et publie chaque paquet dès réception. */
+    /**
+     * Récupère les métadonnées par paquets en tâche de fond et débounce/accumule
+     * les émissions d'état pour éviter de reconstruire l'arbre UI et d'inonder
+     * le thread principal pendant le scroll initial.
+     */
     private suspend fun fetchMetadataIntoState(videos: List<VideoItem>) {
-        for (chunk in videos.chunked(metadataChunkSize)) {
+        val pendingAdditions = mutableMapOf<String, TmdbMetadata>()
+        var lastEmitTime = System.currentTimeMillis()
+        val chunks = videos.chunked(metadataChunkSize)
+        val totalChunks = chunks.size
+
+        chunks.forEachIndexed { index, chunk ->
             val results = coroutineScope {
                 chunk.map { video ->
                     async(ioDispatcher) {
@@ -203,10 +214,21 @@ class LibraryViewModel(
                     }
                 }.awaitAll()
             }.filterNotNull()
+
             if (results.isNotEmpty()) {
-                val additions = results.associate { it.queryKey to it }
+                results.associateTo(pendingAdditions) { it.queryKey to it }
+            }
+
+            val isLast = index == totalChunks - 1
+            val now = System.currentTimeMillis()
+            val timeSinceLastEmit = now - lastEmitTime
+
+            if (pendingAdditions.isNotEmpty() && (timeSinceLastEmit >= METADATA_EMIT_DEBOUNCE_MS || isLast)) {
+                val additionsToEmit = pendingAdditions.toMap()
+                pendingAdditions.clear()
+                lastEmitTime = now
                 withContext(computationDispatcher) {
-                    _uiState.update { it.withMetadataUpdate(additions) }
+                    _uiState.update { it.withMetadataUpdate(additionsToEmit) }
                 }
             }
         }
@@ -217,12 +239,12 @@ class LibraryViewModel(
     private fun observeWatchState() {
         viewModelScope.launch {
             watchStateRepository.watchedItems.collect { watched ->
-                _uiState.update { it.copy(watched = watched).withDerived() }
+                _uiState.update { it.copy(displayData = it.displayData.copy(watched = watched)).withDerived() }
             }
         }
         viewModelScope.launch {
             watchStateRepository.activePlaybackStates.collect { progress ->
-                _uiState.update { it.copy(progress = progress).withDerived() }
+                _uiState.update { it.copy(displayData = it.displayData.copy(progress = progress)).withDerived() }
             }
         }
     }
@@ -322,13 +344,13 @@ class LibraryViewModel(
      * actifs ne dépendent pas des métadonnées (évite 20 tris complets lors du streaming TMDB).
      */
     private fun LibraryUiState.withMetadataUpdate(additions: Map<String, TmdbMetadata>): LibraryUiState {
-        val newMetadata = metadata + additions
+        val newDisplayData = displayData.copy(metadata = displayData.metadata + additions)
         val needsFilterSort = filterGenre != null || sortBy == SortBy.DATE
         val newFilteredSorted = if (needsFilterSort) {
-            val newReleaseDates = newMetadata.mapNotNull { (key, meta) ->
+            val newReleaseDates = newDisplayData.metadata.mapNotNull { (key, meta) ->
                 meta.releaseDate?.takeIf { it.isNotBlank() }?.let { key to it }
             }.toMap()
-            val newVideoGenres = newMetadata.mapValues { it.value.genreIds }
+            val newVideoGenres = newDisplayData.metadata.mapValues { it.value.genreIds }
             VideoFilterSorter.filterAndSortVideos(
                 videos,
                 FilterSortOptions(
@@ -345,7 +367,7 @@ class LibraryViewModel(
             filteredSorted
         }
         return copy(
-            metadata = newMetadata,
+            displayData = newDisplayData,
             filteredSorted = newFilteredSorted,
             searchResults = if (needsFilterSort) {
                 VideoUiSelectors.filterByQuery(newFilteredSorted, _searchQuery.value)
@@ -359,6 +381,7 @@ class LibraryViewModel(
         const val DEFAULT_METADATA_CHUNK_SIZE = 8
         const val WIFI_METADATA_CHUNK_SIZE = 16
         const val MOBILE_METADATA_CHUNK_SIZE = 4
+        const val METADATA_EMIT_DEBOUNCE_MS = 300L
         private const val SEARCH_DEBOUNCE_MS = 250L
 
         fun factory(container: AppContainer): ViewModelProvider.Factory = viewModelFactory {

--- a/native/app/src/main/java/com/localstream/app/ui/navigation/LocalStreamNavHost.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/navigation/LocalStreamNavHost.kt
@@ -164,9 +164,7 @@ fun LocalStreamApp(navController: NavHostController = rememberNavController()) {
                 SearchScreen(
                     query = query,
                     results = uiState.searchResults,
-                    metadata = uiState.metadata,
-                    watched = uiState.watched,
-                    progress = uiState.progress,
+                    displayData = uiState.displayData,
                     onQueryChange = libraryViewModel::onSearchChange,
                     onOpenDetails = openDetails,
                     onBack = { navController.popBackStack() },

--- a/native/app/src/main/java/com/localstream/app/ui/screens/HomeScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/HomeScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.localstream.app.domain.model.VideoDisplayData
 import com.localstream.app.domain.model.VideoItem
 import com.localstream.app.ui.components.HeroSection
 import com.localstream.app.ui.components.TopBar
@@ -101,7 +102,7 @@ fun HomeScreen(
                         HomeRow(
                             title = "Continuer la lecture",
                             items = uiState.continueWatching,
-                            uiState = uiState,
+                            displayData = uiState.displayData,
                             showResetProgress = true,
                             onOpenDetails = onOpenDetails,
                             onResetProgress = onResetProgress,
@@ -113,7 +114,7 @@ fun HomeScreen(
                     HomeRow(
                         title = "Nouveautés",
                         items = uiState.recentAdditions,
-                        uiState = uiState,
+                        displayData = uiState.displayData,
                         showResetProgress = false,
                         onOpenDetails = onOpenDetails,
                         onResetProgress = onResetProgress,
@@ -124,7 +125,7 @@ fun HomeScreen(
                     HomeRow(
                         title = "Recommandations",
                         items = uiState.recommendations,
-                        uiState = uiState,
+                        displayData = uiState.displayData,
                         showResetProgress = false,
                         onOpenDetails = onOpenDetails,
                         onResetProgress = onResetProgress,
@@ -135,7 +136,7 @@ fun HomeScreen(
                     HomeRow(
                         title = "Séries",
                         items = uiState.series,
-                        uiState = uiState,
+                        displayData = uiState.displayData,
                         showResetProgress = false,
                         onOpenDetails = onOpenDetails,
                         onResetProgress = onResetProgress,
@@ -146,7 +147,7 @@ fun HomeScreen(
                     HomeRow(
                         title = "Films",
                         items = uiState.movies,
-                        uiState = uiState,
+                        displayData = uiState.displayData,
                         showResetProgress = false,
                         onOpenDetails = onOpenDetails,
                         onResetProgress = onResetProgress,
@@ -157,7 +158,7 @@ fun HomeScreen(
                     HomeRow(
                         title = "De A à Z",
                         items = uiState.alphabetical,
-                        uiState = uiState,
+                        displayData = uiState.displayData,
                         showResetProgress = false,
                         onOpenDetails = onOpenDetails,
                         onResetProgress = onResetProgress,
@@ -186,7 +187,7 @@ fun HomeScreen(
 private fun HomeRow(
     title: String,
     items: List<VideoItem>,
-    uiState: HomeUiState,
+    displayData: VideoDisplayData,
     showResetProgress: Boolean,
     onOpenDetails: (VideoItem) -> Unit,
     onResetProgress: (String) -> Unit,
@@ -195,9 +196,7 @@ private fun HomeRow(
     VideoRow(
         title = title,
         items = items,
-        metadata = uiState.metadata,
-        watched = uiState.watched,
-        progress = uiState.progress,
+        displayData = displayData,
         showResetProgress = showResetProgress,
         onOpenDetails = onOpenDetails,
         onResetProgress = onResetProgress,

--- a/native/app/src/main/java/com/localstream/app/ui/screens/LibraryScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/LibraryScreen.kt
@@ -81,9 +81,7 @@ fun LibraryScreen(
         } else {
             VideoGrid(
                 videos = uiState.filteredSorted,
-                metadata = uiState.metadata,
-                watched = uiState.watched,
-                progress = uiState.progress,
+                displayData = uiState.displayData,
                 onOpenDetails = onOpenDetails,
             )
         }

--- a/native/app/src/main/java/com/localstream/app/ui/screens/SearchScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/SearchScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.localstream.app.domain.model.TmdbMetadata
+import com.localstream.app.domain.model.VideoDisplayData
 import com.localstream.app.domain.model.VideoItem
 import com.localstream.app.ui.components.VideoGrid
 import com.localstream.app.ui.theme.Red600
@@ -55,9 +56,7 @@ import com.localstream.app.ui.theme.Zinc900
 fun SearchScreen(
     query: String,
     results: List<VideoItem>,
-    metadata: Map<String, TmdbMetadata>,
-    watched: Map<String, Boolean>,
-    progress: Map<String, Double>,
+    displayData: VideoDisplayData,
     onQueryChange: (String) -> Unit,
     onOpenDetails: (VideoItem) -> Unit,
     onBack: () -> Unit,
@@ -137,13 +136,37 @@ fun SearchScreen(
         } else {
             VideoGrid(
                 videos = results,
-                metadata = metadata,
-                watched = watched,
-                progress = progress,
+                displayData = displayData,
                 onOpenDetails = onOpenDetails,
             )
         }
     }
+}
+
+/**
+ * Surcharge de compatibilité pour [SearchScreen].
+ */
+@Composable
+fun SearchScreen(
+    query: String,
+    results: List<VideoItem>,
+    metadata: Map<String, TmdbMetadata>,
+    watched: Map<String, Boolean>,
+    progress: Map<String, Double>,
+    onQueryChange: (String) -> Unit,
+    onOpenDetails: (VideoItem) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SearchScreen(
+        query = query,
+        results = results,
+        displayData = VideoDisplayData(metadata = metadata, watched = watched, progress = progress),
+        onQueryChange = onQueryChange,
+        onOpenDetails = onOpenDetails,
+        onBack = onBack,
+        modifier = modifier,
+    )
 }
 
 @Composable

--- a/native/app/src/test/java/com/localstream/app/domain/VideoUiSelectorsTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/VideoUiSelectorsTest.kt
@@ -1,4 +1,4 @@
-﻿package com.localstream.app.domain
+package com.localstream.app.domain
 
 import com.localstream.app.domain.model.VideoItem
 import org.junit.Assert.assertEquals
@@ -85,5 +85,17 @@ class VideoUiSelectorsTest {
         assertEquals(listOf(film), VideoUiSelectors.filterByQuery(videos, "film.2024"))
         assertTrue(VideoUiSelectors.filterByQuery(videos, "   ").isEmpty())
         assertTrue(VideoUiSelectors.filterByQuery(videos, "inconnu").isEmpty())
+    }
+
+    @Test
+    fun `selectors avec VideoDisplayData fonctionnent identiquement aux maps directes`() {
+        val displayData = com.localstream.app.domain.model.VideoDisplayData(
+            metadata = mapOf("Film.2024.1080p.mkv" to com.localstream.app.domain.model.TmdbMetadata(queryKey = "Film.2024.1080p.mkv", posterPath = "/poster.jpg")),
+            watched = mapOf("Film.2024.1080p.mkv" to true),
+            progress = mapOf("Film.2024.1080p.mkv" to 50.0),
+        )
+        assertTrue(VideoUiSelectors.isWatched(film, displayData))
+        assertEquals(50.0, VideoUiSelectors.progressOf(film, displayData), 0.001)
+        assertEquals("https://image.tmdb.org/t/p/w500/poster.jpg", VideoUiSelectors.posterUrl(film, displayData))
     }
 }

--- a/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
@@ -198,6 +198,35 @@ class LibraryViewModelTest {
         assertEquals(3, homeState.alphabetical.size)
     }
 
+    @Test
+    fun `HomeViewModel conserve les instances de rows sans retrier quand seules les metadonnees changent`() = runTest(testDispatcher) {
+        val homeVm = com.localstream.app.ui.home.HomeViewModel(
+            libraryUiState = viewModel.uiState,
+            computationDispatcher = testDispatcher,
+        )
+        backgroundScope.launch { homeVm.uiState.collect() }
+        viewModel.refreshLibrary()
+        advanceUntilIdle()
+
+        val initialAlphabetical = homeVm.uiState.value.alphabetical
+        val initialRecent = homeVm.uiState.value.recentAdditions
+
+        // Mise à jour de métadonnées sans changement de liste de vidéos ni de filtres
+        val fakeMeta = com.localstream.app.domain.model.TmdbMetadata(
+            queryKey = "Avatar.2009.2160p.mkv",
+            posterPath = "/avatar.jpg",
+        )
+        val stateWithMeta = viewModel.uiState.value.copy(
+            displayData = viewModel.uiState.value.displayData.copy(
+                metadata = mapOf("Avatar.2009.2160p.mkv" to fakeMeta),
+            ),
+        )
+        val homeStateWithMeta = com.localstream.app.ui.home.HomeViewModel.deriveHomeUiState(stateWithMeta)
+        assertEquals("/avatar.jpg", homeStateWithMeta.metadata["Avatar.2009.2160p.mkv"]?.posterPath)
+        assertEquals(initialAlphabetical.size, homeStateWithMeta.alphabetical.size)
+        assertEquals(initialRecent.size, homeStateWithMeta.recentAdditions.size)
+    }
+
     // -------- Fakes --------
 
     private class FakeScanner(


### PR DESCRIPTION
## Résumé des modifications

Cette PR résout deux problèmes de performance majeurs causant des saccades lors du scroll initial lors du chargement des métadonnées TMDB :

1. **Restauration du skip Compose via \@Immutable VideoDisplayData\** :
   - Encapsulation des 3 \Map\ brutes (\metadata\, \watched\, \progress\) dans une data class stable \@Immutable VideoDisplayData\.
   - Mise à jour de \VideoGrid\, \VideoRow\, \VideoCard\ et des écrans (\HomeScreen\, \LibraryScreen\, \SearchScreen\, \LocalStreamNavHost\) pour consommer \VideoDisplayData\.
   - Évite les recompositions inutiles de toutes les cartes vidéo visibles lors du recalcul d'un composant parent.

2. **Debounce & Accumulation temporelle des métadonnées TMDB** :
   - Dans \LibraryViewModel.fetchMetadataIntoState()\, les métadonnées sont désormais accumulées et publiées avec un délai minimum de 300 ms (\METADATA_EMIT_DEBOUNCE_MS\), ainsi qu'à la fin du traitement de tous les paquets.
   - Évite d'émettre des mises à jour d'état en rafale sur le Main thread et le dispatcher de calcul.

3. **Mémorisation de la dérivation dans \HomeViewModel\** :
   - Mise en cache du résultat de \HomeRowsDeriver.derive()\ : lorsque seules les métadonnées TMDB arrivent, les listes de rows précédentes sont réutilisées par référence (\===\), évitant tout retri/refiltrage O(N log N) et toute allocation mémoire superflue.

## Validation
- Tous les tests unitaires passent avec succès (\	estDebugUnitTest\).
- Analyse statique \detekt\ validée avec 0 avertissement.
- Zéro conflit avec \origin/main\.