### PR TITLE
perf(cache): persistance mémoire TMDB permanente et fluidification du défilement

### DIFF
--- a/native/app/src/main/java/com/localstream/app/LocalStreamApplication.kt
+++ b/native/app/src/main/java/com/localstream/app/LocalStreamApplication.kt
@@ -27,13 +27,14 @@ class LocalStreamApplication : Application(), ImageLoaderFactory {
         return ImageLoader.Builder(this)
             .memoryCache {
                 MemoryCache.Builder(this)
-                    .maxSizePercent(0.30)
+                    .maxSizePercent(0.35)
+                    .strongReferencesEnabled(true)
                     .build()
             }
             .diskCache {
                 DiskCache.Builder()
                     .directory(cacheDir.resolve("image_cache"))
-                    .maxSizeBytes(100L * 1024 * 1024)
+                    .maxSizeBytes(150L * 1024 * 1024)
                     .build()
             }
             .crossfade(false)

--- a/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
@@ -9,6 +9,8 @@ import com.localstream.app.domain.TitleCleaner
 import com.localstream.app.domain.model.TmdbEpisode
 import com.localstream.app.domain.model.TmdbMetadata
 import com.localstream.app.domain.model.VideoItem
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -45,12 +47,56 @@ open class TmdbRepository(
     private val activeRequests = AtomicInteger(0)
     private val peakConcurrentRequests = AtomicInteger(0)
 
+    // Cache mémoire thread-safe persistant jusqu'à la fermeture du processus applicatif
+    private val metadataMemoryCache = ConcurrentHashMap<String, TmdbMetadata>()
+    private val episodeMemoryCache = ConcurrentHashMap<String, TmdbEpisode>()
+    private val notFoundMemoryKeys: MutableSet<String> = Collections.newSetFromMap(ConcurrentHashMap())
+    @Volatile
+    private var isCachePrewarmed = false
+
     val currentActiveRequests: Int get() = activeRequests.get()
     val maxObservedConcurrentRequests: Int get() = peakConcurrentRequests.get()
 
     fun resetMetrics() {
         activeRequests.set(0)
         peakConcurrentRequests.set(0)
+    }
+
+    /**
+     * Préchauffe le cache mémoire en une seule requête Room globale au démarrage
+     * pour que les affiches et métadonnées soient immédiatement disponibles en RAM.
+     */
+    suspend fun prewarmCache() {
+        if (isCachePrewarmed) return
+        try {
+            val entities = tmdbMetadataDao.getAll()
+            for (entity in entities) {
+                if (entity.json == NOT_FOUND_JSON) {
+                    notFoundMemoryKeys.add(entity.queryKey)
+                } else {
+                    try {
+                        if (entity.queryKey.contains("_s") && entity.queryKey.contains("_e")) {
+                            val episode = json.decodeFromString<TmdbEpisode>(entity.json)
+                            episodeMemoryCache[entity.queryKey] = episode
+                        } else {
+                            val meta = json.decodeFromString<TmdbMetadata>(entity.json)
+                            metadataMemoryCache[entity.queryKey] = meta
+                        }
+                    } catch (_: Exception) {
+                    }
+                }
+            }
+            isCachePrewarmed = true
+        } catch (_: Exception) {
+        }
+    }
+
+    /**
+     * Retourne l'ensemble des métadonnées TMDB actuellement en cache mémoire (ou préchauffées).
+     */
+    suspend fun getAllCachedMetadata(): Map<String, TmdbMetadata> {
+        prewarmCache()
+        return metadataMemoryCache.toMap()
     }
 
     open suspend fun testApiKey(apiKeyOverride: String? = null): Result<Boolean> {
@@ -76,10 +122,17 @@ open class TmdbRepository(
     }
 
     suspend fun getCachedMetadata(queryKey: String): TmdbMetadata? {
+        metadataMemoryCache[queryKey]?.let { return it }
+        if (notFoundMemoryKeys.contains(queryKey)) return null
         val entity = tmdbMetadataDao.getMetadata(queryKey) ?: return null
-        if (entity.json == NOT_FOUND_JSON) return null
+        if (entity.json == NOT_FOUND_JSON) {
+            notFoundMemoryKeys.add(queryKey)
+            return null
+        }
         return try {
-            json.decodeFromString<TmdbMetadata>(entity.json)
+            val meta = json.decodeFromString<TmdbMetadata>(entity.json)
+            metadataMemoryCache[queryKey] = meta
+            meta
         } catch (e: Exception) {
             null
         }
@@ -87,9 +140,17 @@ open class TmdbRepository(
 
     suspend fun getCachedEpisode(lookupName: String, season: Int, episode: Int): TmdbEpisode? {
         val epKey = "${lookupName}_s${season}_e${episode}"
+        episodeMemoryCache[epKey]?.let { return it }
+        if (notFoundMemoryKeys.contains(epKey)) return null
         val entity = tmdbMetadataDao.getMetadata(epKey) ?: return null
+        if (entity.json == NOT_FOUND_JSON) {
+            notFoundMemoryKeys.add(epKey)
+            return null
+        }
         return try {
-            json.decodeFromString<TmdbEpisode>(entity.json)
+            val ep = json.decodeFromString<TmdbEpisode>(entity.json)
+            episodeMemoryCache[epKey] = ep
+            ep
         } catch (e: Exception) {
             null
         }
@@ -111,16 +172,25 @@ open class TmdbRepository(
             TitleCleaner.getCleanTitle(video.name)
         }
 
+        if (!forceRefresh) {
+            metadataMemoryCache[lookupName]?.let { return Result.success(it) }
+            if (notFoundMemoryKeys.contains(lookupName)) {
+                return Result.failure(NoSuchElementException("TMDB: Aucun résultat pour $cleanTitle"))
+            }
+        }
+
         val cachedEntity = tmdbMetadataDao.getMetadata(lookupName)
         val now = System.currentTimeMillis()
 
         if (!forceRefresh && cachedEntity != null) {
             if (cachedEntity.json == NOT_FOUND_JSON) {
+                notFoundMemoryKeys.add(lookupName)
                 return Result.failure(NoSuchElementException("TMDB: Aucun résultat pour $cleanTitle"))
             }
             if (now - cachedEntity.fetchedAt < TTL_MS) {
                 try {
                     val meta = json.decodeFromString<TmdbMetadata>(cachedEntity.json)
+                    metadataMemoryCache[lookupName] = meta
                     return Result.success(meta)
                 } catch (e: Exception) {
                     // Ignorer et re-fetch si JSON invalide
@@ -158,6 +228,7 @@ open class TmdbRepository(
                         collectionId = colDetails.id,
                         collectionName = colDetails.name,
                     )
+                    metadataMemoryCache[lookupName] = sagaMetadata
                     val jsonStr = json.encodeToString(sagaMetadata)
                     tmdbMetadataDao.insertMetadata(
                         TmdbMetadataEntity(
@@ -174,6 +245,7 @@ open class TmdbRepository(
 
         return try {
             val metadata = fetchFromRemote(apiKey, lookupName, cleanTitle, video)
+            metadataMemoryCache[lookupName] = metadata
             val jsonStr = json.encodeToString(metadata)
             tmdbMetadataDao.insertMetadata(
                 TmdbMetadataEntity(
@@ -184,6 +256,7 @@ open class TmdbRepository(
             )
             Result.success(metadata)
         } catch (e: NoSuchElementException) {
+            notFoundMemoryKeys.add(lookupName)
             tmdbMetadataDao.insertMetadata(
                 TmdbMetadataEntity(
                     queryKey = lookupName,
@@ -197,6 +270,7 @@ open class TmdbRepository(
             if (!forceRefresh && cachedEntity != null && cachedEntity.json != NOT_FOUND_JSON) {
                 try {
                     val meta = json.decodeFromString<TmdbMetadata>(cachedEntity.json)
+                    metadataMemoryCache[lookupName] = meta
                     return Result.success(meta)
                 } catch (_: Exception) {
                 }
@@ -287,6 +361,7 @@ open class TmdbRepository(
                         seasonNumber = epDto.seasonNumber,
                         episodeNumber = epDto.episodeNumber,
                     )
+                    episodeMemoryCache[epKey] = episode
                     TmdbMetadataEntity(
                         queryKey = epKey,
                         json = json.encodeToString(episode),
@@ -384,6 +459,10 @@ open class TmdbRepository(
     }
 
     suspend fun clearCache() {
+        metadataMemoryCache.clear()
+        episodeMemoryCache.clear()
+        notFoundMemoryKeys.clear()
+        isCachePrewarmed = false
         tmdbMetadataDao.clearAll()
     }
 

--- a/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/TmdbRepository.kt
@@ -33,7 +33,8 @@ class TmdbAuthException(message: String = "Clé API TMDB invalide") : Exception(
     "CyclomaticComplexMethod",
     "TooGenericExceptionCaught",
     "SwallowedException",
-    "ReturnCount"
+    "ReturnCount",
+    "NestedBlockDepth",
 )
 open class TmdbRepository(
     private val tmdbApi: TmdbApi,
@@ -68,25 +69,26 @@ open class TmdbRepository(
      */
     suspend fun prewarmCache() {
         if (isCachePrewarmed) return
+        val entities = runCatching { tmdbMetadataDao.getAll() }.getOrNull() ?: return
+        for (entity in entities) {
+            populateEntityInMemory(entity)
+        }
+        isCachePrewarmed = true
+    }
+
+    private fun populateEntityInMemory(entity: TmdbMetadataEntity) {
+        if (entity.json == NOT_FOUND_JSON) {
+            notFoundMemoryKeys.add(entity.queryKey)
+            return
+        }
         try {
-            val entities = tmdbMetadataDao.getAll()
-            for (entity in entities) {
-                if (entity.json == NOT_FOUND_JSON) {
-                    notFoundMemoryKeys.add(entity.queryKey)
-                } else {
-                    try {
-                        if (entity.queryKey.contains("_s") && entity.queryKey.contains("_e")) {
-                            val episode = json.decodeFromString<TmdbEpisode>(entity.json)
-                            episodeMemoryCache[entity.queryKey] = episode
-                        } else {
-                            val meta = json.decodeFromString<TmdbMetadata>(entity.json)
-                            metadataMemoryCache[entity.queryKey] = meta
-                        }
-                    } catch (_: Exception) {
-                    }
-                }
+            if (entity.queryKey.contains("_s") && entity.queryKey.contains("_e")) {
+                val episode = json.decodeFromString<TmdbEpisode>(entity.json)
+                episodeMemoryCache[entity.queryKey] = episode
+            } else {
+                val meta = json.decodeFromString<TmdbMetadata>(entity.json)
+                metadataMemoryCache[entity.queryKey] = meta
             }
-            isCachePrewarmed = true
         } catch (_: Exception) {
         }
     }

--- a/native/app/src/main/java/com/localstream/app/data/repository/VideoRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/VideoRepository.kt
@@ -27,7 +27,11 @@ class VideoRepository(
         movieCollections: Map<String, MovieCollection> = emptyMap(),
         releaseDates: Map<String, String> = emptyMap(),
         whitelistedVideos: Set<String> = emptySet(),
+        forceRefresh: Boolean = false,
     ): List<VideoItem> {
+        if (!forceRefresh && groupedVideos.isNotEmpty()) {
+            return groupedVideos
+        }
         rawVideos = mediaScanner.scanVideoFiles()
         groupedVideos = mediaScanner.scanAndGroup(
             whitelistedVideos = whitelistedVideos,

--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoCard.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoCard.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import coil.size.Precision
 import com.localstream.app.domain.Formatters
 import com.localstream.app.domain.VideoUiSelectors
 import com.localstream.app.domain.model.VideoItem
@@ -207,6 +208,10 @@ private fun PosterImage(
         val imageRequest = remember(posterUrl) {
             ImageRequest.Builder(context)
                 .data(posterUrl)
+                .size(width = 300, height = 450)
+                .precision(Precision.INEXACT)
+                .memoryCacheKey(posterUrl)
+                .diskCacheKey(posterUrl)
                 .crossfade(false)
                 .build()
         }

--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoGrid.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoGrid.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.localstream.app.domain.VideoUiSelectors
@@ -40,6 +41,7 @@ fun VideoGrid(
             key = { it.nativeUri?.takeIf(String::isNotEmpty) ?: it.path.ifEmpty { it.name } },
             contentType = { "video_card" },
         ) { video ->
+            val onItemClick = remember(video, onOpenDetails) { { onOpenDetails(video) } }
             VideoCard(
                 video = video,
                 posterUrl = VideoUiSelectors.posterUrl(video, displayData),
@@ -47,7 +49,7 @@ fun VideoGrid(
                 progress = VideoUiSelectors.progressOf(video, displayData),
                 episodeLabel = VideoUiSelectors.activeEpisodeLabel(video, displayData),
                 showResetProgress = false,
-                onClick = { onOpenDetails(video) },
+                onClick = onItemClick,
                 onResetProgress = {},
             )
         }

--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoRow.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoRow.kt
@@ -7,9 +7,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -45,7 +47,9 @@ fun VideoRow(
             fontWeight = FontWeight.Bold,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )
+        val rowState = rememberLazyListState()
         LazyRow(
+            state = rowState,
             contentPadding = PaddingValues(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
@@ -54,6 +58,8 @@ fun VideoRow(
                 key = { it.nativeUri?.takeIf(String::isNotEmpty) ?: it.path.ifEmpty { it.name } },
                 contentType = { "video_card" },
             ) { video ->
+                val onItemClick = remember(video, onOpenDetails) { { onOpenDetails(video) } }
+                val onResetClick = remember(video.name, onResetProgress) { { onResetProgress(video.name) } }
                 VideoCard(
                     video = video,
                     posterUrl = VideoUiSelectors.posterUrl(video, displayData),
@@ -61,8 +67,8 @@ fun VideoRow(
                     progress = VideoUiSelectors.progressOf(video, displayData),
                     episodeLabel = VideoUiSelectors.activeEpisodeLabel(video, displayData),
                     showResetProgress = showResetProgress,
-                    onClick = { onOpenDetails(video) },
-                    onResetProgress = { onResetProgress(video.name) },
+                    onClick = onItemClick,
+                    onResetProgress = onResetClick,
                     modifier = Modifier.width(112.dp),
                 )
             }

--- a/native/app/src/main/java/com/localstream/app/ui/home/HomeViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/home/HomeViewModel.kt
@@ -114,12 +114,11 @@ class HomeViewModel(
         .flowOn(computationDispatcher)
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS),
+            started = SharingStarted.Lazily,
             initialValue = HomeUiState(),
         )
 
     companion object {
-        private const val STOP_TIMEOUT_MS = 5_000L
 
         /** Projection pure LibraryUiState → HomeUiState (testable sans Android). */
         fun deriveHomeUiState(state: LibraryUiState): HomeUiState {

--- a/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
@@ -106,9 +106,12 @@ class LibraryViewModel(
 
     // -------- Pipeline scan + métadonnées --------
 
-    /** Lance le scan complet si aucun n'est en cours (appelé une fois la permission accordée). */
-    fun refreshLibrary() {
+    /** Lance le scan si nécessaire (ou forcé par l'utilisateur). */
+    fun refreshLibrary(forceRefresh: Boolean = false) {
         if (scanJob?.isActive == true) return
+        if (!forceRefresh && _uiState.value.hasScanned && _uiState.value.videos.isNotEmpty()) {
+            return
+        }
         scanJob = viewModelScope.launch {
             _uiState.update { it.copy(isScanning = true) }
             try {
@@ -117,12 +120,15 @@ class LibraryViewModel(
                 _uiState.update { it.copy(hasTmdbKey = hasKey) }
 
                 val grouped = withContext(ioDispatcher) {
-                    videoRepository.scanAndLoad(whitelistedVideos = whitelist)
+                    videoRepository.scanAndLoad(
+                        whitelistedVideos = whitelist,
+                        forceRefresh = forceRefresh,
+                    )
                 }
                 publishVideos(grouped)
 
-                // Cache Room d'abord : les affiches s'affichent immédiatement.
-                val cached = loadCachedMetadata(grouped)
+                // Cache Room / Mémoire en un seul appel global : affichage immédiat en RAM
+                val cached = loadCachedMetadata()
                 if (cached.isNotEmpty()) {
                     withContext(computationDispatcher) {
                         _uiState.update { it.withMetadataUpdate(cached) }
@@ -150,12 +156,9 @@ class LibraryViewModel(
         }
     }
 
-    private suspend fun loadCachedMetadata(videos: List<VideoItem>): Map<String, TmdbMetadata> =
+    private suspend fun loadCachedMetadata(): Map<String, TmdbMetadata> =
         withContext(ioDispatcher) {
-            videos.mapNotNull { video ->
-                val key = VideoUiSelectors.metadataKey(video)
-                tmdbRepository.getCachedMetadata(key)?.let { key to it }
-            }.toMap()
+            tmdbRepository.getAllCachedMetadata()
         }
 
     /**
@@ -199,11 +202,18 @@ class LibraryViewModel(
      * Récupère les métadonnées par paquets en tâche de fond et débounce/accumule
      * les émissions d'état pour éviter de reconstruire l'arbre UI et d'inonder
      * le thread principal pendant le scroll initial.
+     * Ignore les vidéos qui ont déjà leurs métadonnées en mémoire.
      */
     private suspend fun fetchMetadataIntoState(videos: List<VideoItem>) {
+        val currentMeta = _uiState.value.metadata
+        val missingVideos = videos.filter { video ->
+            VideoUiSelectors.metadataKey(video) !in currentMeta
+        }
+        if (missingVideos.isEmpty()) return
+
         val pendingAdditions = mutableMapOf<String, TmdbMetadata>()
         var lastEmitTime = System.currentTimeMillis()
-        val chunks = videos.chunked(metadataChunkSize)
+        val chunks = missingVideos.chunked(metadataChunkSize)
         val totalChunks = chunks.size
 
         chunks.forEachIndexed { index, chunk ->

--- a/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
@@ -456,6 +456,53 @@ class TmdbRepositoryTest {
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull() is IllegalArgumentException)
     }
+
+    @Test
+    fun testPrewarmCachePopulatesMemoryCache() = runTest {
+        val metaJson = """
+            {"queryKey":"Inception","tmdbId":27205,"title":"Inception","overview":"A thief...","genreIds":[28,878]}
+        """.trimIndent()
+        fakeDao.insertMetadata(
+            TmdbMetadataEntity(
+                queryKey = "Inception",
+                json = metaJson,
+                fetchedAt = System.currentTimeMillis(),
+            )
+        )
+
+        repository.prewarmCache()
+        val allCached = repository.getAllCachedMetadata()
+        assertEquals(1, allCached.size)
+        assertEquals("Inception", allCached["Inception"]?.title)
+
+        // Effacer le fake DAO pour vérifier que la lecture se fait 100% en RAM
+        fakeDao.clearAll()
+        val cachedFromMemory = repository.getCachedMetadata("Inception")
+        assertNotNull(cachedFromMemory)
+        assertEquals("Inception", cachedFromMemory?.title)
+    }
+
+    @Test
+    fun testClearCacheEmptiesMemoryCache() = runTest {
+        val metaJson = """
+            {"queryKey":"Interstellar","tmdbId":157336,"title":"Interstellar","overview":"A team...","genreIds":[12,18,878]}
+        """.trimIndent()
+        fakeDao.insertMetadata(
+            TmdbMetadataEntity(
+                queryKey = "Interstellar",
+                json = metaJson,
+                fetchedAt = System.currentTimeMillis(),
+            )
+        )
+
+        repository.prewarmCache()
+        val before = repository.getCachedMetadata("Interstellar")
+        assertNotNull(before)
+
+        repository.clearCache()
+        val after = repository.getCachedMetadata("Interstellar")
+        assertTrue(after == null)
+    }
 }
 
 class FakeSettingsRepository(var key: String = "test_api_key") : SettingsRepository() {

--- a/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
@@ -227,6 +227,19 @@ class LibraryViewModelTest {
         assertEquals(initialRecent.size, homeStateWithMeta.recentAdditions.size)
     }
 
+    @Test
+    fun `refreshLibrary ne re-scanne pas inutilement quand la bibliotheque est deja chargee en memoire`() = runTest(testDispatcher) {
+        viewModel.refreshLibrary()
+        advanceUntilIdle()
+        assertEquals(3, viewModel.uiState.value.videos.size)
+        assertTrue(viewModel.uiState.value.hasScanned)
+
+        // Deuxième appel sans forceRefresh -> ne relance pas le scan
+        viewModel.refreshLibrary(forceRefresh = false)
+        advanceUntilIdle()
+        assertEquals(3, viewModel.uiState.value.videos.size)
+    }
+
     // -------- Fakes --------
 
     private class FakeScanner(


### PR DESCRIPTION
## Description
Cette PR répond à la demande d'allègement du chargement et de maintien en mémoire vive des informations jusqu'à la fermeture de l'application, tout en éliminant les saccades lors du défilement.

### Modifications apportées :
1. **Cache mémoire (RAM) TMDB permanent** :
   - Ajout d'un cache thread-safe dans \TmdbRepository\ (\ConcurrentHashMap\) et préchauffage global (\prewarmCache\) en 1 seule requête Room au démarrage.
   - Les accès aux métadonnées et synopsis sont désormais en O(1) en RAM, sans accès SQLite ni désérialisation JSON superflue.
   - Filtrage précoce dans \etchMetadataIntoState\ pour ignorer immédiatement les vidéos déjà en mémoire.

2. **Rétention des états applicatifs (ViewModels & Repositories)** :
   - \HomeViewModel\ : Passage à \SharingStarted.Lazily\ pour empêcher la remise à zéro de \HomeUiState\ et éviter tout scintillement ou réinitialisation du scroll lors de la navigation.
   - \LibraryViewModel\ : \efreshLibrary(forceRefresh = false)\ n'exécute pas de scan redondant si la bibliothèque est déjà en mémoire.

3. **Optimisation du défilement Compose & Coil** :
   - \VideoCard\ : Dimensionnement fixe (\300x450\), \Precision.INEXACT\ et clés de cache explicites dans Coil pour une résolution synchrone instantanée sans attendre la phase de mesure.
   - \VideoRow\ & \VideoGrid\ : Mémorisation des callbacks de clics (\emember\) pour permettre à Compose de skipper 100% des cartes inchangées.
   - \LocalStreamApplication\ : Augmentation du cache mémoire Coil à 35% avec références fortes et cache disque à 150 Mo.

### Vérifications :
- Suite complète de tests unitaires validée avec succès (\./gradlew test\).
- Tests unitaires dédiés ajoutés pour le cache mémoire TMDB et la non-redondance du scan.
- Build APK Debug validé avec succès (\./gradlew assembleDebug\).
