### PR TITLE
feat(history): regrouper les sagas et séries dans l'onglet historique

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/history/HistoryViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/history/HistoryViewModel.kt
@@ -8,6 +8,8 @@ import com.localstream.app.data.db.entity.PlaybackStateEntity
 import com.localstream.app.data.db.entity.WatchedItemEntity
 import com.localstream.app.di.AppContainer
 import com.localstream.app.domain.TitleCleaner
+import com.localstream.app.domain.VideoGrouper
+import com.localstream.app.domain.VideoUiSelectors
 import com.localstream.app.domain.model.TmdbMetadata
 import com.localstream.app.domain.model.VideoItem
 import kotlinx.coroutines.flow.SharingStarted
@@ -27,12 +29,23 @@ data class HistoryItemUiState(
     val positionMs: Long,
     val isWatched: Boolean,
     val metadata: TmdbMetadata? = null,
+    val isSeriesGroup: Boolean = false,
+    val isTvSeries: Boolean = false,
+    val episodeLabel: String? = null,
 )
 
 @Immutable
 data class HistoryUiState(
     val items: List<HistoryItemUiState> = emptyList(),
     val isLoading: Boolean = false,
+)
+
+private data class HistoryContext(
+    val watchedMap: Map<String, WatchedItemEntity>,
+    val playbackMap: Map<String, PlaybackStateEntity>,
+    val metadataMap: Map<String, TmdbMetadata>,
+    val forceSet: Set<String>,
+    val rawVideos: List<VideoItem> = emptyList(),
 )
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
@@ -58,52 +71,15 @@ class HistoryViewModel(
         metadataMap: Map<String, TmdbMetadata>,
         forceSet: Set<String> ->
 
-        val allNames = (watchedMap.keys + playbackMap.keys).distinct()
-        val rawVideos = container.videoRepository.getRawVideos()
-        val allVideos = (rawVideos + diskVideos + diskVideos.flatMap { it.episodes.orEmpty() })
-        val allVideosMap = allVideos.associateBy { it.name }
-        val diskNames = allVideosMap.keys
+        val context = HistoryContext(
+            watchedMap = watchedMap,
+            playbackMap = playbackMap,
+            metadataMap = metadataMap,
+            forceSet = forceSet,
+            rawVideos = container.videoRepository.getRawVideos(),
+        )
 
-        val historyItems = allNames.mapNotNull { name ->
-            val pb = playbackMap[name]
-            val watchedEntity = watchedMap[name]
-            val isWatched = watchedEntity?.watched ?: false
-            if (!isWatched && pb == null) return@mapNotNull null
-
-            val isDiskAvailable = diskNames.contains(name) || rawVideos.any { it.name == name || it.path == name }
-            val isForceAvailable = forceSet.contains(name)
-            val effectiveAvailable = isDiskAvailable || isForceAvailable
-
-            val diskVideo = allVideosMap[name]
-            val durationMs = (diskVideo?.duration ?: 0L) * 1000L
-            val positionMs = pb?.positionMs ?: 0L
-            val progressPercent = if (durationMs > 0L) {
-                (positionMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
-            } else {
-                ((pb?.progressPct ?: 0.0) / 100.0).toFloat().coerceIn(0f, 1f)
-            }
-            val watchedAt = maxOf(pb?.lastPlayedAt ?: 0L, watchedEntity?.watchedAt ?: 0L)
-
-            val cleanTitle = diskVideo?.cleanTitle ?: TitleCleaner.getCleanTitle(name)
-
-            val metadata = metadataMap[name]
-                ?: metadataMap[cleanTitle]
-                ?: diskVideo?.seriesName?.let { metadataMap[it] ?: metadataMap[TitleCleaner.getCleanTitle(it)] }
-                ?: metadataMap[TitleCleaner.getCleanTitle(name)]
-
-            HistoryItemUiState(
-                videoName = name,
-                cleanTitle = cleanTitle,
-                isAvailableOnDisk = effectiveAvailable,
-                isForceAvailable = isForceAvailable,
-                watchedAt = watchedAt,
-                progressPercent = progressPercent,
-                positionMs = positionMs,
-                isWatched = isWatched,
-                metadata = metadata,
-            )
-        }.sortedByDescending { it.watchedAt }
-
+        val historyItems = buildHistoryItems(diskVideos, context)
         HistoryUiState(items = historyItems)
     }.stateIn(
         scope = viewModelScope,
@@ -111,15 +87,320 @@ class HistoryViewModel(
         initialValue = HistoryUiState(),
     )
 
+    private fun buildHistoryItems(
+        diskVideos: List<VideoItem>,
+        context: HistoryContext,
+    ): List<HistoryItemUiState> {
+        val handledNames = mutableSetOf<String>()
+        val result = mutableListOf<HistoryItemUiState>()
+
+        diskVideos.forEach { video ->
+            if (video.isSeriesGroup) {
+                val groupItem = processDiskGroup(video, context, handledNames)
+                if (groupItem != null) {
+                    result.add(groupItem)
+                }
+            } else {
+                val standaloneItem = processDiskStandalone(video, context, handledNames)
+                if (standaloneItem != null) {
+                    result.add(standaloneItem)
+                }
+            }
+        }
+
+        val remainingNames = (context.watchedMap.keys + context.playbackMap.keys)
+            .filter { it !in handledNames }
+            .distinct()
+
+        if (remainingNames.isNotEmpty()) {
+            val orphanItems = processOrphanItems(remainingNames, context)
+            result.addAll(orphanItems)
+        }
+
+        return result.sortedByDescending { it.watchedAt }
+    }
+
+    private fun processDiskGroup(
+        video: VideoItem,
+        context: HistoryContext,
+        handledNames: MutableSet<String>,
+    ): HistoryItemUiState? {
+        val episodes = video.episodes.orEmpty()
+        val allGroupKeys = (listOfNotNull(video.name, video.seriesName) +
+            episodes.map { it.name } +
+            episodes.mapNotNull { it.cleanTitle }).distinct()
+        handledNames.addAll(allGroupKeys)
+
+        val groupWatchedEntities = allGroupKeys.mapNotNull { context.watchedMap[it] }
+        val groupPlaybackStates = allGroupKeys.mapNotNull { context.playbackMap[it] }
+
+        val hasWatched = groupWatchedEntities.any { it.watched }
+        val hasPlayback = groupPlaybackStates.isNotEmpty()
+        if (!hasWatched && !hasPlayback) return null
+
+        val maxWatchedAt = maxOf(
+            groupWatchedEntities.maxOfOrNull { it.watchedAt } ?: 0L,
+            groupPlaybackStates.maxOfOrNull { it.lastPlayedAt } ?: 0L,
+        )
+
+        val isGroupWatched = context.watchedMap[video.name]?.watched == true ||
+            (episodes.isNotEmpty() && episodes.all { ep -> context.watchedMap[ep.name]?.watched == true })
+
+        val isForceAvailable = context.forceSet.contains(video.name) ||
+            episodes.any { ep -> context.forceSet.contains(ep.name) }
+
+        val latestPbEntry = allGroupKeys.mapNotNull { key ->
+            context.playbackMap[key]?.let { key to it }
+        }.maxByOrNull { it.second.lastPlayedAt }
+
+        val (progressPct, posMs) = if (latestPbEntry != null) {
+            val (key, pb) = latestPbEntry
+            val ep = episodes.find { it.name == key || it.cleanTitle == key }
+            val durMs = (ep?.duration ?: 0L) * 1000L
+            val p = if (durMs > 0L) {
+                (pb.positionMs.toFloat() / durMs.toFloat()).coerceIn(0f, 1f)
+            } else {
+                ((pb.progressPct) / 100.0).toFloat().coerceIn(0f, 1f)
+            }
+            p to pb.positionMs
+        } else {
+            0f to 0L
+        }
+
+        val episodeLabel = if (video.isTvSeries) {
+            VideoUiSelectors.activeEpisodeLabel(
+                video = video,
+                progress = context.playbackMap.mapValues { it.value.progressPct },
+                watched = context.watchedMap.mapValues { it.value.watched },
+            )
+        } else {
+            val watchedCount = episodes.count { context.watchedMap[it.name]?.watched == true }
+            if (watchedCount > 0) "$watchedCount/${episodes.size} vus" else null
+        }
+
+        val cleanTitle = video.cleanTitle ?: video.seriesName ?: TitleCleaner.getCleanTitle(video.name)
+
+        val metadata = context.metadataMap[video.name]
+            ?: context.metadataMap[cleanTitle]
+            ?: video.seriesName?.let { context.metadataMap[it] ?: context.metadataMap[TitleCleaner.getCleanTitle(it)] }
+            ?: context.metadataMap[TitleCleaner.getCleanTitle(video.name)]
+            ?: episodes.firstNotNullOfOrNull { ep -> context.metadataMap[ep.name] ?: context.metadataMap[ep.cleanTitle] }
+
+        return HistoryItemUiState(
+            videoName = video.name,
+            cleanTitle = cleanTitle,
+            isAvailableOnDisk = true,
+            isForceAvailable = isForceAvailable,
+            watchedAt = maxWatchedAt,
+            progressPercent = progressPct,
+            positionMs = posMs,
+            isWatched = isGroupWatched,
+            metadata = metadata,
+            isSeriesGroup = true,
+            isTvSeries = video.isTvSeries,
+            episodeLabel = episodeLabel,
+        )
+    }
+
+    private fun processDiskStandalone(
+        video: VideoItem,
+        context: HistoryContext,
+        handledNames: MutableSet<String>,
+    ): HistoryItemUiState? {
+        val name = video.name
+        val clean = video.cleanTitle ?: TitleCleaner.getCleanTitle(name)
+        handledNames.add(name)
+        handledNames.add(clean)
+
+        val pb = context.playbackMap[name] ?: context.playbackMap[clean]
+        val we = context.watchedMap[name] ?: context.watchedMap[clean]
+        val isWatched = we?.watched ?: false
+        if (!isWatched && pb == null) return null
+
+        val isForceAvailable = context.forceSet.contains(name) || context.forceSet.contains(clean)
+        val durMs = video.duration * 1000L
+        val posMs = pb?.positionMs ?: 0L
+        val progressPercent = if (durMs > 0L) {
+            (posMs.toFloat() / durMs.toFloat()).coerceIn(0f, 1f)
+        } else {
+            ((pb?.progressPct ?: 0.0) / 100.0).toFloat().coerceIn(0f, 1f)
+        }
+        val watchedAt = maxOf(pb?.lastPlayedAt ?: 0L, we?.watchedAt ?: 0L)
+        val metadata = context.metadataMap[name] ?: context.metadataMap[clean] ?: context.metadataMap[TitleCleaner.getCleanTitle(name)]
+
+        return HistoryItemUiState(
+            videoName = name,
+            cleanTitle = clean,
+            isAvailableOnDisk = true,
+            isForceAvailable = isForceAvailable,
+            watchedAt = watchedAt,
+            progressPercent = progressPercent,
+            positionMs = posMs,
+            isWatched = isWatched,
+            metadata = metadata,
+            isSeriesGroup = false,
+            isTvSeries = false,
+            episodeLabel = null,
+        )
+    }
+
+    private fun processOrphanItems(
+        remainingNames: List<String>,
+        context: HistoryContext,
+    ): List<HistoryItemUiState> {
+        val orphanDummyVideos = remainingNames.map { name ->
+            val raw = context.rawVideos.find { it.name == name || it.path == name }
+            raw ?: VideoItem(name = name, url = "", path = "", size = 0, duration = 0)
+        }
+        val groupedOrphans = VideoGrouper.groupVideos(
+            videos = orphanDummyVideos,
+            movieCollections = emptyMap(),
+            releaseDates = emptyMap(),
+            whitelistedVideos = emptySet(),
+        )
+
+        return groupedOrphans.mapNotNull { item ->
+            if (item.isSeriesGroup) {
+                processOrphanGroup(item, context)
+            } else {
+                processOrphanStandalone(item, context)
+            }
+        }
+    }
+
+    private fun processOrphanGroup(
+        item: VideoItem,
+        context: HistoryContext,
+    ): HistoryItemUiState? {
+        val eps = item.episodes.orEmpty()
+        val keys = (listOfNotNull(item.name, item.seriesName) + eps.map { it.name }).distinct()
+        val wEntities = keys.mapNotNull { context.watchedMap[it] }
+        val pbStates = keys.mapNotNull { context.playbackMap[it] }
+        val isWatched = wEntities.any { it.watched }
+        val hasPb = pbStates.isNotEmpty()
+        if (!isWatched && !hasPb) return null
+
+        val watchedAt = maxOf(
+            wEntities.maxOfOrNull { it.watchedAt } ?: 0L,
+            pbStates.maxOfOrNull { it.lastPlayedAt } ?: 0L,
+        )
+        val isGroupWatched = context.watchedMap[item.name]?.watched == true ||
+            (eps.isNotEmpty() && eps.all { ep -> context.watchedMap[ep.name]?.watched == true })
+
+        val isDiskAvail = eps.any { ep -> context.rawVideos.any { r -> r.name == ep.name || r.path == ep.name } }
+        val isForceAvail = keys.any { context.forceSet.contains(it) }
+        val cleanTitle = item.cleanTitle ?: item.seriesName ?: TitleCleaner.getCleanTitle(item.name)
+
+        val latestPbEntry = keys.mapNotNull { key -> context.playbackMap[key]?.let { key to it } }
+            .maxByOrNull { it.second.lastPlayedAt }
+
+        val (progressPct, posMs) = if (latestPbEntry != null) {
+            val (key, pb) = latestPbEntry
+            val ep = eps.find { it.name == key }
+            val durMs = (ep?.duration ?: 0L) * 1000L
+            val p = if (durMs > 0L) {
+                (pb.positionMs.toFloat() / durMs.toFloat()).coerceIn(0f, 1f)
+            } else {
+                ((pb.progressPct) / 100.0).toFloat().coerceIn(0f, 1f)
+            }
+            p to pb.positionMs
+        } else {
+            0f to 0L
+        }
+
+        val metadata = context.metadataMap[item.name]
+            ?: context.metadataMap[cleanTitle]
+            ?: item.seriesName?.let { context.metadataMap[it] ?: context.metadataMap[TitleCleaner.getCleanTitle(it)] }
+            ?: context.metadataMap[TitleCleaner.getCleanTitle(item.name)]
+
+        val episodeLabel = if (item.isTvSeries) {
+            VideoUiSelectors.activeEpisodeLabel(
+                video = item,
+                progress = context.playbackMap.mapValues { it.value.progressPct },
+                watched = context.watchedMap.mapValues { it.value.watched },
+            )
+        } else {
+            val watchedCount = eps.count { context.watchedMap[it.name]?.watched == true }
+            if (watchedCount > 0) "$watchedCount/${eps.size} vus" else null
+        }
+
+        return HistoryItemUiState(
+            videoName = item.name,
+            cleanTitle = cleanTitle,
+            isAvailableOnDisk = isDiskAvail || isForceAvail,
+            isForceAvailable = isForceAvail,
+            watchedAt = watchedAt,
+            progressPercent = progressPct,
+            positionMs = posMs,
+            isWatched = isGroupWatched,
+            metadata = metadata,
+            isSeriesGroup = true,
+            isTvSeries = item.isTvSeries,
+            episodeLabel = episodeLabel,
+        )
+    }
+
+    private fun processOrphanStandalone(
+        item: VideoItem,
+        context: HistoryContext,
+    ): HistoryItemUiState? {
+        val name = item.name
+        val pb = context.playbackMap[name]
+        val we = context.watchedMap[name]
+        val isWatched = we?.watched ?: false
+        if (!isWatched && pb == null) return null
+
+        val isDiskAvail = context.rawVideos.any { it.name == name || it.path == name }
+        val isForceAvail = context.forceSet.contains(name)
+        val cleanTitle = item.cleanTitle ?: TitleCleaner.getCleanTitle(name)
+        val watchedAt = maxOf(pb?.lastPlayedAt ?: 0L, we?.watchedAt ?: 0L)
+        val posMs = pb?.positionMs ?: 0L
+        val durMs = item.duration * 1000L
+        val progressPercent = if (durMs > 0L) {
+            (posMs.toFloat() / durMs.toFloat()).coerceIn(0f, 1f)
+        } else {
+            ((pb?.progressPct ?: 0.0) / 100.0).toFloat().coerceIn(0f, 1f)
+        }
+        val metadata = context.metadataMap[name] ?: context.metadataMap[cleanTitle] ?: context.metadataMap[TitleCleaner.getCleanTitle(name)]
+
+        return HistoryItemUiState(
+            videoName = name,
+            cleanTitle = cleanTitle,
+            isAvailableOnDisk = isDiskAvail || isForceAvail,
+            isForceAvailable = isForceAvail,
+            watchedAt = watchedAt,
+            progressPercent = progressPercent,
+            positionMs = posMs,
+            isWatched = isWatched,
+            metadata = metadata,
+            isSeriesGroup = false,
+            isTvSeries = false,
+            episodeLabel = null,
+        )
+    }
+
     fun removeFromHistory(videoName: String) {
         viewModelScope.launch {
             container.watchStateRepository.setWatched(videoName, false)
             container.watchStateRepository.clearProgress(videoName)
+            val clean = TitleCleaner.getCleanTitle(videoName)
+            container.watchStateRepository.setWatched(clean, false)
+            container.watchStateRepository.clearProgress(clean)
+
             val grouped = container.videoRepository.getGroupedVideos()
-            val group = grouped.find { it.name == videoName || it.seriesName == videoName }
+            val group = grouped.find {
+                it.name == videoName || it.seriesName == videoName ||
+                    it.name.equals(videoName, ignoreCase = true) ||
+                    it.seriesName?.equals(videoName, ignoreCase = true) == true ||
+                    it.cleanTitle?.equals(clean, ignoreCase = true) == true
+            }
             group?.episodes?.forEach { ep ->
                 container.watchStateRepository.setWatched(ep.name, false)
                 container.watchStateRepository.clearProgress(ep.name)
+                ep.cleanTitle?.let {
+                    container.watchStateRepository.setWatched(it, false)
+                    container.watchStateRepository.clearProgress(it)
+                }
             }
         }
     }
@@ -133,6 +414,11 @@ class HistoryViewModel(
     fun toggleForceAvailable(videoName: String) {
         viewModelScope.launch {
             container.settingsRepository.toggleForceAvailable(videoName)
+            val grouped = container.videoRepository.getGroupedVideos()
+            val group = grouped.find { it.name == videoName || it.seriesName == videoName }
+            group?.episodes?.forEach { ep ->
+                container.settingsRepository.toggleForceAvailable(ep.name)
+            }
         }
     }
 

--- a/native/app/src/main/java/com/localstream/app/ui/screens/HistoryScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/HistoryScreen.kt
@@ -256,14 +256,30 @@ private fun HistoryItemCard(
                         )
                     }
                 }
+                if (item.isSeriesGroup) {
+                    val badgeText = if (item.isTvSeries) "Série" else "Saga"
+                    Text(
+                        text = badgeText.uppercase(),
+                        color = White,
+                        fontSize = 9.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier
+                            .background(Red600, RoundedCornerShape(4.dp))
+                            .align(Alignment.TopStart)
+                            .padding(horizontal = 6.dp, vertical = 2.dp),
+                    )
+                }
                 if (!item.isAvailableOnDisk) {
                     Text(
                         text = "Non disponible",
                         color = White,
                         style = MaterialTheme.typography.labelSmall,
                         modifier = Modifier
-                            .background(Red600.copy(alpha = 0.85f))
-                            .align(Alignment.TopStart)
+                            .background(
+                                if (item.isSeriesGroup) Zinc800.copy(alpha = 0.9f) else Red600.copy(alpha = 0.85f),
+                                RoundedCornerShape(4.dp),
+                            )
+                            .align(if (item.isSeriesGroup) Alignment.TopEnd else Alignment.TopStart)
                             .padding(horizontal = 6.dp, vertical = 2.dp),
                     )
                 }
@@ -289,6 +305,17 @@ private fun HistoryItemCard(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+                if (!item.episodeLabel.isNullOrEmpty()) {
+                    Text(
+                        text = item.episodeLabel,
+                        color = if (item.episodeLabel.startsWith("En cours")) Red600 else Zinc500,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontSize = 11.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,

--- a/native/app/src/test/java/com/localstream/app/ui/history/HistoryViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/history/HistoryViewModelTest.kt
@@ -76,23 +76,24 @@ class HistoryViewModelTest {
 
     @Suppress("LongMethod")
     @Test
-    fun `uiState associe les metadonnees TMDB et detecte la disponibilite disque pour films et episodes`() = runTest(testDispatcher) {
+    fun `uiState regroupe les episodes d'une serie TV en un seul element dans l'historique`() = runTest(testDispatcher) {
         val watchRepo = WatchStateRepository(watchedDao, playbackDao)
         val settingsRepo = SettingsRepository(dataStore = null)
         val osRepo = OpenSubtitlesRepository(UnusedOsApi(), settingsRepo, SubtitleCache(File("/tmp")))
 
-        val episode1 = VideoItem(name = "Breaking.Bad.S01E01.mkv", duration = 3600, path = "/storage/BB/S01E01.mkv")
+        val episode1 = VideoItem(name = "Breaking.Bad.S01E01.mkv", duration = 3600, path = "/storage/BB/S01E01.mkv", season = 1, episode = 1)
+        val episode2 = VideoItem(name = "Breaking.Bad.S01E02.mkv", duration = 3600, path = "/storage/BB/S01E02.mkv", season = 1, episode = 2)
         val seriesGroup = VideoItem(
             name = "Breaking Bad",
             seriesName = "Breaking Bad",
             isSeriesGroup = true,
             isTvSeries = true,
-            episodes = listOf(episode1),
+            episodes = listOf(episode1, episode2),
         )
         val movie = VideoItem(name = "Inception.2010.mkv", duration = 7200, path = "/storage/Inception.mkv")
 
         val scanner = object : MediaScanner {
-            override fun scanVideoFiles(): List<VideoItem> = listOf(episode1, movie)
+            override fun scanVideoFiles(): List<VideoItem> = listOf(episode1, episode2, movie)
             override fun scanSubtitleFiles(): List<SubtitleEntry> = emptyList()
             override fun scanAndGroup(
                 whitelistedVideos: Set<String>,
@@ -125,6 +126,7 @@ class HistoryViewModelTest {
         )
 
         watchedDao.upsert(WatchedItemEntity(name = "Breaking.Bad.S01E01.mkv", watched = true, watchedAt = 1000L))
+        playbackDao.upsert(PlaybackStateEntity(name = "Breaking.Bad.S01E02.mkv", progressPct = 40.0, positionMs = 1440000L, lastPlayedAt = 1500L))
         playbackDao.upsert(PlaybackStateEntity(name = "Inception.2010.mkv", progressPct = 50.0, positionMs = 3600000L, lastPlayedAt = 2000L))
 
         val dummyContainer = DummyContainer(
@@ -145,34 +147,112 @@ class HistoryViewModelTest {
         org.junit.Assert.assertEquals("Inception.2010.mkv", firstItem.videoName)
         assertTrue(firstItem.isAvailableOnDisk)
         org.junit.Assert.assertEquals(2000L, firstItem.watchedAt)
+        org.junit.Assert.assertFalse(firstItem.isSeriesGroup)
 
         val secondItem = items[1]
-        org.junit.Assert.assertEquals("Breaking.Bad.S01E01.mkv", secondItem.videoName)
-        assertTrue("L'épisode de série doit être détecté sur disque", secondItem.isAvailableOnDisk)
-        org.junit.Assert.assertEquals(1000L, secondItem.watchedAt)
+        org.junit.Assert.assertEquals("Breaking Bad", secondItem.videoName)
+        assertTrue("La série doit être détectée sur disque", secondItem.isAvailableOnDisk)
+        org.junit.Assert.assertEquals(1500L, secondItem.watchedAt)
+        assertTrue(secondItem.isSeriesGroup)
+        assertTrue(secondItem.isTvSeries)
         org.junit.Assert.assertNotNull(secondItem.metadata)
         org.junit.Assert.assertEquals("Breaking Bad", secondItem.metadata?.title)
     }
 
     @Test
-    fun `removeFromHistory nettoie l'etat vu et la progression de lecture`() = runTest(testDispatcher) {
+    fun `uiState regroupe les films d'une saga MovieCollection en un seul element dans l'historique`() = runTest(testDispatcher) {
         val watchRepo = WatchStateRepository(watchedDao, playbackDao)
         val settingsRepo = SettingsRepository(dataStore = null)
         val osRepo = OpenSubtitlesRepository(UnusedOsApi(), settingsRepo, SubtitleCache(File("/tmp")))
-        val videoRepo = VideoRepository(FakeScanner())
 
-        watchedDao.upsert(WatchedItemEntity(name = "TestVideo.mp4", watched = true))
-        playbackDao.upsert(PlaybackStateEntity(name = "TestVideo.mp4", progressPct = 50.0, positionMs = 1000L))
+        val movie1 = VideoItem(name = "Harry.Potter.1.2001.mkv", cleanTitle = "Harry Potter 1", duration = 7200, path = "/storage/HP1.mkv")
+        val movie2 = VideoItem(name = "Harry.Potter.2.2002.mkv", cleanTitle = "Harry Potter 2", duration = 7200, path = "/storage/HP2.mkv")
+        val sagaGroup = VideoItem(
+            name = "Harry Potter Collection",
+            seriesName = "Harry Potter Collection",
+            cleanTitle = "Harry Potter Collection",
+            isSeriesGroup = true,
+            isTvSeries = false,
+            episodes = listOf(movie1, movie2),
+        )
+
+        val scanner = object : MediaScanner {
+            override fun scanVideoFiles(): List<VideoItem> = listOf(movie1, movie2)
+            override fun scanSubtitleFiles(): List<SubtitleEntry> = emptyList()
+            override fun scanAndGroup(
+                whitelistedVideos: Set<String>,
+                movieCollections: Map<String, MovieCollection>,
+                releaseDates: Map<String, String>,
+                rawVideos: List<VideoItem>?,
+            ): List<VideoItem> = listOf(sagaGroup)
+        }
+        val videoRepo = VideoRepository(scanner)
+        videoRepo.scanAndLoad()
+
+        watchedDao.upsert(WatchedItemEntity(name = "Harry.Potter.1.2001.mkv", watched = true, watchedAt = 1000L))
+        playbackDao.upsert(PlaybackStateEntity(name = "Harry.Potter.2.2002.mkv", progressPct = 30.0, positionMs = 2160000L, lastPlayedAt = 3000L))
+
+        val dummyContainer = DummyContainer(
+            overrideWatchRepo = watchRepo,
+            overrideOsRepo = osRepo,
+            overrideSettingsRepo = settingsRepo,
+            overrideVideoRepo = videoRepo,
+        )
+        val viewModel = HistoryViewModel(dummyContainer)
+        backgroundScope.launch { viewModel.uiState.collect() }
+        advanceUntilIdle()
+
+        val items = viewModel.uiState.value.items
+        org.junit.Assert.assertEquals(1, items.size)
+
+        val sagaItem = items[0]
+        org.junit.Assert.assertEquals("Harry Potter Collection", sagaItem.videoName)
+        assertTrue(sagaItem.isSeriesGroup)
+        org.junit.Assert.assertFalse(sagaItem.isTvSeries)
+        assertTrue(sagaItem.isAvailableOnDisk)
+        org.junit.Assert.assertEquals(3000L, sagaItem.watchedAt)
+    }
+
+    @Test
+    fun `removeFromHistory nettoie l'etat vu et la progression de lecture pour un groupe`() = runTest(testDispatcher) {
+        val watchRepo = WatchStateRepository(watchedDao, playbackDao)
+        val settingsRepo = SettingsRepository(dataStore = null)
+        val osRepo = OpenSubtitlesRepository(UnusedOsApi(), settingsRepo, SubtitleCache(File("/tmp")))
+
+        val ep1 = VideoItem(name = "BB.S01E01.mkv", path = "/BB1.mp4")
+        val ep2 = VideoItem(name = "BB.S01E02.mkv", path = "/BB2.mp4")
+        val series = VideoItem(
+            name = "Breaking Bad",
+            seriesName = "Breaking Bad",
+            isSeriesGroup = true,
+            isTvSeries = true,
+            episodes = listOf(ep1, ep2),
+        )
+        val scanner = object : MediaScanner {
+            override fun scanVideoFiles(): List<VideoItem> = listOf(ep1, ep2)
+            override fun scanSubtitleFiles(): List<SubtitleEntry> = emptyList()
+            override fun scanAndGroup(
+                whitelistedVideos: Set<String>,
+                movieCollections: Map<String, MovieCollection>,
+                releaseDates: Map<String, String>,
+                rawVideos: List<VideoItem>?,
+            ): List<VideoItem> = listOf(series)
+        }
+        val videoRepo = VideoRepository(scanner)
+        videoRepo.scanAndLoad()
+
+        watchedDao.upsert(WatchedItemEntity(name = "BB.S01E01.mkv", watched = true))
+        playbackDao.upsert(PlaybackStateEntity(name = "BB.S01E02.mkv", progressPct = 50.0, positionMs = 1000L))
 
         val dummyContainer = DummyContainer(watchRepo, osRepo, settingsRepo, videoRepo)
         val viewModel = HistoryViewModel(dummyContainer)
         advanceUntilIdle()
 
-        viewModel.removeFromHistory("TestVideo.mp4")
+        viewModel.removeFromHistory("Breaking Bad")
         advanceUntilIdle()
 
-        assertTrue(watchedDao.items.value.none { it.name == "TestVideo.mp4" })
-        assertTrue(playbackDao.items.value.none { it.name == "TestVideo.mp4" })
+        assertTrue(watchedDao.items.value.none { it.name == "BB.S01E01.mkv" })
+        assertTrue(playbackDao.items.value.none { it.name == "BB.S01E02.mkv" })
     }
 
     private class DummyContainer(


### PR DESCRIPTION
## 📌 Description
Cette Pull Request regroupe l'ensemble des épisodes d'une même série TV ou des films d'une saga sous une seule carte dans l'onglet Historique, évitant la redondance d'afficher chaque épisode ou volet indépendamment.

## ✨ Changements principaux
- **HistoryViewModel** :
  - Regroupement automatique des sous-éléments visionnés ou en cours sous leur entité mère (Série TV ou Saga de films).
  - Calcul de la date de visionnage la plus récente (\watchedAt\) sur l'ensemble du groupe.
  - Détection de l'épisode actif / en cours de lecture et calcul de la progression globale.
  - Extension de \emoveFromHistory\ et \	oggleForceAvailable\ à l'intégralité des épisodes du groupe.
  - Gestion unifiée via \HistoryContext\ conforme aux seuils Detekt.
- **HistoryScreen** :
  - Affichage des badges **SÉRIE** et **SAGA** sur les vignettes.
  - Affichage de l'étiquette d'épisode / statut (\episodeLabel\).
  - Positionnement clair du badge « Non disponible ».
- **Tests unitaires (HistoryViewModelTest)** :
  - Couverture du regroupement des séries TV avec calcul de fraîcheur.
  - Couverture du regroupement des sagas de films (\MovieCollection\).
  - Validation du nettoyage complet lors de la suppression.

## 🧪 Validation
- [x] \./gradlew testDebugUnitTest\ passe avec succès (26 tâches).
- [x] \./gradlew detekt\ passe avec succès (0 violation).
- [x] Simulation de fusion \git merge-tree\ propre avec \origin/main\.