### PR TITLE
perf: utiliser w342 pour les affiches TMDB plutot que w500

### DIFF
--- a/native/app/src/main/java/com/localstream/app/domain/Formatters.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/Formatters.kt
@@ -105,7 +105,7 @@ object Formatters {
 
 object TmdbUrls {
     fun posterUrl(path: String?): String? = path?.let {
-        if (it.startsWith("http")) it else "https://image.tmdb.org/t/p/w500$it"
+        if (it.startsWith("http")) it else "https://image.tmdb.org/t/p/w342$it"
     }
     fun backdropUrl(path: String?): String? = path?.let {
         if (it.startsWith("http")) it else "https://image.tmdb.org/t/p/w1280$it"

--- a/native/app/src/main/java/com/localstream/app/domain/model/TmdbMetadata.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/model/TmdbMetadata.kt
@@ -19,7 +19,7 @@ data class TmdbMetadata(
     val collectionName: String? = null,
 ) {
     fun posterUrl(): String? = posterPath?.let {
-        if (it.startsWith("http")) it else "https://image.tmdb.org/t/p/w500$it"
+        if (it.startsWith("http")) it else "https://image.tmdb.org/t/p/w342$it"
     }
 
     fun backdropUrl(): String? = backdropPath?.let {

--- a/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/repository/TmdbRepositoryTest.kt
@@ -117,7 +117,7 @@ class TmdbRepositoryTest {
         assertNotNull(metadata)
         assertEquals("Fight Club", metadata?.title)
         assertEquals(550L, metadata?.tmdbId)
-        assertEquals("https://image.tmdb.org/t/p/w500/poster_fight_club.jpg", metadata?.posterUrl())
+        assertEquals("https://image.tmdb.org/t/p/w342/poster_fight_club.jpg", metadata?.posterUrl())
         assertEquals("https://image.tmdb.org/t/p/w1280/backdrop_fight_club.jpg", metadata?.backdropUrl())
         assertEquals(10L, metadata?.collectionId)
         assertEquals("Fight Club Collection", metadata?.collectionName)

--- a/native/app/src/test/java/com/localstream/app/domain/FormattersTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/FormattersTest.kt
@@ -56,7 +56,7 @@ class FormattersTest {
 
     @Test
     fun tmdbUrls_buildsCorrectImageUrls() {
-        assertEquals("https://image.tmdb.org/t/p/w500/abc.jpg", TmdbUrls.posterUrl("/abc.jpg"))
+        assertEquals("https://image.tmdb.org/t/p/w342/abc.jpg", TmdbUrls.posterUrl("/abc.jpg"))
         assertEquals("https://image.tmdb.org/t/p/w1280/abc.jpg", TmdbUrls.backdropUrl("/abc.jpg"))
         assertEquals("https://image.tmdb.org/t/p/w300/abc.jpg", TmdbUrls.stillUrl("/abc.jpg"))
         assertNull(TmdbUrls.posterUrl(null))

--- a/native/app/src/test/java/com/localstream/app/domain/VideoUiSelectorsTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/VideoUiSelectorsTest.kt
@@ -96,6 +96,6 @@ class VideoUiSelectorsTest {
         )
         assertTrue(VideoUiSelectors.isWatched(film, displayData))
         assertEquals(50.0, VideoUiSelectors.progressOf(film, displayData), 0.001)
-        assertEquals("https://image.tmdb.org/t/p/w500/poster.jpg", VideoUiSelectors.posterUrl(film, displayData))
+        assertEquals("https://image.tmdb.org/t/p/w342/poster.jpg", VideoUiSelectors.posterUrl(film, displayData))
     }
 }


### PR DESCRIPTION
## Resume\n\nCloses #176.\n\nLes affiches TMDB etaient servies en \w500\ alors que les cartes (VideoCard) les affichent a ~112 dp (~330 px en xxhdpi). Passage a \w342\, qui reste net jusqu'en xxxhdpi (~440 px) tout divisant la memoire bitmap allouee par vignette.\n\n## Changements\n\n- \TmdbMetadata.posterUrl()\ : w500 -> w342 (point d'entree reel des grilles/lignes via VideoUiSelectors)\n- \TmdbUrls.posterUrl()\ dans Formatters.kt : aligne sur w342 par coherence\n- \ackdropUrl()\ reste en w1280 (hero/details uniquement), comme demande dans l'issue\n- Tests unitaires mis a jour (FormattersTest, VideoUiSelectorsTest, TmdbRepositoryTest)\n\n## Verification\n\n- :white_check_mark: \:app:testDebugUnitTest\ + detekt : BUILD SUCCESSFUL (meme invocation que ci.yml)\n- :white_check_mark: Branch check : 0 commit de retard sur main, 0 conflit de merge (merge-tree PASS)\n- :information_source: Verification visuelle sur device haute densite non faite (pas d'emulateur disponible localement) ; w342 est le choix retenu parmi w185/w342 pour rester net en xxxhdpi