### PR TITLE
perf(library): éviter le re-tri complet à chaque mise à jour watched/progress

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -62,15 +63,22 @@ data class LibraryUiState(
     val watched: Map<String, Boolean> get() = displayData.watched
     val progress: Map<String, Double> get() = displayData.progress
 
-    /** Dates de sortie par clé de lookup (tri par date). */
-    val releaseDates: Map<String, String>
-        get() = metadata.mapNotNull { (key, meta) ->
+    // Mémoïsation interne : reconstruites uniquement quand l'état change,
+    // pas à chaque accès (withDerived y accède plusieurs fois par update).
+    private val cachedReleaseDates: Map<String, String> by lazy {
+        metadata.mapNotNull { (key, meta) ->
             meta.releaseDate?.takeIf { it.isNotBlank() }?.let { key to it }
         }.toMap()
+    }
+    private val cachedVideoGenres: Map<String, List<Int>> by lazy {
+        metadata.mapValues { it.value.genreIds }
+    }
+
+    /** Dates de sortie par clé de lookup (tri par date). */
+    val releaseDates: Map<String, String> get() = cachedReleaseDates
 
     /** Genres TMDB par clé de lookup (filtre par genre). */
-    val videoGenres: Map<String, List<Int>>
-        get() = metadata.mapValues { it.value.genreIds }
+    val videoGenres: Map<String, List<Int>> get() = cachedVideoGenres
 }
 
 /**
@@ -248,16 +256,31 @@ class LibraryViewModel(
 
     private fun observeWatchState() {
         viewModelScope.launch {
-            watchStateRepository.watchedItems.collect { watched ->
-                _uiState.update { it.copy(displayData = it.displayData.copy(watched = watched)).withDerived() }
-            }
-        }
-        viewModelScope.launch {
-            watchStateRepository.activePlaybackStates.collect { progress ->
-                _uiState.update { it.copy(displayData = it.displayData.copy(progress = progress)).withDerived() }
+            combine(
+                watchStateRepository.watchedItems,
+                watchStateRepository.activePlaybackStates,
+            ) { watched, progress -> watched to progress }.collect { (watched, progress) ->
+                _uiState.update { previous ->
+                    val next = previous.copy(
+                        displayData = previous.displayData.copy(watched = watched, progress = progress),
+                    )
+                    if (next.needsWatchStateResort(previous)) {
+                        next.withDerived()
+                    } else {
+                        // Seule la progression a changé : le tri/filtrage n'en dépend pas.
+                        next
+                    }
+                }
             }
         }
     }
+
+    /** True si le tri/filtrage doit être recalculé après un changement d'état de visionnage. */
+    private fun LibraryUiState.needsWatchStateResort(previous: LibraryUiState): Boolean =
+        sortBy != previous.sortBy ||
+            filterGenre != previous.filterGenre ||
+            filterResolution != previous.filterResolution ||
+            watched != previous.watched
 
     private fun observePreferences() {
         viewModelScope.launch {

--- a/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
@@ -240,6 +240,32 @@ class LibraryViewModelTest {
         assertEquals(3, viewModel.uiState.value.videos.size)
     }
 
+    @Test
+    fun `une mise a jour de progression seule ne declenche pas de re-tri complet`() = runTest(testDispatcher) {
+        viewModel.refreshLibrary()
+        advanceUntilIdle()
+
+        val initialFilteredSorted = viewModel.uiState.value.filteredSorted
+
+        // Écriture de progression seule (aucun changement watched / tri / filtre)
+        playbackDao.upsert(
+            PlaybackStateEntity(name = "Avatar.2009.2160p.mkv", progressPct = 42.0, positionMs = 1000L),
+        )
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(42.0, state.progress["Avatar.2009.2160p.mkv"]!!, 0.0)
+        assertEquals(
+            "Le re-tri ne doit pas être relancé pour une progression seule",
+            initialFilteredSorted,
+            state.filteredSorted,
+        )
+        assertTrue(
+            "L'instance de filteredSorted doit être conservée sans re-tri",
+            initialFilteredSorted === state.filteredSorted,
+        )
+    }
+
     // -------- Fakes --------
 
     private class FakeScanner(


### PR DESCRIPTION
## Résumé

Réduit le coût des mises à jour d'état de visionnage pendant la lecture vidéo, conformément à l'issue #174.

## Changements

- Combine watchedItems et activePlaybackStates en une seule émission d'état.
- Mémoïse releaseDates et videoGenres dans LibraryUiState (calculées une fois par état, plus à chaque accès).
- Saute le recompute filterAndSortVideos quand seule la progression a changé (tri, filtres et watched inchangés).
- Test unitaire vérifiant qu'une écriture de progression seule conserve l'instance filteredSorted.

Fixes #174