### PR TITLE
perf(domain): borner les rows Séries, Films et De A à Z à 50 items

### DIFF
--- a/native/app/src/main/java/com/localstream/app/domain/HomeRowsDeriver.kt
+++ b/native/app/src/main/java/com/localstream/app/domain/HomeRowsDeriver.kt
@@ -19,11 +19,12 @@ data class HomeRows(
  * Dérivation pure des rows de l'accueil (réf. `HomeScreen.tsx` + `App.tsx`).
  *
  * Ordre exact : "Continuer la lecture" (si non vide), "Nouveautés" (15),
- * "Recommandations" (15), "Séries", "Films", "De A à Z".
+ * "Recommandations" (15), "Séries" (50), "Films" (50), "De A à Z" (50).
  */
 object HomeRowsDeriver {
 
     const val ROW_LIMIT = 15
+    const val CATEGORY_ROW_LIMIT = 50
     const val CONTINUE_MAX_PROGRESS = 95.0
 
     fun derive(
@@ -50,12 +51,12 @@ object HomeRowsDeriver {
             },
             recentAdditions = unwatchedOnly(grouped.asReversed().take(ROW_LIMIT)),
             recommendations = unwatchedOnly(grouped.take(ROW_LIMIT)),
-            series = unwatchedOnly(grouped.filter { it.isSeriesGroup }),
-            movies = unwatchedOnly(grouped.filter { !it.isSeriesGroup }),
+            series = unwatchedOnly(grouped.filter { it.isSeriesGroup }).take(CATEGORY_ROW_LIMIT),
+            movies = unwatchedOnly(grouped.filter { !it.isSeriesGroup }).take(CATEGORY_ROW_LIMIT),
             alphabetical = unwatchedOnly(filteredSorted.sortedWith(
                 compareBy<VideoItem, String>(String.CASE_INSENSITIVE_ORDER) { it.name }
                     .thenBy { it.name },
-            )),
+            )).take(CATEGORY_ROW_LIMIT),
         )
     }
 }

--- a/native/app/src/test/java/com/localstream/app/domain/HomeRowsDeriverTest.kt
+++ b/native/app/src/test/java/com/localstream/app/domain/HomeRowsDeriverTest.kt
@@ -106,4 +106,16 @@ class HomeRowsDeriverTest {
         val rows = HomeRowsDeriver.derive(grouped, grouped, emptyMap(), progress)
         assertEquals(filmC, rows.heroCandidates.first())
     }
+
+    @Test
+    fun `séries, films et de A à Z sont bornés à 50 items maximum`() {
+        val manyMovies = (1..70).map { idx -> movie("Movie_" + idx + ".mp4", lastModified = idx.toLong()) }
+        val manySeries = (1..60).map { idx -> series("Series_" + idx, listOf(movie("Series_" + idx + "_ep1.mkv"))) }
+        val allGrouped = manyMovies + manySeries
+
+        val rows = HomeRowsDeriver.derive(allGrouped, allGrouped, emptyMap(), emptyMap())
+        assertEquals(50, rows.movies.size)
+        assertEquals(50, rows.series.size)
+        assertEquals(50, rows.alphabetical.size)
+    }
 }


### PR DESCRIPTION
## Description
Limite les rows « Séries », « Films » et « De A à Z » de l'écran d'accueil à 50 éléments maximum dans HomeRowsDeriver.kt, évitant ainsi la composition et le layout de carrousels horizontaux démesurés lors du scan de bibliothèques volumineuses.

## Modifications
- Ajout de const val CATEGORY_ROW_LIMIT = 50 dans HomeRowsDeriver.
- Application de .take(CATEGORY_ROW_LIMIT) sur les listes series, movies et lphabetical.
- Ajout d'un test unitaire dans HomeRowsDeriverTest vérifiant le bornage effectif à 50 éléments.

Closes #173