### PR TITLE
perf(ui): supprimer material-icons-extended au profit d'icônes ciblées

### DIFF
--- a/native/app/build.gradle.kts
+++ b/native/app/build.gradle.kts
@@ -104,7 +104,6 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.navigation.compose)
 
     // Phase 4 — Room

--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoCard.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoCard.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Replay
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -146,7 +146,7 @@ fun VideoCard(
                     contentAlignment = Alignment.Center,
                 ) {
                     Icon(
-                        imageVector = Icons.Filled.Replay,
+                        imageVector = AppIcons.Replay,
                         contentDescription = "Reprendre à zéro",
                         tint = Color.White,
                         modifier = Modifier.size(16.dp),

--- a/native/app/src/main/java/com/localstream/app/ui/navigation/Destinations.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/navigation/Destinations.kt
@@ -2,10 +2,8 @@ package com.localstream.app.ui.navigation
 
 import java.net.URLEncoder
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
-import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Movie
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.ui.graphics.vector.ImageVector
 
 /**
@@ -46,7 +44,7 @@ enum class TopLevelDestination(
     val labelRes: Int,
 ) {
     HOME(Routes.HOME, Icons.Filled.Home, com.localstream.app.R.string.tab_home),
-    LIBRARY(Routes.LIBRARY, Icons.Filled.Movie, com.localstream.app.R.string.tab_library),
-    PLAYLISTS(Routes.PLAYLISTS, Icons.AutoMirrored.Filled.PlaylistPlay, com.localstream.app.R.string.tab_playlists),
-    HISTORY(Routes.HISTORY, Icons.Filled.History, com.localstream.app.R.string.tab_history),
+    LIBRARY(Routes.LIBRARY, AppIcons.Movie, com.localstream.app.R.string.tab_library),
+    PLAYLISTS(Routes.PLAYLISTS, AppIcons.PlaylistPlay, com.localstream.app.R.string.tab_playlists),
+    HISTORY(Routes.HISTORY, AppIcons.History, com.localstream.app.R.string.tab_history),
 }

--- a/native/app/src/main/java/com/localstream/app/ui/player/BottomPlayerBar.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/BottomPlayerBar.kt
@@ -7,8 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.LockOpen
-import androidx.compose.material.icons.filled.PictureInPicture
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Slider
@@ -88,11 +87,11 @@ fun BottomPlayerBar(
             )
             Row {
                 IconButton(onClick = onEnterPip) {
-                    Icon(Icons.Filled.PictureInPicture, contentDescription = "PiP", tint = White)
+                    Icon(AppIcons.PictureInPicture, contentDescription = "PiP", tint = White)
                 }
                 IconButton(onClick = onToggleLock) {
                     Icon(
-                        imageVector = if (isLocked) Icons.Filled.Lock else Icons.Filled.LockOpen,
+                        imageVector = if (isLocked) Icons.Filled.Lock else AppIcons.LockOpen,
                         contentDescription = "Verrouiller",
                         tint = White,
                     )

--- a/native/app/src/main/java/com/localstream/app/ui/player/CenterPlayerControls.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/CenterPlayerControls.kt
@@ -8,11 +8,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Forward10
-import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Replay10
-import androidx.compose.material.icons.filled.SkipNext
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
@@ -39,7 +36,7 @@ fun CenterPlayerControls(
         horizontalArrangement = Arrangement.spacedBy(24.dp),
     ) {
         IconButton(onClick = onRewind, modifier = Modifier.size(48.dp)) {
-            Icon(Icons.Filled.Replay10, contentDescription = "Reculer 10s", tint = White, modifier = Modifier.size(36.dp))
+            Icon(AppIcons.Replay10, contentDescription = "Reculer 10s", tint = White, modifier = Modifier.size(36.dp))
         }
 
         Box(
@@ -51,7 +48,7 @@ fun CenterPlayerControls(
             contentAlignment = Alignment.Center,
         ) {
             Icon(
-                imageVector = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                imageVector = if (isPlaying) AppIcons.Pause else Icons.Filled.PlayArrow,
                 contentDescription = if (isPlaying) "Pause" else "Lecture",
                 tint = White,
                 modifier = Modifier.size(40.dp),
@@ -59,12 +56,12 @@ fun CenterPlayerControls(
         }
 
         IconButton(onClick = onForward, modifier = Modifier.size(48.dp)) {
-            Icon(Icons.Filled.Forward10, contentDescription = "Avancer 10s", tint = White, modifier = Modifier.size(36.dp))
+            Icon(AppIcons.Forward10, contentDescription = "Avancer 10s", tint = White, modifier = Modifier.size(36.dp))
         }
 
         if (hasNextVideo) {
             IconButton(onClick = onNextVideo, modifier = Modifier.size(48.dp)) {
-                Icon(Icons.Filled.SkipNext, contentDescription = "Épisode suivant", tint = White, modifier = Modifier.size(36.dp))
+                Icon(AppIcons.SkipNext, contentDescription = "Épisode suivant", tint = White, modifier = Modifier.size(36.dp))
             }
         }
     }

--- a/native/app/src/main/java/com/localstream/app/ui/player/GestureFeedbackCard.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/GestureFeedbackCard.kt
@@ -5,11 +5,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Brightness6
-import androidx.compose.material.icons.filled.Forward10
-import androidx.compose.material.icons.filled.Replay10
-import androidx.compose.material.icons.filled.VolumeUp
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -40,10 +36,10 @@ fun GestureFeedbackCard(
         ) {
             Icon(
                 imageVector = when (feedback.type) {
-                    FeedbackType.VOLUME -> Icons.Filled.VolumeUp
-                    FeedbackType.BRIGHTNESS -> Icons.Filled.Brightness6
-                    FeedbackType.SEEK_FORWARD -> Icons.Filled.Forward10
-                    FeedbackType.SEEK_REWIND -> Icons.Filled.Replay10
+                    FeedbackType.VOLUME -> AppIcons.VolumeUp
+                    FeedbackType.BRIGHTNESS -> AppIcons.Brightness6
+                    FeedbackType.SEEK_FORWARD -> AppIcons.Forward10
+                    FeedbackType.SEEK_REWIND -> AppIcons.Replay10
                 },
                 contentDescription = null,
                 tint = White,

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
@@ -31,8 +31,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Lock
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -530,7 +530,7 @@ fun PlayerScreen(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Icon(
-                        imageVector = Icons.Filled.ErrorOutline,
+                        imageVector = AppIcons.ErrorOutline,
                         contentDescription = null,
                         tint = Red600,
                         modifier = Modifier.size(48.dp),

--- a/native/app/src/main/java/com/localstream/app/ui/player/TopPlayerBar.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/TopPlayerBar.kt
@@ -10,9 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AspectRatio
-import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.Subtitles
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -65,17 +63,17 @@ fun TopPlayerBar(
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
             IconButton(onClick = onOpenTracks) {
-                Icon(Icons.Filled.Subtitles, contentDescription = "Sous-titres & Audio", tint = White)
+                Icon(AppIcons.Subtitles, contentDescription = "Sous-titres & Audio", tint = White)
             }
             IconButton(onClick = onCycleAspect) {
-                Icon(Icons.Filled.AspectRatio, contentDescription = "Format : ${aspectRatioMode.label}", tint = White)
+                Icon(AppIcons.AspectRatio, contentDescription = "Format : ${aspectRatioMode.label}", tint = White)
             }
             Button(
                 onClick = onCycleSpeed,
                 colors = ButtonDefaults.buttonColors(containerColor = Zinc800),
                 contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
             ) {
-                Icon(Icons.Filled.Speed, contentDescription = null, tint = White, modifier = Modifier.size(16.dp))
+                Icon(AppIcons.Speed, contentDescription = null, tint = White, modifier = Modifier.size(16.dp))
                 Spacer(modifier = Modifier.width(4.dp))
                 Text("${playbackSpeed}x", color = White, fontSize = 12.sp)
             }

--- a/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
@@ -25,13 +25,10 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.ClosedCaption
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -382,7 +379,7 @@ private fun DetailsActionButtons(
             colors = ButtonDefaults.buttonColors(containerColor = Zinc800, contentColor = White),
             shape = RoundedCornerShape(4.dp),
         ) {
-            Icon(Icons.AutoMirrored.Filled.PlaylistAdd, contentDescription = null)
+            Icon(AppIcons.PlaylistAdd, contentDescription = null)
             Text(text = "MA LISTE", modifier = Modifier.padding(start = 4.dp))
         }
 
@@ -398,7 +395,7 @@ private fun DetailsActionButtons(
         }
 
         IconButton(onClick = onShowSubtitleSheet) {
-            Icon(Icons.Filled.ClosedCaption, contentDescription = "Sous-titres", tint = White)
+            Icon(AppIcons.ClosedCaption, contentDescription = "Sous-titres", tint = White)
         }
     }
 }
@@ -678,7 +675,7 @@ private fun EpisodeItemRow(
 
                 IconButton(onClick = onToggleExpanded) {
                     Icon(
-                        if (ep.isExpanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                        if (ep.isExpanded) AppIcons.ExpandLess else AppIcons.ExpandMore,
                         contentDescription = "Détails de l'épisode",
                         tint = White,
                     )

--- a/native/app/src/main/java/com/localstream/app/ui/screens/HistoryScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/HistoryScreen.kt
@@ -19,10 +19,8 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Cloud
-import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.DeleteSweep
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -165,7 +163,7 @@ fun HistoryScreen(
 
                 if (uiState.items.isNotEmpty()) {
                     IconButton(onClick = viewModel::clearHistory) {
-                        Icon(Icons.Filled.DeleteSweep, contentDescription = "Vider l'historique", tint = White)
+                        Icon(AppIcons.DeleteSweep, contentDescription = "Vider l'historique", tint = White)
                     }
                 }
             }
@@ -323,7 +321,7 @@ private fun HistoryItemCard(
                 ) {
                     IconButton(onClick = onToggleForceAvailable, modifier = Modifier.size(28.dp)) {
                         Icon(
-                            if (item.isForceAvailable) Icons.Filled.Cloud else Icons.Filled.CloudOff,
+                            if (item.isForceAvailable) AppIcons.Cloud else AppIcons.CloudOff,
                             contentDescription = "Disponibilité",
                             tint = if (item.isForceAvailable) Red600 else White.copy(alpha = 0.5f),
                             modifier = Modifier.size(18.dp),

--- a/native/app/src/main/java/com/localstream/app/ui/screens/HomeScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/HomeScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.outlined.Image
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -255,7 +255,7 @@ private fun TmdbBanner(
         verticalAlignment = Alignment.Top,
     ) {
         Icon(
-            imageVector = Icons.Outlined.Image,
+            imageVector = AppIcons.Image,
             contentDescription = null,
             tint = Red600,
             modifier = Modifier.padding(top = 2.dp),

--- a/native/app/src/main/java/com/localstream/app/ui/screens/PermissionScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PermissionScreen.kt
@@ -12,8 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FolderOpen
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -62,7 +61,7 @@ fun PermissionScreen(
         verticalArrangement = Arrangement.Center,
     ) {
         Icon(
-            imageVector = Icons.Filled.FolderOpen,
+            imageVector = AppIcons.FolderOpen,
             contentDescription = null,
             tint = Red600,
             modifier = Modifier

--- a/native/app/src/main/java/com/localstream/app/ui/screens/PlaylistsScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/PlaylistsScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.PlaylistPlay
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -273,7 +273,7 @@ private fun PlaylistCard(
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
-                    Icons.Filled.PlaylistPlay,
+                    AppIcons.PlaylistPlay,
                     contentDescription = null,
                     tint = Red600,
                     modifier = Modifier.height(40.dp),

--- a/native/app/src/main/java/com/localstream/app/ui/screens/SettingsScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/SettingsScreen.kt
@@ -15,11 +15,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
-import androidx.compose.material.icons.filled.Error
-import androidx.compose.material.icons.filled.Movie
-import androidx.compose.material.icons.filled.OpenInNew
-import androidx.compose.material.icons.filled.Subtitles
-import androidx.compose.material.icons.filled.VpnKey
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -116,7 +112,7 @@ fun SettingsScreen(
             Card(colors = CardDefaults.cardColors(containerColor = Zinc900), modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.Filled.VpnKey, contentDescription = null, tint = Red600)
+                        Icon(AppIcons.VpnKey, contentDescription = null, tint = Red600)
                         Text(
                             text = stringResource(R.string.settings_tmdb_title),
                             color = White,
@@ -184,7 +180,7 @@ fun SettingsScreen(
                                 modifier = Modifier.weight(1f, fill = false),
                             ) {
                                 Icon(
-                                    imageVector = if (isSuccess) Icons.Filled.CheckCircle else Icons.Filled.Error,
+                                    imageVector = if (isSuccess) Icons.Filled.CheckCircle else AppIcons.Error,
                                     contentDescription = null,
                                     tint = if (isSuccess) White else Red600,
                                     modifier = Modifier.size(18.dp),
@@ -205,7 +201,7 @@ fun SettingsScreen(
             Card(colors = CardDefaults.cardColors(containerColor = Zinc900), modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.Filled.Subtitles, contentDescription = null, tint = Red600)
+                        Icon(AppIcons.Subtitles, contentDescription = null, tint = Red600)
                         Text(
                             text = stringResource(R.string.settings_opensubtitles_title),
                             color = White,
@@ -301,7 +297,7 @@ fun SettingsScreen(
             Card(colors = CardDefaults.cardColors(containerColor = Zinc900), modifier = Modifier.fillMaxWidth()) {
                 Column(modifier = Modifier.padding(16.dp)) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.Filled.Movie, contentDescription = null, tint = Red600)
+                        Icon(AppIcons.Movie, contentDescription = null, tint = Red600)
                         Text(
                             text = stringResource(R.string.settings_player_title),
                             color = White,
@@ -390,7 +386,7 @@ fun SettingsScreen(
                 shape = RoundedCornerShape(4.dp),
                 modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
             ) {
-                Icon(Icons.Filled.OpenInNew, contentDescription = null, tint = White)
+                Icon(AppIcons.OpenInNew, contentDescription = null, tint = White)
                 Text(stringResource(R.string.settings_system_apps_settings), color = White, modifier = Modifier.padding(start = 8.dp))
             }
         }

--- a/native/app/src/main/java/com/localstream/app/ui/subtitles/SubtitlePickerSheet.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/subtitles/SubtitlePickerSheet.kt
@@ -13,9 +13,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CloudDownload
-import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.Search
+import com.localstream.app.ui.theme.AppIcons
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -166,7 +165,7 @@ fun SubtitlePickerSheet(
                     shape = RoundedCornerShape(4.dp),
                     modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
                 ) {
-                    Icon(Icons.Filled.FolderOpen, contentDescription = null, tint = Red600)
+                    Icon(AppIcons.FolderOpen, contentDescription = null, tint = Red600)
                     Text("Sélectionner un fichier (.srt, .vtt)", color = White, modifier = Modifier.padding(start = 8.dp))
                 }
             }
@@ -195,7 +194,7 @@ private fun SubtitleItemRow(
             Text(text = "Langue : ${item.language.uppercase()}", color = White.copy(alpha = 0.6f), style = MaterialTheme.typography.bodySmall)
         }
         IconButton(onClick = onDownload) {
-            Icon(Icons.Filled.CloudDownload, contentDescription = "Télécharger", tint = Red600)
+            Icon(AppIcons.CloudDownload, contentDescription = "Télécharger", tint = Red600)
         }
     }
 }

--- a/native/app/src/main/java/com/localstream/app/ui/theme/AppIcons.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/theme/AppIcons.kt
@@ -1,0 +1,141 @@
+package com.localstream.app.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.PathParser
+import androidx.compose.ui.unit.dp
+
+object AppIcons {
+    private fun icon(name: String, pathData: String, autoMirror: Boolean = false): ImageVector {
+        return ImageVector.Builder(
+            name = name,
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+            autoMirror = autoMirror,
+        ).apply {
+            addPath(
+                pathData = PathParser().parsePathString(pathData).toNodes(),
+                fill = SolidColor(Color.Black),
+            )
+        }.build()
+    }
+
+    val Movie: ImageVector by lazy {
+        icon("Movie", "M18 4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4h-4z")
+    }
+
+    val History: ImageVector by lazy {
+        icon("History", "M13 3c-4.97 0-9 4.03-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-7 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C8.27 19.99 10.51 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z")
+    }
+
+    val PlaylistPlay: ImageVector by lazy {
+        icon("PlaylistPlay", "M4 10h12v2H4zm0-4h12v2H4zm0 8h8v2H4zm10 0v6l5-3z", autoMirror = true)
+    }
+
+    val PlaylistAdd: ImageVector by lazy {
+        icon("PlaylistAdd", "M14 10H2v2h12v-2zm0-4H2v2h12V6zm4 8v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zM2 16h8v-2H2v2z", autoMirror = true)
+    }
+
+    val Replay: ImageVector by lazy {
+        icon("Replay", "M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z")
+    }
+
+    val Pause: ImageVector by lazy {
+        icon("Pause", "M6 19h4V5H6v14zm8-14v14h4V5h-4z")
+    }
+
+    val SkipNext: ImageVector by lazy {
+        icon("SkipNext", "M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z")
+    }
+
+    val Replay10: ImageVector by lazy {
+        icon("Replay10", "M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8zm-1.8 11.3h-.9v-3.5h-.9v-.8h1.8v4.3zm3.7-.8c0 .6-.4 1-1 1s-1-.4-1-1v-2.3c0-.6.4-1 1-1s1 .4 1 1v2.3zm-.9-2.5c-.2 0-.3.1-.3.3v2.7c0 .2.1.3.3.3s.3-.1.3-.3V13c0-.2-.1-.3-.3-.3z")
+    }
+
+    val Forward10: ImageVector by lazy {
+        icon("Forward10", "M12 5V1l5 5-5 5V7c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6h2c0 4.42-3.58 8-8 8s-8-3.58-8-8 3.58-8 8-8zm-1.8 11.3h-.9v-3.5h-.9v-.8h1.8v4.3zm3.7-.8c0 .6-.4 1-1 1s-1-.4-1-1v-2.3c0-.6.4-1 1-1s1 .4 1 1v2.3zm-.9-2.5c-.2 0-.3.1-.3.3v2.7c0 .2.1.3.3.3s.3-.1.3-.3V13c0-.2-.1-.3-.3-.3z")
+    }
+
+    val LockOpen: ImageVector by lazy {
+        icon("LockOpen", "M12 17c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm6-9h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6h1.9c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm0 12H6V10h12v10z")
+    }
+
+    val PictureInPicture: ImageVector by lazy {
+        icon("PictureInPicture", "M19 7h-8v6h8V7zm2-4H3c-1.1 0-2 .9-2 2v14c0 1.1.9 1.98 2 1.98h18c1.1 0 2-.88 2-1.98V5c0-1.1-.9-2-2-2zm0 16.01H3V4.98h18v14.03z")
+    }
+
+    val VolumeUp: ImageVector by lazy {
+        icon("VolumeUp", "M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z", autoMirror = true)
+    }
+
+    val Brightness6: ImageVector by lazy {
+        icon("Brightness6", "M20 8.69V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69zM12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6zm0-10v8c2.21 0 4-1.79 4-4s-1.79-4-4-4z")
+    }
+
+    val ErrorOutline: ImageVector by lazy {
+        icon("ErrorOutline", "M11 15h2v2h-2zm0-8h2v6h-2zm1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z")
+    }
+
+    val AspectRatio: ImageVector by lazy {
+        icon("AspectRatio", "M19 12h-2v3h-3v2h5v-5zM7 9h3V7H5v5h2V9zm14-6H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16.01H3V4.99h18v14.02z")
+    }
+
+    val Speed: ImageVector by lazy {
+        icon("Speed", "M20.38 8.57l-1.23 1.85a8 8 0 0 1-.22 7.58H5.07A8 8 0 0 1 15.58 6.85l1.85-1.23A10 10 0 0 0 3.35 19a2 2 0 0 0 1.72 1h13.85a2 2 0 0 0 1.74-1 10 10 0 0 0-.27-10.44zm-9.79 6.84a2 2 0 0 0 2.83 0l5.66-8.49-8.49 5.66a2 2 0 0 0 0 2.83z")
+    }
+
+    val Subtitles: ImageVector by lazy {
+        icon("Subtitles", "M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-10 7H4v-2h6v2zm0 4H4v-2h6v2zm10 0h-8v-2h8v2zm0-4h-8v-2h8v2z")
+    }
+
+    val ClosedCaption: ImageVector by lazy {
+        icon("ClosedCaption", "M19 4H5c-1.11 0-2 .9-2 2v12c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm-8 7H9.5v-.5h-2v3h2V13H11v1c0 .55-.45 1-1 1H7c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1h3c.55 0 1 .45 1 1v1zm7 0h-1.5v-.5h-2v3h2V13H18v1c0 .55-.45 1-1 1h-3c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1h3c.55 0 1 .45 1 1v1z")
+    }
+
+    val ExpandLess: ImageVector by lazy {
+        icon("ExpandLess", "M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z")
+    }
+
+    val ExpandMore: ImageVector by lazy {
+        icon("ExpandMore", "M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z")
+    }
+
+    val Cloud: ImageVector by lazy {
+        icon("Cloud", "M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z")
+    }
+
+    val CloudOff: ImageVector by lazy {
+        icon("CloudOff", "M19.35 10.04C18.67 6.59 15.64 4 12 4c-1.48 0-2.85.43-4.01 1.17l1.46 1.46C10.21 6.23 11.08 6 12 6c3.04 0 5.5 2.46 5.5 5.5v.5H19c1.66 0 3 1.34 3 3 0 1.13-.64 2.11-1.56 2.62l1.45 1.45C23.16 17.67 24 16.44 24 15c0-2.64-2.05-4.78-4.65-4.96zM3 5.27l2.75 2.74C5.6 8.33 5.35 8.65 5.35 9.04 2.34 9.36 0 11.91 0 15c0 3.31 2.69 6 6 6h11.73l2 2 1.41-1.41L4.41 3.86 3 5.27zM7.73 10l8 8H6c-2.21 0-4-1.79-4-4s1.79-4 4-4h1.73z")
+    }
+
+    val DeleteSweep: ImageVector by lazy {
+        icon("DeleteSweep", "M15 16h4v2h-4zm0-8h7v2h-7zm0 4h6v2h-6zM3 18c0 1.1.9 2 2 2h6c1.1 0 2-.9 2-2V8H3v10zM14 5h-3l-1-1H6L5 5H2v2h12z")
+    }
+
+    val Image: ImageVector by lazy {
+        icon("Image", "M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z")
+    }
+
+    val FolderOpen: ImageVector by lazy {
+        icon("FolderOpen", "M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z")
+    }
+
+    val Error: ImageVector by lazy {
+        icon("Error", "M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z")
+    }
+
+    val OpenInNew: ImageVector by lazy {
+        icon("OpenInNew", "M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z", autoMirror = true)
+    }
+
+    val VpnKey: ImageVector by lazy {
+        icon("VpnKey", "M12.65 10C11.83 7.67 9.61 6 7 6c-3.31 0-6 2.69-6 6s2.69 6 6 6c2.61 0 4.83-1.67 5.65-4H17v4h4v-4h2v-4H12.65zM7 14c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z")
+    }
+
+    val CloudDownload: ImageVector by lazy {
+        icon("CloudDownload", "M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z")
+    }
+}

--- a/native/gradle/libs.versions.toml
+++ b/native/gradle/libs.versions.toml
@@ -42,7 +42,6 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }


### PR DESCRIPTION
## Description
Supprime la dépendance material-icons-extended qui embarquait des milliers de classes vectorielles inutilisées dans le DEX et ralentissait les builds et le démarrage. Les icônes nécessaires non présentes dans le core de Compose Material sont désormais définies directement dans un composant ciblé AppIcons.

## Modifications
- Création de AppIcons dans com.localstream.app.ui.theme avec les ImageVector nécessaires à l'application.
- Remplacement des imports ndroidx.compose.material.icons.filled.* par AppIcons.* dans les composants et écrans UI.
- Suppression de la dépendance ndroidx-material-icons-extended dans libs.versions.toml et pp/build.gradle.kts.

Closes #177