### PR TITLE
fix(player): Corriger la fermeture et le crash lors du lancement d'une vidéo

### DIFF
--- a/native/app/src/main/AndroidManifest.xml
+++ b/native/app/src/main/AndroidManifest.xml
@@ -5,12 +5,17 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- Maintien de l'écran et du CPU allumés pendant la lecture vidéo (ExoPlayer) -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
     <!-- Scan MediaStore (Phase 3) : lecture des vidéos du stockage partagé.
          READ_MEDIA_VIDEO à partir d'Android 13, READ_EXTERNAL_STORAGE avant. -->
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
+    <!-- Android 14+ sélection partielle de médias -->
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
 
     <application
         android:name=".LocalStreamApplication"
@@ -25,7 +30,7 @@
 
         <activity
             android:name=".MainActivity"
-            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|density"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|density|keyboard|keyboardHidden|navigation|uiMode|fontScale"
             android:exported="true"
             android:label="@string/app_name"
             android:resizeableActivity="true"

--- a/native/app/src/main/java/com/localstream/app/ui/permission/StoragePermissions.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/permission/StoragePermissions.kt
@@ -13,14 +13,37 @@ import androidx.core.content.ContextCompat
 object StoragePermissions {
 
     val required: Array<String>
-        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            arrayOf(Manifest.permission.READ_MEDIA_VIDEO)
-        } else {
-            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+        get() = when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE ->
+                arrayOf(Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED)
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ->
+                arrayOf(Manifest.permission.READ_MEDIA_VIDEO)
+            else ->
+                arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
         }
 
-    fun hasStoragePermission(context: Context): Boolean =
-        required.all {
-            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+    fun hasStoragePermission(context: Context): Boolean = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.READ_MEDIA_VIDEO,
+            ) == PackageManager.PERMISSION_GRANTED ||
+                ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+                ) == PackageManager.PERMISSION_GRANTED
         }
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.READ_MEDIA_VIDEO,
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+        else -> {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+    }
 }

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
@@ -18,6 +18,7 @@ import android.os.SystemClock
 import android.util.Rational
 import android.view.ViewGroup
 import android.view.WindowManager
+import java.io.File
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -141,6 +142,13 @@ fun PlayerScreen(
                 val insetsController = WindowCompat.getInsetsController(window, window.decorView)
                 insetsController.show(WindowInsetsCompat.Type.systemBars())
             }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && activity != null) {
+                runCatching {
+                    activity.setPictureInPictureParams(
+                        PictureInPictureParams.Builder().setAutoEnterEnabled(false).build(),
+                    )
+                }
+            }
         }
     }
 
@@ -158,28 +166,34 @@ fun PlayerScreen(
     var dragStartSeekPos by remember { mutableLongStateOf(0L) }
 
     LaunchedEffect(Unit) {
-        audioManager?.let { am ->
-            val maxVol = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
-            if (maxVol > 0) {
-                val curVol = am.getStreamVolume(AudioManager.STREAM_MUSIC)
-                val curPct = ((curVol.toFloat() / maxVol) * 100f).coerceIn(0f, 100f)
-                viewModel.setInitialVolumePercent(curPct)
+        try {
+            audioManager?.let { am ->
+                val maxVol = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+                if (maxVol > 0) {
+                    val curVol = am.getStreamVolume(AudioManager.STREAM_MUSIC)
+                    val curPct = ((curVol.toFloat() / maxVol) * 100f).coerceIn(0f, 100f)
+                    viewModel.setInitialVolumePercent(curPct)
+                }
             }
+        } catch (_: Exception) {
         }
         isVolumeInitialized = true
     }
 
     LaunchedEffect(uiState.volumePercent, isVolumeInitialized) {
         if (!isVolumeInitialized) return@LaunchedEffect
-        audioManager?.let { am ->
-            val maxVol = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
-            if (maxVol > 0) {
-                val targetVol = ((uiState.volumePercent / 100f) * maxVol).roundToInt().coerceIn(0, maxVol)
-                val curVol = am.getStreamVolume(AudioManager.STREAM_MUSIC)
-                if (curVol != targetVol) {
-                    am.setStreamVolume(AudioManager.STREAM_MUSIC, targetVol, 0)
+        try {
+            audioManager?.let { am ->
+                val maxVol = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+                if (maxVol > 0) {
+                    val targetVol = ((uiState.volumePercent / 100f) * maxVol).roundToInt().coerceIn(0, maxVol)
+                    val curVol = am.getStreamVolume(AudioManager.STREAM_MUSIC)
+                    if (curVol != targetVol) {
+                        am.setStreamVolume(AudioManager.STREAM_MUSIC, targetVol, 0)
+                    }
                 }
             }
+        } catch (_: Exception) {
         }
     }
 
@@ -247,16 +261,24 @@ fun PlayerScreen(
             .build()
     }
 
-    val loudnessEnhancer = remember(exoPlayer) {
-        try {
-            val audioSessionId = exoPlayer.audioSessionId
-            if (audioSessionId != C.AUDIO_SESSION_ID_UNSET && audioSessionId != 0) {
-                LoudnessEnhancer(audioSessionId)
-            } else {
-                null
+    var loudnessEnhancer by remember { mutableStateOf<LoudnessEnhancer?>(null) }
+
+    LaunchedEffect(uiState.isAudioBoostEnabled) {
+        if (uiState.isAudioBoostEnabled && loudnessEnhancer == null) {
+            try {
+                val audioSessionId = exoPlayer.audioSessionId
+                if (audioSessionId != C.AUDIO_SESSION_ID_UNSET && audioSessionId != 0) {
+                    loudnessEnhancer = LoudnessEnhancer(audioSessionId)
+                }
+            } catch (_: Exception) {
+                loudnessEnhancer = null
             }
-        } catch (_: Exception) {
-            null
+        } else if (!uiState.isAudioBoostEnabled && loudnessEnhancer != null) {
+            try {
+                loudnessEnhancer?.release()
+            } catch (_: Exception) {
+            }
+            loudnessEnhancer = null
         }
     }
 
@@ -272,10 +294,11 @@ fun PlayerScreen(
         }
     }
 
-    DisposableEffect(loudnessEnhancer) {
+    DisposableEffect(Unit) {
         onDispose {
             try {
                 loudnessEnhancer?.release()
+                loudnessEnhancer = null
             } catch (_: Exception) {
             }
         }
@@ -328,9 +351,6 @@ fun PlayerScreen(
                         if (floatRatio in 0.42f..2.38f) {
                             val rational = Rational(width.coerceIn(1, 2390), height.coerceIn(1, 2390))
                             val pipBuilder = PictureInPictureParams.Builder().setAspectRatio(rational)
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                                pipBuilder.setAutoEnterEnabled(true)
-                            }
                             runCatching { activity.setPictureInPictureParams(pipBuilder.build()) }
                         }
                     }
@@ -911,10 +931,16 @@ private fun launchExternalPlayer(context: Context, video: VideoItem, packageName
 private fun extractUri(video: VideoItem?): Uri? {
     if (video == null) return null
     if (video.url.isNotBlank()) {
-        return Uri.parse(video.url)
+        val parsed = Uri.parse(video.url)
+        return if (parsed.scheme != null) parsed else Uri.fromFile(File(video.url))
     }
     if (video.path.isNotBlank()) {
-        return Uri.parse(video.path)
+        val parsed = Uri.parse(video.path)
+        return if (parsed.scheme != null) parsed else Uri.fromFile(File(video.path))
+    }
+    if (!video.nativeUri.isNullOrBlank()) {
+        val parsed = Uri.parse(video.nativeUri)
+        return if (parsed.scheme != null) parsed else Uri.fromFile(File(video.nativeUri))
     }
     return null
 }

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -156,8 +156,14 @@ class PlayerViewModel(
     private fun loadVideoDetails() {
         viewModelScope.launch {
             val decodedName = decodeUri(videoName)
-            val allRaw = container.videoRepository.getRawVideos()
-            val allGrouped = container.videoRepository.getGroupedVideos()
+            var allRaw = container.videoRepository.getRawVideos()
+            var allGrouped = container.videoRepository.getGroupedVideos()
+
+            if (allRaw.isEmpty() && allGrouped.isEmpty()) {
+                container.videoRepository.scanAndLoad()
+                allRaw = container.videoRepository.getRawVideos()
+                allGrouped = container.videoRepository.getGroupedVideos()
+            }
 
             val targetVideo = resolveTargetVideo(decodedName, videoName, allGrouped, allRaw)
 
@@ -515,19 +521,16 @@ class PlayerViewModel(
         viewModelScope.launch {
             _uiState.update { it.copy(isEnded = false) }
             val decodedName = decodeUri(newName)
-            val allRaw = container.videoRepository.getRawVideos()
-            val allGrouped = container.videoRepository.getGroupedVideos()
+            var allRaw = container.videoRepository.getRawVideos()
+            var allGrouped = container.videoRepository.getGroupedVideos()
 
-            val foundInGrouped = allGrouped.firstNotNullOfOrNull { group ->
-                if (group.name == decodedName || group.name == newName) {
-                    group
-                } else {
-                    group.episodes?.find { it.name == decodedName || it.name == newName }
-                }
+            if (allRaw.isEmpty() && allGrouped.isEmpty()) {
+                container.videoRepository.scanAndLoad()
+                allRaw = container.videoRepository.getRawVideos()
+                allGrouped = container.videoRepository.getGroupedVideos()
             }
-            val video = allRaw.find { it.name == decodedName || it.name == newName }
-                ?: foundInGrouped
-                ?: createFallbackVideoItem(decodedName)
+
+            val video = resolveTargetVideo(decodedName, newName, allGrouped, allRaw)
 
             val watchedMap = container.watchStateRepository.getWatchedMap()
             val isWatched = watchedMap[video.name] == true


### PR DESCRIPTION
## 🎯 Problème résolu
L'application se fermait brutalement ou revenait à l'accueil lors du lancement d'un film ou d'un épisode de série.

## 🛠️ Corrections apportées
1. **Permission \WAKE_LOCK\** : ajout dans \AndroidManifest.xml\ requis par le mode wake lock d'ExoPlayer (\C.WAKE_MODE_LOCAL\) pour éviter les \SecurityException\.
2. **Gestion des changements d'orientation** : enrichissement de \ndroid:configChanges\ dans \AndroidManifest.xml\ avec \keyboard|keyboardHidden|navigation|uiMode|fontScale\ pour éviter la récréation de l'activité \MainActivity\ lors du passage en mode paysage.
3. **Comportement PiP** : suppression de \setAutoEnterEnabled(true)\ inconditionnel lors du changement de ratio vidéo qui forçait l'application en arrière-plan sur Android 12+, et réinitialisation de \utoEnterEnabled\ dans le \onDispose\ du lecteur.
4. **URIs locales** : normalisation des chemins de fichiers locaux sans schéma avec \Uri.fromFile(File(...))\ dans \extractUri\.
5. **Robustesse \LoudnessEnhancer\ & \AudioManager\** : initialisation paresseuse et sécurisée de l'amplification audio et protection \	ry-catch\ des accès volume.
6. **Rechargement résilient des vidéos** : appel automatique à \scanAndLoad()\ dans \PlayerViewModel\ si la liste des vidéos n'est pas encore initialisée au moment du lancement.
7. **Permissions Android 14+** : support de \READ_MEDIA_VISUAL_USER_SELECTED\ dans \StoragePermissions.kt\.

## 🧪 Validations
- \./gradlew testDebugUnitTest\ : ✅ Validé
- \./gradlew detekt\ : ✅ Validé
- \./gradlew assembleDebug\ : ✅ Validé