### PR TITLE
perf(player): eviter la recomposition de l overlay masque pendant la lecture

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerControlsOverlay.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerControlsOverlay.kt
@@ -47,19 +47,21 @@ fun PlayerControlsOverlay(
     positionMs: Long = 0L,
     positionMsFlow: StateFlow<Long>? = null,
 ) {
-    val currentPosition = if (positionMsFlow != null) {
-        val pos by positionMsFlow.collectAsStateWithLifecycle()
-        pos
-    } else {
-        positionMs
-    }
-
     AnimatedVisibility(
         visible = isVisible && !isLocked,
         enter = fadeIn(),
         exit = fadeOut(),
         modifier = modifier.fillMaxSize(),
     ) {
+        // Collectée ici, dans le contenu visible : hors écran, l'overlay
+        // ne se recompose plus à chaque tick de position (4x/seconde).
+        val currentPosition = if (positionMsFlow != null) {
+            val pos by positionMsFlow.collectAsStateWithLifecycle()
+            pos
+        } else {
+            positionMs
+        }
+
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -104,4 +106,3 @@ fun PlayerControlsOverlay(
         }
     }
 }
-


### PR DESCRIPTION
## Description\nPendant la lecture, PlayerScreen met à jour positionMsFlow toutes les 250 ms. La collecte se faisait en tête de PlayerControlsOverlay, avant l'AnimatedVisibility : l'overlay entier se recomposait donc 4 fois par seconde pendant toute la lecture, même masqué, gaspillant du CPU en concurrence directe avec le décodage Media3.\n\n## Modifications\n- Déplacement de la collecte de positionMsFlow à l'intérieur du contenu de l'AnimatedVisibility dans 
ative/app/src/main/java/com/localstream/app/ui/player/PlayerControlsOverlay.kt. Hors écran, l'overlay ne se recompose plus à chaque tick de position ; seul BottomPlayerBar (le seul consommateur) recompose quand l'overlay est visible.\n\n## Vérifications\n- CI locale (mêmes cibles que le workflow ci.yml) : ./gradlew.bat testDebugUnitTest detekt --no-daemon --stacktrace : BUILD SUCCESSFUL, 189 tests verts, detekt 0 violation.\n- Branche à jour d'origin/main (0 commit de retard), git merge-tree sans conflit.\n\nCloses #189