### PR TITLE
perf(player): eliminer les requetes Room N+1 a l ouverture du lecteur

### DIFF
--- a/native/app/src/main/java/com/localstream/app/data/repository/WatchStateRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/WatchStateRepository.kt
@@ -99,6 +99,9 @@ class WatchStateRepository(
     suspend fun getPositionsMap(): Map<String, Long> =
         playbackStateDao.getAll().associate { it.name to it.positionMs }
 
+    suspend fun getPlaybackStatesMap(): Map<String, PlaybackStateEntity> =
+        playbackStateDao.getAll().associateBy { it.name }
+
     suspend fun getPlaybackState(name: String): PlaybackStateEntity? =
         playbackStateDao.findByName(name)
 

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -5,6 +5,7 @@ import kotlin.math.roundToInt
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.localstream.app.data.db.entity.PlaybackStateEntity
 import com.localstream.app.di.AppContainer
 import com.localstream.app.domain.model.VideoItem
 import kotlinx.coroutines.FlowPreview
@@ -155,7 +156,6 @@ class PlayerViewModel(
 
     private fun loadVideoDetails() {
         viewModelScope.launch {
-            val decodedName = decodeUri(videoName)
             var allRaw = container.videoRepository.getRawVideos()
             var allGrouped = container.videoRepository.getGroupedVideos()
 
@@ -165,11 +165,18 @@ class PlayerViewModel(
                 allGrouped = container.videoRepository.getGroupedVideos()
             }
 
-            val targetVideo = resolveTargetVideo(decodedName, videoName, allGrouped, allRaw)
-
             val watchedMap = container.watchStateRepository.getWatchedMap()
+            val playbackStatesMap = container.watchStateRepository.getPlaybackStatesMap()
+            val targetVideo = resolveTargetVideo(
+                rawName = videoName,
+                allGrouped = allGrouped,
+                allRaw = allRaw,
+                watchedMap = watchedMap,
+                playbackStatesMap = playbackStatesMap,
+            )
+
             val isWatched = watchedMap[targetVideo.name] == true
-            val state = container.watchStateRepository.getPlaybackState(targetVideo.name)
+            val state = playbackStatesMap[targetVideo.name]
             val rawPos = state?.positionMs ?: 0L
             val pct = state?.progressPct ?: 0.0
             val pos = if (isFinished(isWatched, pct, rawPos, targetVideo.duration * 1000L)) 0L else rawPos
@@ -207,12 +214,14 @@ class PlayerViewModel(
         }
     }
 
-    private suspend fun resolveTargetVideo(
-        decodedName: String,
+    private fun resolveTargetVideo(
         rawName: String,
         allGrouped: List<VideoItem>,
         allRaw: List<VideoItem>,
+        watchedMap: Map<String, Boolean>,
+        playbackStatesMap: Map<String, PlaybackStateEntity>,
     ): VideoItem {
+        val decodedName = decodeUri(rawName)
         val rawVideo = allRaw.find { it.name == decodedName || it.name == rawName }
         val foundGroup = allGrouped.find { group ->
             group.name == decodedName || group.name == rawName
@@ -220,9 +229,8 @@ class PlayerViewModel(
 
         return when {
             foundGroup != null && foundGroup.isSeriesGroup && !foundGroup.episodes.isNullOrEmpty() -> {
-                val watchedMap = container.watchStateRepository.getWatchedMap()
                 foundGroup.episodes.firstOrNull { ep ->
-                    val state = container.watchStateRepository.getPlaybackState(ep.name)
+                    val state = playbackStatesMap[ep.name]
                     (state?.positionMs ?: 0L) > 0L && watchedMap[ep.name] != true
                 } ?: foundGroup.episodes.firstOrNull { ep ->
                     watchedMap[ep.name] != true
@@ -520,7 +528,6 @@ class PlayerViewModel(
     private fun videoNameFlowOrLoad(newName: String) {
         viewModelScope.launch {
             _uiState.update { it.copy(isEnded = false) }
-            val decodedName = decodeUri(newName)
             var allRaw = container.videoRepository.getRawVideos()
             var allGrouped = container.videoRepository.getGroupedVideos()
 
@@ -530,11 +537,18 @@ class PlayerViewModel(
                 allGrouped = container.videoRepository.getGroupedVideos()
             }
 
-            val video = resolveTargetVideo(decodedName, newName, allGrouped, allRaw)
-
             val watchedMap = container.watchStateRepository.getWatchedMap()
+            val playbackStatesMap = container.watchStateRepository.getPlaybackStatesMap()
+            val video = resolveTargetVideo(
+                rawName = newName,
+                allGrouped = allGrouped,
+                allRaw = allRaw,
+                watchedMap = watchedMap,
+                playbackStatesMap = playbackStatesMap,
+            )
+
             val isWatched = watchedMap[video.name] == true
-            val state = container.watchStateRepository.getPlaybackState(video.name)
+            val state = playbackStatesMap[video.name]
             val rawPos = state?.positionMs ?: 0L
             val pct = state?.progressPct ?: 0.0
             val pos = if (isFinished(isWatched, pct, rawPos, video.duration * 1000L)) 0L else rawPos

--- a/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
@@ -516,6 +516,29 @@ class PlayerViewModelTest {
     }
 
     @Test
+    fun `loadVideoDetails for series group selects first in-progress unwatched episode`() = runTest {
+        playbackDao.upsert(PlaybackStateEntity(name = ep2.name, progressPct = 20.0, positionMs = 50000L))
+
+        val viewModel = PlayerViewModel(seriesGroup.name, container)
+        backgroundScope.launch { viewModel.uiState.collect {} }
+        advanceUntilIdle()
+
+        assertEquals(ep2.name, viewModel.uiState.value.currentVideo?.name)
+        assertEquals(50000L, viewModel.uiState.value.initialPositionMs)
+    }
+
+    @Test
+    fun `loadVideoDetails for series group selects first unwatched episode when none in-progress`() = runTest {
+        watchedDao.upsert(WatchedItemEntity(name = ep1.name, watched = true))
+
+        val viewModel = PlayerViewModel(seriesGroup.name, container)
+        backgroundScope.launch { viewModel.uiState.collect {} }
+        advanceUntilIdle()
+
+        assertEquals(ep2.name, viewModel.uiState.value.currentVideo?.name)
+    }
+
+    @Test
     fun `startSleepTimer and cancelSleepTimer control sleep timer state`() = runTest {
         val viewModel = PlayerViewModel(video1.name, container)
         backgroundScope.launch { viewModel.uiState.collect {} }


### PR DESCRIPTION
## Description

Cette PR résout le problème de requêtes SQLite séquentielles N+1 dans \PlayerViewModel\ lors de la résolution de l'épisode cible pour une série (à l'ouverture du lecteur et lors de la navigation vers un épisode suivant).

Fixes #190

### Changements apportés
- **\WatchStateRepository\** : Ajout de la méthode \getPlaybackStatesMap(): Map<String, PlaybackStateEntity>\ pour charger tous les états de lecture en une seule requête Room.
- **\PlayerViewModel\** :
  - Dans \loadVideoDetails\ et \ideoNameFlowOrLoad\, chargement groupé en mémoire de \watchedMap\ et \playbackStatesMap\.
  - Résolution synchrone en mémoire dans \esolveTargetVideo\ sans requêtes N+1 SQLite.
  - Réutilisation directe de l'état en mémoire pour l'épisode résolu sans requête SQL unitaire supplémentaire.
- **\PlayerViewModelTest\** : Nouveaux tests unitaires validant la sélection d'épisode de série (reprise d'un épisode en cours, premier épisode non vu).
- Validation complète des tests unitaires et de l'analyse statique detekt.