### PR TITLE
perf(details): memoiser le calcul des titres d'épisodes dans DetailsScreen (#194)

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
@@ -549,7 +549,11 @@ private fun EpisodeItemRow(
     val epNum = ep.video.episode ?: ep.tmdbEpisode?.episodeNumber ?: (epIndex + 1)
     val epSeason = ep.video.season ?: seasonNum
     val epLabel = "S$epSeason:E$epNum"
-    val epTitle = ep.tmdbEpisode?.name ?: ep.video.cleanTitle ?: TitleCleaner.getCleanTitle(ep.video.name)
+    val epTitle = remember(ep.tmdbEpisode?.name, ep.video.cleanTitle, ep.video.name) {
+        ep.tmdbEpisode?.name?.takeIf { it.isNotBlank() }
+            ?: ep.video.cleanTitle?.takeIf { it.isNotBlank() }
+            ?: TitleCleaner.getCleanTitle(ep.video.name)
+    }
 
     Card(
         colors = CardDefaults.cardColors(containerColor = Zinc900),


### PR DESCRIPTION
## Description
Closes #194

Dans \DetailsScreen.kt\, \EpisodeItemRow\ recalculait le titre de l'épisode via \TitleCleaner.getCleanTitle(ep.video.name)\ lors de chaque recomposition lorsque les titres préalables étaient absents.

Cette PR :
- Enveloppe la résolution du titre d'épisode dans un \emember(ep.tmdbEpisode?.name, ep.video.cleanTitle, ep.video.name)\.
- Privilégier le nom d'épisode TMDB (\ep.tmdbEpisode?.name\), puis le \cleanTitle\ précalculé de \VideoItem\, et ne fait fallback sur \TitleCleaner.getCleanTitle\ qu'en dernier recours, calculé une seule fois par ligne.
- Conserve la réactivité si les métadonnées TMDB se chargent de manière asynchrone.

## Validation
- \./gradlew.bat testDebugUnitTest\ : SUCCÈS
- \./gradlew.bat detekt\ : SUCCÈS
- Simulation \git merge-tree\ avec \origin/main\ : aucun conflit