### PR TITLE
perf(library): déporter le tri et filtrage hors du thread principal (#192)

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/library/LibraryViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -255,23 +256,25 @@ class LibraryViewModel(
     // -------- Observation des états persistés --------
 
     private fun observeWatchState() {
-        viewModelScope.launch {
+        viewModelScope.launch(computationDispatcher) {
             combine(
                 watchStateRepository.watchedItems,
                 watchStateRepository.activePlaybackStates,
-            ) { watched, progress -> watched to progress }.collect { (watched, progress) ->
-                _uiState.update { previous ->
-                    val next = previous.copy(
-                        displayData = previous.displayData.copy(watched = watched, progress = progress),
-                    )
-                    if (next.needsWatchStateResort(previous)) {
-                        next.withDerived()
-                    } else {
-                        // Seule la progression a changé : le tri/filtrage n'en dépend pas.
-                        next
+            ) { watched, progress -> watched to progress }
+                .flowOn(computationDispatcher)
+                .collect { (watched, progress) ->
+                    _uiState.update { previous ->
+                        val next = previous.copy(
+                            displayData = previous.displayData.copy(watched = watched, progress = progress),
+                        )
+                        if (next.needsWatchStateResort(previous)) {
+                            next.withDerived()
+                        } else {
+                            // Seule la progression a changé : le tri/filtrage n'en dépend pas.
+                            next
+                        }
                     }
                 }
-            }
         }
     }
 
@@ -293,12 +296,14 @@ class LibraryViewModel(
     /** Résultats de recherche débouncés (250 ms comme le web) sur la liste filtrée/triée. */
     @OptIn(FlowPreview::class)
     private fun observeSearchQuery() {
-        viewModelScope.launch {
-            _searchQuery.debounce(SEARCH_DEBOUNCE_MS).collectLatest { query ->
-                _uiState.update {
-                    it.copy(searchResults = VideoUiSelectors.filterByQuery(it.filteredSorted, query))
+        viewModelScope.launch(computationDispatcher) {
+            _searchQuery.debounce(SEARCH_DEBOUNCE_MS)
+                .flowOn(computationDispatcher)
+                .collectLatest { query ->
+                    _uiState.update {
+                        it.copy(searchResults = VideoUiSelectors.filterByQuery(it.filteredSorted, query))
+                    }
                 }
-            }
         }
     }
 
@@ -309,27 +314,35 @@ class LibraryViewModel(
     }
 
     fun setSortBy(sortBy: SortBy) {
-        _uiState.update { it.copy(sortBy = sortBy).withDerived() }
+        viewModelScope.launch(computationDispatcher) {
+            _uiState.update { it.copy(sortBy = sortBy).withDerived() }
+        }
     }
 
     fun setFilterGenre(genreId: Int?) {
-        _uiState.update { it.copy(filterGenre = genreId).withDerived() }
+        viewModelScope.launch(computationDispatcher) {
+            _uiState.update { it.copy(filterGenre = genreId).withDerived() }
+        }
     }
 
     fun setFilterResolution(resolution: ResolutionFilter) {
-        _uiState.update { it.copy(filterResolution = resolution).withDerived() }
+        viewModelScope.launch(computationDispatcher) {
+            _uiState.update { it.copy(filterResolution = resolution).withDerived() }
+        }
     }
 
     /** Clic sur le logo : retour à l'état d'accueil (filtres et recherche réinitialisés). */
     fun resetFilters() {
         _searchQuery.value = ""
-        _uiState.update {
-            it.copy(
-                sortBy = SortBy.ALPHA,
-                filterGenre = null,
-                filterResolution = ResolutionFilter.ALL,
-                searchResults = emptyList(),
-            ).withDerived()
+        viewModelScope.launch(computationDispatcher) {
+            _uiState.update {
+                it.copy(
+                    sortBy = SortBy.ALPHA,
+                    filterGenre = null,
+                    filterResolution = ResolutionFilter.ALL,
+                    searchResults = emptyList(),
+                ).withDerived()
+            }
         }
     }
 
@@ -353,6 +366,9 @@ class LibraryViewModel(
 
     // -------- Dérivation filtre/tri --------
 
+    /**
+     * Dérive la liste filtrée/triée et les résultats de recherche (CPU-bound, exécuté sur [computationDispatcher]).
+     */
     private fun LibraryUiState.withDerived(): LibraryUiState {
         val filtered = VideoFilterSorter.filterAndSortVideos(
             videos,

--- a/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/library/LibraryViewModelTest.kt
@@ -146,6 +146,67 @@ class LibraryViewModelTest {
         assertEquals(listOf("Blockbuster.2024.1080p.mkv"), viewModel.uiState.value.searchResults.map { it.name })
     }
 
+    @Test
+    fun `resetFilters reinitialise les filtres et le tri par defaut`() = runTest(testDispatcher) {
+        viewModel.refreshLibrary()
+        advanceUntilIdle()
+
+        viewModel.setSortBy(SortBy.SIZE)
+        viewModel.setFilterResolution(ResolutionFilter.FOUR_K)
+        advanceUntilIdle()
+        assertEquals(listOf("Avatar.2009.2160p.mkv"), viewModel.uiState.value.filteredSorted.map { it.name })
+
+        viewModel.resetFilters()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(SortBy.ALPHA, state.sortBy)
+        assertEquals(ResolutionFilter.ALL, state.filterResolution)
+        assertEquals(
+            listOf("Avatar.2009.2160p.mkv", "Blockbuster.2024.1080p.mkv", "Old.Movie.avi"),
+            state.filteredSorted.map { it.name },
+        )
+    }
+
+    @Test
+    fun `les operations de tri et filtrage sont executees sur le computationDispatcher`() = runTest(testDispatcher) {
+        val computationCalls = java.util.concurrent.atomic.AtomicInteger(0)
+        val trackingDispatcher = object : kotlinx.coroutines.CoroutineDispatcher() {
+            override fun dispatch(context: kotlin.coroutines.CoroutineContext, block: Runnable) {
+                computationCalls.incrementAndGet()
+                testDispatcher.dispatch(context, block)
+            }
+        }
+
+        val trackingVm = LibraryViewModel(
+            videoRepository = VideoRepository(FakeScanner(raw, grouped)),
+            watchStateRepository = WatchStateRepository(FakeWatchedItemDao(), playbackDao),
+            tmdbRepository = TmdbRepository(UnusedTmdbApi(), FakeTmdbMetadataDao(), SettingsRepository()),
+            settingsRepository = SettingsRepository(),
+            ioDispatcher = testDispatcher,
+            computationDispatcher = trackingDispatcher,
+        )
+        trackingVm.refreshLibrary()
+        advanceUntilIdle()
+
+        val initialCalls = computationCalls.get()
+        assertTrue(initialCalls > 0)
+
+        trackingVm.setSortBy(SortBy.SIZE)
+        advanceUntilIdle()
+        assertTrue(computationCalls.get() > initialCalls)
+
+        val callsAfterSort = computationCalls.get()
+        trackingVm.setFilterResolution(ResolutionFilter.FOUR_K)
+        advanceUntilIdle()
+        assertTrue(computationCalls.get() > callsAfterSort)
+
+        val callsAfterFilter = computationCalls.get()
+        trackingVm.resetFilters()
+        advanceUntilIdle()
+        assertTrue(computationCalls.get() > callsAfterFilter)
+    }
+
 
     @Test
     fun `resetProgress sur une serie supprime la progression de tous ses episodes`() = runTest(testDispatcher) {


### PR DESCRIPTION
Closes #192

### Contexte
Dans \LibraryViewModel.kt\, \withDerived()\ exécute le tri et filtrage (\VideoFilterSorter.filterAndSortVideos\ et \VideoUiSelectors.filterByQuery\) de manière synchrone lors des changements de tri, filtres, recherche et mises à jour de visionnage. Sur des bibliothèques de grande taille (> 1000 vidéos), cette exécution sur le thread principal peut provoquer des saccades d'interface (jank) et dépasser le budget de 16 ms par frame.

### Modifications apportées
- **Actions utilisateur** (\setSortBy\, \setFilterGenre\, \setFilterResolution\, \esetFilters\) : lancement de la mise à jour d'état sur \computationDispatcher\ via \iewModelScope.launch(computationDispatcher)\.
- **Observation de l'état de visionnage** (\observeWatchState\) : exécution sur \computationDispatcher\ avec \lowOn(computationDispatcher)\ pour le re-tri éventuel hors Main.
- **Observation de la recherche** (\observeSearchQuery\) : exécution de \ilterByQuery\ sur \computationDispatcher\ avec \lowOn(computationDispatcher)\.
- **Tests unitaires** : ajout de tests dans \LibraryViewModelTest.kt\ pour vérifier la réinitialisation (\esetFilters\) et le dispatch effectif des opérations de calcul sur \computationDispatcher\.