### PR TITLE
perf(ui): ajouter un placeholder aux affiches AsyncImage pour un scroll sans pop-in (#195)

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/components/VideoCard.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/components/VideoCard.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -40,6 +41,7 @@ import com.localstream.app.domain.VideoUiSelectors
 import com.localstream.app.domain.model.VideoItem
 import com.localstream.app.ui.theme.Red600
 import com.localstream.app.ui.theme.Zinc500
+import com.localstream.app.ui.theme.Zinc700
 import com.localstream.app.ui.theme.Zinc800
 
 private val WatchedGreen = Color(0xFF16A34A) // green-600 Tailwind
@@ -221,6 +223,8 @@ private fun PosterImage(
         AsyncImage(
             model = imageRequest,
             contentDescription = title,
+            placeholder = ColorPainter(Zinc700),
+            error = ColorPainter(Zinc800),
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .fillMaxSize()

--- a/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/screens/DetailsScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -76,6 +77,7 @@ import com.localstream.app.ui.theme.Red600
 import com.localstream.app.ui.theme.White
 import com.localstream.app.ui.theme.Zinc300
 import com.localstream.app.ui.theme.Zinc500
+import com.localstream.app.ui.theme.Zinc700
 import com.localstream.app.ui.theme.Zinc800
 import com.localstream.app.ui.theme.Zinc900
 
@@ -236,6 +238,8 @@ private fun DetailsBackdropHeader(
             AsyncImage(
                 model = imageRequest,
                 contentDescription = cleanTitle,
+                placeholder = ColorPainter(Zinc700),
+                error = ColorPainter(Zinc800),
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize(),
             )
@@ -589,6 +593,8 @@ private fun EpisodeItemRow(
                         AsyncImage(
                             model = imageRequest,
                             contentDescription = ep.video.name,
+                            placeholder = ColorPainter(Zinc700),
+                            error = ColorPainter(Zinc800),
                             contentScale = ContentScale.Crop,
                             modifier = Modifier.fillMaxSize(),
                         )

--- a/native/app/src/main/java/com/localstream/app/ui/theme/Color.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/theme/Color.kt
@@ -10,9 +10,10 @@ import androidx.compose.ui.graphics.Color
 // Fond principal (bg-black).
 val Black = Color(0xFF000000)
 
-// Surfaces (zinc-900 / zinc-800).
+// Surfaces (zinc-900 / zinc-800 / zinc-700).
 val Zinc900 = Color(0xFF18181B)
 val Zinc800 = Color(0xFF27272A)
+val Zinc700 = Color(0xFF3F3F46)
 
 // Texte et bordures.
 val Zinc300 = Color(0xFFD4D4D8)


### PR DESCRIPTION
Closes #195

### Contexte
Pendant un scroll rapide ou lors du chargement initial d'une affiche, \AsyncImage\ (avec \crossfade(false)\) laissait apparaître le fond zinc-800 avant que l'image ne s'affiche brutalement. Ce pop-in cassait la fluidité visuelle perçue de l'interface sur les vignettes vidéo, les bannières de détail et les miniatures d'épisodes.

### Modifications apportées
- **Thème** (\Color.kt\) : ajout de la teinte de surface intermédiaire \Zinc700 = Color(0xFF3F3F46)\ (zinc-700 Tailwind).
- **Vignettes vidéo** (\VideoCard.kt\) : ajout de \placeholder = ColorPainter(Zinc700)\ et \error = ColorPainter(Zinc800)\ sur \AsyncImage\.
- **Écran de détail** (\DetailsScreen.kt\) : ajout du même placeholder/error sur l'image de fond du header (\DetailsBackdropHeader\) et les vignettes d'épisodes (\EpisodeItemRow\).