### PR TITLE
perf(scanner): mettre en cache l'index des sous-titres dans MediaStoreScanner (#193)

### DIFF
--- a/native/app/src/main/java/com/localstream/app/data/repository/VideoRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/VideoRepository.kt
@@ -32,6 +32,9 @@ class VideoRepository(
         if (!forceRefresh && groupedVideos.isNotEmpty()) {
             return groupedVideos
         }
+        if (forceRefresh) {
+            mediaScanner.clearSubtitleCache()
+        }
         rawVideos = mediaScanner.scanVideoFiles()
         groupedVideos = mediaScanner.scanAndGroup(
             whitelistedVideos = whitelistedVideos,

--- a/native/app/src/main/java/com/localstream/app/data/scanner/MediaScanner.kt
+++ b/native/app/src/main/java/com/localstream/app/data/scanner/MediaScanner.kt
@@ -16,4 +16,7 @@ interface MediaScanner {
         releaseDates: Map<String, String> = emptyMap(),
         rawVideos: List<VideoItem>? = null,
     ): List<VideoItem>
+
+    /** Invalide le cache des sous-titres (appelé lors d'un refresh forcé). */
+    fun clearSubtitleCache() {}
 }

--- a/native/app/src/main/java/com/localstream/app/data/scanner/MediaStoreScanner.kt
+++ b/native/app/src/main/java/com/localstream/app/data/scanner/MediaStoreScanner.kt
@@ -23,6 +23,24 @@ class MediaStoreScanner(
     private val customDirectories: List<File> = emptyList()
 ) : MediaScanner {
 
+    private var cachedSubtitleIndex: Map<String, SubtitleEntry>? = null
+
+    override fun clearSubtitleCache() {
+        cachedSubtitleIndex = null
+    }
+
+    /**
+     * Retourne l\'index des sous-titres en cache ou le construit au premier appel.
+     */
+    fun getOrBuildSubtitleIndex(): Map<String, SubtitleEntry> {
+        val existing = cachedSubtitleIndex
+        if (existing != null) return existing
+        val subtitles = scanSubtitleFiles()
+        val index = VideoNameParser.buildSubtitleIndex(subtitles)
+        cachedSubtitleIndex = index
+        return index
+    }
+
     override fun scanVideoFiles(): List<VideoItem> {
         return scanVideoFilesPaged(pageSize = DEFAULT_PAGE_SIZE)
     }
@@ -217,8 +235,7 @@ class MediaStoreScanner(
         rawVideos: List<VideoItem>?,
     ): List<VideoItem> {
         val videos = rawVideos ?: scanVideoFiles()
-        val subtitles = scanSubtitleFiles()
-        val subIndex = VideoNameParser.buildSubtitleIndex(subtitles)
+        val subIndex = getOrBuildSubtitleIndex()
 
         val videosWithSubtitles = videos.map { video ->
             val folder = VideoNameParser.parentFolder(video.path)

--- a/native/app/src/test/java/com/localstream/app/data/MediaStoreScannerTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/MediaStoreScannerTest.kt
@@ -114,4 +114,27 @@ class MediaStoreScannerTest {
         assertTrue(result.any { it.name == "Item1.mkv" })
         assertTrue(result.any { it.name == "Item2.mkv" })
     }
+
+    @Test
+    fun scanAndGroup_cachesSubtitleIndexAcrossCalls() {
+        File(tempDir, "Movie.mkv").createNewFile()
+        File(tempDir, "Movie.srt").createNewFile()
+
+        val scanner = MediaStoreScanner(context = null, customDirectories = listOf(tempDir))
+        val firstResult = scanner.scanAndGroup()
+        val movieWithSub = firstResult.first { it.name == "Movie.mkv" }
+        assertTrue(movieWithSub.subtitleNativePath != null)
+
+        File(tempDir, "Movie2.mkv").createNewFile()
+        File(tempDir, "Movie2.srt").createNewFile()
+
+        val secondResult = scanner.scanAndGroup()
+        val movie2 = secondResult.firstOrNull { it.name == "Movie2.mkv" }
+        assertTrue(movie2?.subtitleNativePath == null)
+
+        scanner.clearSubtitleCache()
+        val thirdResult = scanner.scanAndGroup()
+        val movie2AfterInvalidate = thirdResult.firstOrNull { it.name == "Movie2.mkv" }
+        assertTrue(movie2AfterInvalidate?.subtitleNativePath != null)
+    }
 }


### PR DESCRIPTION
Closes #193

### Contexte
Dans \MediaStoreScanner.kt\, \scanAndGroup\ exécutait systématiquement \scanSubtitleFiles()\ puis \uildSubtitleIndex(subtitles)\ à chaque appel. Cette requête MediaStore.Files avec pattern non indexable (\LIKE '%.srt' OR '%.vtt' OR '%.ass' OR '%.ssa'\) et le parsing complet du curseur étaient répétés inutilement à chaque scan / regroupement.

### Modifications apportées
- **Mise en cache** : ajout d'un champ \cachedSubtitleIndex\ dans \MediaStoreScanner\ et de la méthode \getOrBuildSubtitleIndex()\.
- **Réutilisation** : \scanAndGroup\ réutilise désormais cet index en mémoire pour associer les sous-titres aux vidéos sans relancer la requête MediaStore ou le scan disque.
- **Invalidation** : ajout de \clearSubtitleCache()\ sur l'interface \MediaScanner\ et appel de celle-ci depuis \VideoRepository.scanAndLoad\ lors d'un refresh forcé (\orceRefresh = true\).
- **Tests unitaires** : ajout d'un test dans \MediaStoreScannerTest.kt\ vérifiant la persistance du cache entre appels et sa réinitialisation après \clearSubtitleCache()\.