### PR TITLE
perf(db): supprimer le read-then-write de savePlaybackState et indexer name (#191)

### DIFF
--- a/native/app/schemas/com.localstream.app.data.db.AppDatabase/4.json
+++ b/native/app/schemas/com.localstream.app.data.db.AppDatabase/4.json
@@ -1,0 +1,244 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "8fbbeda0924b897ffcd26db1439c10bb",
+    "entities": [
+      {
+        "tableName": "watched_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `watched` INTEGER NOT NULL, `watched_at` INTEGER NOT NULL, `media_store_id` INTEGER, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watched",
+            "columnName": "watched",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "watchedAt",
+            "columnName": "watched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaStoreId",
+            "columnName": "media_store_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_watched_items_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_watched_items_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `progress_pct` REAL NOT NULL, `position_ms` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `media_store_id` INTEGER, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressPct",
+            "columnName": "progress_pct",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaStoreId",
+            "columnName": "media_store_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_state_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playback_state_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_playback_state_last_played_at",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_state_last_played_at` ON `${TABLE_NAME}` (`last_played_at`)"
+          },
+          {
+            "name": "index_playback_state_progress_pct",
+            "unique": false,
+            "columnNames": [
+              "progress_pct"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_state_progress_pct` ON `${TABLE_NAME}` (`progress_pct`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `created_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` TEXT NOT NULL, `video_name` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `video_name`), FOREIGN KEY(`playlist_id`) REFERENCES `playlist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoName",
+            "columnName": "video_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "video_name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_item_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_item_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tmdb_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`query_key` TEXT NOT NULL, `json` TEXT NOT NULL, `fetched_at` INTEGER NOT NULL, PRIMARY KEY(`query_key`))",
+        "fields": [
+          {
+            "fieldPath": "queryKey",
+            "columnName": "query_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "json",
+            "columnName": "json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetched_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "query_key"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8fbbeda0924b897ffcd26db1439c10bb')"
+    ]
+  }
+}

--- a/native/app/src/main/java/com/localstream/app/data/db/AppDatabase.kt
+++ b/native/app/src/main/java/com/localstream/app/data/db/AppDatabase.kt
@@ -30,7 +30,7 @@ import com.localstream.app.data.db.entity.WatchedItemEntity
         PlaylistItemEntity::class,
         TmdbMetadataEntity::class,
     ],
-    version = 3,
+    version = 4,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -65,6 +65,13 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_playback_state_name` ON `playback_state` (`name`)")
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_watched_items_name` ON `watched_items` (`name`)")
+            }
+        }
+
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
@@ -75,7 +82,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     DB_NAME,
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                     .build()
                     .also { INSTANCE = it }
             }

--- a/native/app/src/main/java/com/localstream/app/data/db/dao/PlaybackStateDao.kt
+++ b/native/app/src/main/java/com/localstream/app/data/db/dao/PlaybackStateDao.kt
@@ -1,8 +1,7 @@
 package com.localstream.app.data.db.dao
 
 import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
+import androidx.room.Upsert
 import androidx.room.Query
 import com.localstream.app.data.db.entity.PlaybackStateEntity
 import kotlinx.coroutines.flow.Flow
@@ -21,10 +20,10 @@ interface PlaybackStateDao {
     @Query("SELECT * FROM playback_state")
     suspend fun getAll(): List<PlaybackStateEntity>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsert(state: PlaybackStateEntity)
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsertAll(states: List<PlaybackStateEntity>)
 
     @Query("DELETE FROM playback_state WHERE name = :name")

--- a/native/app/src/main/java/com/localstream/app/data/db/dao/WatchedItemDao.kt
+++ b/native/app/src/main/java/com/localstream/app/data/db/dao/WatchedItemDao.kt
@@ -1,8 +1,7 @@
 package com.localstream.app.data.db.dao
 
 import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
+import androidx.room.Upsert
 import androidx.room.Query
 import com.localstream.app.data.db.entity.WatchedItemEntity
 import kotlinx.coroutines.flow.Flow
@@ -18,10 +17,10 @@ interface WatchedItemDao {
     @Query("SELECT * FROM watched_items")
     suspend fun getAllWatchedItems(): List<WatchedItemEntity>
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsert(item: WatchedItemEntity)
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsertAll(items: List<WatchedItemEntity>)
 
     @Query("DELETE FROM watched_items WHERE name = :name")

--- a/native/app/src/main/java/com/localstream/app/data/db/entity/PlaybackStateEntity.kt
+++ b/native/app/src/main/java/com/localstream/app/data/db/entity/PlaybackStateEntity.kt
@@ -18,6 +18,7 @@ import androidx.room.Index
 @Entity(
     tableName = "playback_state",
     indices = [
+        Index(value = ["name"], unique = true),
         Index(value = ["last_played_at"]),
         Index(value = ["progress_pct"]),
     ],

--- a/native/app/src/main/java/com/localstream/app/data/db/entity/WatchedItemEntity.kt
+++ b/native/app/src/main/java/com/localstream/app/data/db/entity/WatchedItemEntity.kt
@@ -2,6 +2,7 @@ package com.localstream.app.data.db.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /**
@@ -9,7 +10,12 @@ import androidx.room.PrimaryKey
  * Cl\u00e9 : [name] (nom de fichier) — m\u00eame cl\u00e9 que localStorage "watchedVideos".
  * [mediaStoreId] est nullable pour compatibilit\u00e9 (renseign\u00e9 progressivement).
  */
-@Entity(tableName = "watched_items")
+@Entity(
+    tableName = "watched_items",
+    indices = [
+        Index(value = ["name"], unique = true),
+    ],
+)
 data class WatchedItemEntity(
     @PrimaryKey
     @ColumnInfo(name = "name") val name: String,

--- a/native/app/src/main/java/com/localstream/app/data/repository/WatchStateRepository.kt
+++ b/native/app/src/main/java/com/localstream/app/data/repository/WatchStateRepository.kt
@@ -110,24 +110,20 @@ class WatchStateRepository(
         positionMs: Long,
         durationMs: Long = 0L,
         progressPercent: Int = 0,
+        mediaStoreId: Long? = null,
     ) {
         if (positionMs <= 0L && progressPercent <= 0) {
             playbackStateDao.deleteByName(videoName)
             return
         }
-        val existing = playbackStateDao.findByName(videoName)
-        val calculatedPct = if (durationMs > 0L) {
-            (positionMs.toDouble() / durationMs.toDouble() * 100.0).coerceIn(0.0, 100.0)
-        } else {
-            progressPercent.toDouble()
-        }
+        val calculatedPct = calculateProgressPct(positionMs, durationMs, progressPercent.toDouble())
         playbackStateDao.upsert(
             PlaybackStateEntity(
                 name = videoName,
                 progressPct = calculatedPct,
                 positionMs = positionMs,
                 lastPlayedAt = System.currentTimeMillis(),
-                mediaStoreId = existing?.mediaStoreId,
+                mediaStoreId = mediaStoreId,
             )
         )
     }
@@ -142,14 +138,13 @@ class WatchStateRepository(
             playbackStateDao.deleteByName(videoName)
             return
         }
-        val existing = playbackStateDao.findByName(videoName)
         playbackStateDao.upsert(
             PlaybackStateEntity(
                 name = videoName,
                 progressPct = progressPct,
                 positionMs = positionMs,
                 lastPlayedAt = System.currentTimeMillis(),
-                mediaStoreId = mediaStoreId ?: existing?.mediaStoreId,
+                mediaStoreId = mediaStoreId,
             )
         )
     }
@@ -166,4 +161,18 @@ class WatchStateRepository(
     /** Retourne les 30 derniers fichiers lus, triés par date décroissante. */
     suspend fun getRecentlyWatched(): List<String> =
         playbackStateDao.getRecentlyPlayed(RECENTLY_WATCHED_LIMIT).map { it.name }
+
+    companion object {
+        private const val PERCENT_MAX = 100.0
+
+        fun calculateProgressPct(
+            positionMs: Long,
+            durationMs: Long,
+            fallbackPct: Double = 0.0,
+        ): Double = if (durationMs > 0L) {
+            (positionMs.toDouble() / durationMs.toDouble() * PERCENT_MAX).coerceIn(0.0, PERCENT_MAX)
+        } else {
+            fallbackPct
+        }
+    }
 }

--- a/native/app/src/test/java/com/localstream/app/data/AppDatabaseMigrationTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/AppDatabaseMigrationTest.kt
@@ -66,5 +66,32 @@ class AppDatabaseMigrationTest {
         assertTrue(executedQueries.any { it.contains("CREATE INDEX IF NOT EXISTS `index_playback_state_last_played_at`") })
         assertTrue(executedQueries.any { it.contains("CREATE INDEX IF NOT EXISTS `index_playback_state_progress_pct`") })
     }
+
+    @Test
+    fun migration3To4_hasCorrectVersions() {
+        assertEquals(3, AppDatabase.MIGRATION_3_4.startVersion)
+        assertEquals(4, AppDatabase.MIGRATION_3_4.endVersion)
+    }
+
+    @Test
+    fun migration3To4_executesCreateUniqueIndices() {
+        val executedQueries = mutableListOf<String>()
+
+        val dbProxy = Proxy.newProxyInstance(
+            SupportSQLiteDatabase::class.java.classLoader,
+            arrayOf(SupportSQLiteDatabase::class.java),
+        ) { _, method, args ->
+            if (method.name == "execSQL" && args != null && args.isNotEmpty()) {
+                executedQueries.add(args[0].toString())
+            }
+            null
+        } as SupportSQLiteDatabase
+
+        AppDatabase.MIGRATION_3_4.migrate(dbProxy)
+
+        assertEquals(2, executedQueries.size)
+        assertTrue(executedQueries.any { it.contains("CREATE UNIQUE INDEX IF NOT EXISTS `index_playback_state_name`") })
+        assertTrue(executedQueries.any { it.contains("CREATE UNIQUE INDEX IF NOT EXISTS `index_watched_items_name`") })
+    }
 }
 

--- a/native/app/src/test/java/com/localstream/app/data/WatchStateRepositoryTest.kt
+++ b/native/app/src/test/java/com/localstream/app/data/WatchStateRepositoryTest.kt
@@ -1,0 +1,150 @@
+package com.localstream.app.data
+
+import com.localstream.app.data.db.dao.PlaybackStateDao
+import com.localstream.app.data.db.dao.WatchedItemDao
+import com.localstream.app.data.db.entity.PlaybackStateEntity
+import com.localstream.app.data.db.entity.WatchedItemEntity
+import com.localstream.app.data.repository.WatchStateRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class WatchStateRepositoryTest {
+
+    @Test
+    fun calculateProgressPct_computesCorrectClampedPercentage() {
+        assertEquals(50.0, WatchStateRepository.calculateProgressPct(500L, 1000L), 0.001)
+        assertEquals(100.0, WatchStateRepository.calculateProgressPct(1200L, 1000L), 0.001)
+        assertEquals(0.0, WatchStateRepository.calculateProgressPct(-10L, 1000L), 0.001)
+        assertEquals(42.0, WatchStateRepository.calculateProgressPct(0L, 0L, fallbackPct = 42.0), 0.001)
+    }
+
+    @Test
+    fun savePlaybackState_performsDirectUpsertWithoutFindByName() = runBlocking {
+        var findByNameCalls = 0
+        var upsertCalls = 0
+        var savedEntity: PlaybackStateEntity? = null
+
+        val playbackDao = object : PlaybackStateDao {
+            override fun observeActivePlaybackStates(): Flow<List<PlaybackStateEntity>> = emptyFlow()
+            override suspend fun getRecentlyPlayed(limit: Int): List<PlaybackStateEntity> = emptyList()
+            override suspend fun getAll(): List<PlaybackStateEntity> = emptyList()
+            override suspend fun upsert(state: PlaybackStateEntity) {
+                upsertCalls++
+                savedEntity = state
+            }
+            override suspend fun upsertAll(states: List<PlaybackStateEntity>) {
+                /* no-op */
+            }
+            override suspend fun deleteByName(name: String) {
+                /* no-op */
+            }
+            override suspend fun deleteAll() {
+                /* no-op */
+            }
+            override suspend fun findByName(name: String): PlaybackStateEntity? {
+                findByNameCalls++
+                return null
+            }
+        }
+
+        val watchedDao = object : WatchedItemDao {
+            override fun observeWatchedItems(): Flow<List<WatchedItemEntity>> = emptyFlow()
+            override suspend fun getAllWatchedItems(): List<WatchedItemEntity> = emptyList()
+            override suspend fun upsert(item: WatchedItemEntity) {
+                /* no-op */
+            }
+            override suspend fun upsertAll(items: List<WatchedItemEntity>) {
+                /* no-op */
+            }
+            override suspend fun deleteByName(name: String) {
+                /* no-op */
+            }
+            override suspend fun deleteByNames(names: List<String>) {
+                /* no-op */
+            }
+            override suspend fun deleteAll() {
+                /* no-op */
+            }
+            override suspend fun findByName(name: String): WatchedItemEntity? = null
+        }
+
+        val repository = WatchStateRepository(watchedDao, playbackDao)
+        repository.savePlaybackState(
+            videoName = "Video.mp4",
+            positionMs = 3000L,
+            durationMs = 6000L,
+            mediaStoreId = 123L,
+        )
+
+        assertEquals("Aucun read avant ecriture", 0, findByNameCalls)
+        assertEquals(1, upsertCalls)
+        assertNotNull(savedEntity)
+        assertEquals("Video.mp4", savedEntity?.name)
+        assertEquals(50.0, savedEntity?.progressPct ?: 0.0, 0.001)
+        assertEquals(3000L, savedEntity?.positionMs)
+        assertEquals(123L, savedEntity?.mediaStoreId)
+    }
+
+    @Test
+    fun updateProgress_performsDirectUpsertWithoutFindByName() = runBlocking {
+        var findByNameCalls = 0
+        var upsertCalls = 0
+
+        val playbackDao = object : PlaybackStateDao {
+            override fun observeActivePlaybackStates(): Flow<List<PlaybackStateEntity>> = emptyFlow()
+            override suspend fun getRecentlyPlayed(limit: Int): List<PlaybackStateEntity> = emptyList()
+            override suspend fun getAll(): List<PlaybackStateEntity> = emptyList()
+            override suspend fun upsert(state: PlaybackStateEntity) {
+                upsertCalls++
+            }
+            override suspend fun upsertAll(states: List<PlaybackStateEntity>) {
+                /* no-op */
+            }
+            override suspend fun deleteByName(name: String) {
+                /* no-op */
+            }
+            override suspend fun deleteAll() {
+                /* no-op */
+            }
+            override suspend fun findByName(name: String): PlaybackStateEntity? {
+                findByNameCalls++
+                return null
+            }
+        }
+
+        val watchedDao = object : WatchedItemDao {
+            override fun observeWatchedItems(): Flow<List<WatchedItemEntity>> = emptyFlow()
+            override suspend fun getAllWatchedItems(): List<WatchedItemEntity> = emptyList()
+            override suspend fun upsert(item: WatchedItemEntity) {
+                /* no-op */
+            }
+            override suspend fun upsertAll(items: List<WatchedItemEntity>) {
+                /* no-op */
+            }
+            override suspend fun deleteByName(name: String) {
+                /* no-op */
+            }
+            override suspend fun deleteByNames(names: List<String>) {
+                /* no-op */
+            }
+            override suspend fun deleteAll() {
+                /* no-op */
+            }
+            override suspend fun findByName(name: String): WatchedItemEntity? = null
+        }
+
+        val repository = WatchStateRepository(watchedDao, playbackDao)
+        repository.updateProgress(
+            videoName = "Video.mp4",
+            progressPct = 75.0,
+            positionMs = 4500L,
+        )
+
+        assertEquals("Aucun read avant ecriture lors de updateProgress", 0, findByNameCalls)
+        assertEquals(1, upsertCalls)
+    }
+}


### PR DESCRIPTION
Closes #191

### Contexte
Pendant la lecture vidéo, `WatchStateRepository.savePlaybackState` était appelé toutes les 2 secondes et effectuait systématiquement un `findByName` (SELECT) avant d'exécuter un `upsert` (INSERT REPLACE), doublant le volume de requêtes en base. De plus, la table `watched_items` ne possédait pas d'index explicite sur `name` et le calcul de pourcentage de progression était dupliqué.

### Modifications apportées
- **Suppression du read-then-write** : suppression du `findByName` avant `upsert` dans `savePlaybackState` et `updateProgress`.
- **Annotation `@Upsert`** : utilisation de `androidx.room.Upsert` dans `PlaybackStateDao` et `WatchedItemDao`.
- **Index sur `name`** : ajout de `Index(value = ["name"], unique = true)` sur `PlaybackStateEntity` et `WatchedItemEntity`.
- **Migration Room 3 -> 4** : création de `MIGRATION_3_4` créant les index uniques sur `playback_state(name)` et `watched_items(name)`, mise à jour de la version de base à 4 et génération du schéma `4.json`.
- **Extraction du calcul de progression** : création de la fonction utilitaire pure `WatchStateRepository.calculateProgressPct`.
- **Tests unitaires** : ajout des tests de migration dans `AppDatabaseMigrationTest` et création de `WatchStateRepositoryTest` pour vérifier l'absence de lecture avant écriture et la validité du calcul.
