### PR TITLE
fix(player): corriger la latence d'affichage des sous-titres locaux et supprimer le bandeau noir

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
@@ -12,13 +12,17 @@ import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.media.AudioManager
 import android.media.audiofx.LoudnessEnhancer
+import android.graphics.Color as AndroidColor
+import android.graphics.Typeface
 import android.net.Uri
 import android.os.Build
 import android.os.SystemClock
+import android.provider.OpenableColumns
 import android.util.Rational
 import android.view.ViewGroup
 import android.view.WindowManager
 import java.io.File
+import java.io.FileOutputStream
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -83,7 +87,9 @@ import androidx.media3.common.VideoSize
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
+import androidx.media3.ui.CaptionStyleCompat
 import androidx.media3.ui.PlayerView
+import androidx.media3.ui.SubtitleView
 import com.localstream.app.LocalStreamApplication
 import com.localstream.app.domain.model.VideoItem
 import com.localstream.app.ui.subtitles.SubtitlePickerSheet
@@ -211,8 +217,10 @@ fun PlayerScreen(
         contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
         uri?.let {
-            val fileName = it.lastPathSegment?.substringAfterLast('/') ?: "Sous-titre"
-            viewModel.addExternalSubtitle(fileName, it.toString())
+            val (fileName, targetUriString) = copyUriToCache(context, it)
+            viewModel.addExternalSubtitle(fileName, targetUriString)
+            showTracksSheet = false
+            viewModel.setOnlineSubtitlesSheetVisible(false)
         }
     }
 
@@ -475,20 +483,25 @@ fun PlayerScreen(
                 else -> MimeTypes.APPLICATION_SUBRIP
             }
 
-            val subUri = Uri.parse(uriString)
+            val subUri = if (uriString.startsWith("content://") || uriString.startsWith("file://")) {
+                Uri.parse(uriString)
+            } else {
+                Uri.fromFile(File(uriString))
+            }
             val subConfig = MediaItem.SubtitleConfiguration.Builder(subUri)
+                .setId(externalTrack.id)
+                .setLabel(externalTrack.label)
                 .setMimeType(mimeType)
                 .setLanguage("fr")
-                .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
+                .setSelectionFlags(C.SELECTION_FLAG_DEFAULT or C.SELECTION_FLAG_FORCED)
                 .build()
 
-            val curPos = exoPlayer.currentPosition
-            val mediaItem = MediaItem.Builder()
-                .setUri(uri)
+            val currentMediaItem = exoPlayer.currentMediaItem
+            val mediaItem = (currentMediaItem?.buildUpon() ?: MediaItem.Builder().setUri(uri))
                 .setSubtitleConfigurations(listOf(subConfig))
                 .build()
 
-            exoPlayer.setMediaItem(mediaItem, curPos)
+            exoPlayer.setMediaItem(mediaItem, /* resetPosition = */ false)
             exoPlayer.prepare()
             exoPlayer.playWhenReady = true
         }
@@ -623,6 +636,19 @@ fun PlayerScreen(
                         ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT,
                     )
+                    subtitleView?.apply {
+                        val captionStyle = CaptionStyleCompat(
+                            AndroidColor.WHITE,
+                            AndroidColor.TRANSPARENT,
+                            AndroidColor.TRANSPARENT,
+                            CaptionStyleCompat.EDGE_TYPE_OUTLINE,
+                            AndroidColor.BLACK,
+                            Typeface.DEFAULT_BOLD,
+                        )
+                        setStyle(captionStyle)
+                        setFractionalTextSize(SubtitleView.DEFAULT_TEXT_SIZE_FRACTION * 0.95f)
+                        setBottomPaddingFraction(SubtitleView.DEFAULT_BOTTOM_PADDING_FRACTION)
+                    }
                 }
             },
             update = { playerView ->
@@ -850,7 +876,12 @@ fun PlayerScreen(
             onPickLocal = { subtitleFilePicker.launch("*/*") },
             onSubtitleSelected = { path ->
                 val fileName = path.substringAfterLast('/')
-                viewModel.addExternalSubtitle(fileName, path)
+                val targetUri = if (path.startsWith("content://") || path.startsWith("file://")) {
+                    path
+                } else {
+                    Uri.fromFile(File(path)).toString()
+                }
+                viewModel.addExternalSubtitle(fileName, targetUri)
             },
             onDismiss = { viewModel.setOnlineSubtitlesSheetVisible(false) },
         )
@@ -984,4 +1015,51 @@ private fun findTrackOverride(tracks: Tracks, trackType: @C.TrackType Int, targe
         }
     }
     return null
+}
+
+private fun resolveDisplayName(context: Context, uri: Uri): String {
+    if (uri.scheme == "content") {
+        runCatching {
+            context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (idx >= 0) {
+                        cursor.getString(idx)?.let { return it }
+                    }
+                }
+            }
+        }
+    }
+    return uri.lastPathSegment?.substringAfterLast('/') ?: "Sous-titre"
+}
+
+private fun resolveExtension(fileName: String): String = when {
+    fileName.endsWith(".vtt", ignoreCase = true) -> ".vtt"
+    fileName.endsWith(".ass", ignoreCase = true) -> ".ass"
+    fileName.endsWith(".ssa", ignoreCase = true) -> ".ssa"
+    fileName.endsWith(".srt", ignoreCase = true) -> ".srt"
+    else -> ".srt"
+}
+
+private fun copyUriToCache(context: Context, uri: Uri): Pair<String, String> {
+    val fileName = resolveDisplayName(context, uri)
+    val extension = resolveExtension(fileName)
+    val subDir = File(context.cacheDir, "subtitles").apply { mkdirs() }
+    val cacheFile = File(subDir, "local_${System.currentTimeMillis()}$extension")
+    val copied = runCatching {
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            FileOutputStream(cacheFile).use { output ->
+                input.copyTo(output)
+            }
+        }
+        cacheFile.exists() && cacheFile.length() > 0
+    }.getOrDefault(false)
+
+    val targetUriString = if (copied) {
+        Uri.fromFile(cacheFile).toString()
+    } else {
+        uri.toString()
+    }
+
+    return Pair(fileName, targetUriString)
 }

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -472,11 +472,31 @@ class PlayerViewModel(
         subtitles: List<SubtitleTrackUiState>,
     ) {
         _uiState.update { state ->
+            val externalTracks = state.subtitleTracks.filter { it.isExternal }
+            val mergedSubtitles = subtitles.map { sub ->
+                val matchingExt = externalTracks.find { it.id == sub.id }
+                if (matchingExt != null) {
+                    sub.copy(isExternal = true, uriString = matchingExt.uriString)
+                } else {
+                    sub
+                }
+            } + externalTracks.filter { ext -> subtitles.none { it.id == ext.id } }
+
             val selectedAudio = state.selectedAudioTrackId ?: audio.firstOrNull { it.isSelected }?.id
-            val selectedSub = state.selectedSubtitleTrackId ?: subtitles.firstOrNull { it.isSelected }?.id
+            val selectedSub = state.selectedSubtitleTrackId ?: mergedSubtitles.firstOrNull { it.isSelected }?.id
+            val finalSubtitles = if (selectedSub != null) {
+                mergedSubtitles.map { it.copy(isSelected = it.id == selectedSub) }
+            } else {
+                mergedSubtitles
+            }
+            val finalAudio = if (selectedAudio != null) {
+                audio.map { it.copy(isSelected = it.id == selectedAudio) }
+            } else {
+                audio
+            }
             state.copy(
-                audioTracks = audio,
-                subtitleTracks = subtitles,
+                audioTracks = finalAudio,
+                subtitleTracks = finalSubtitles,
                 selectedAudioTrackId = selectedAudio,
                 selectedSubtitleTrackId = selectedSub,
             )

--- a/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
@@ -372,6 +372,17 @@ class PlayerViewModelTest {
         val state3 = viewModel.uiState.value
         assertEquals(2, state3.subtitleTracks.size)
         assertTrue(state3.subtitleTracks.last().isExternal)
+
+        val extId = state3.selectedSubtitleTrackId
+        viewModel.updateTracks(audio, listOf(SubtitleTrackUiState(id = "s1", label = "Français SRT", isSelected = false)))
+        advanceUntilIdle()
+        val state4 = viewModel.uiState.value
+        assertEquals(2, state4.subtitleTracks.size)
+        val extTrack = state4.subtitleTracks.firstOrNull { it.id == extId }
+        assertNotNull(extTrack)
+        assertTrue(extTrack!!.isExternal)
+        assertTrue(extTrack.isSelected)
+        assertEquals(extId, state4.selectedSubtitleTrackId)
     }
 
     @Test


### PR DESCRIPTION
## Résumé des changements

Cette PR résout deux problèmes majeurs signalés sur le lecteur vidéo lors de l'utilisation de sous-titres :

1. **Suppression du bandeau noir et ajout d'un contour noir net** :
   - Configuration d'un CaptionStyleCompat dédié sur PlayerView.subtitleView.
   - Remplacement du fond opaque par défaut (Color.BLACK) par un fond 100% transparent (Color.TRANSPARENT), permettant de ne plus masquer la vidéo.
   - Application d'un contour noir (EDGE_TYPE_OUTLINE, couleur noire) autour de chaque lettre blanche avec police semi-grasse (DEFAULT_BOLD) pour une lisibilité parfaite sur toutes les scènes.
   - Ajustement de l'échelle et du positionnement cinématique (setFractionalTextSize, setBottomPaddingFraction).

2. **Élimination de la latence d'affichage des sous-titres locaux** :
   - Copie immédiate du fichier sélectionné via SAF (OpenableColumns.DISPLAY_NAME) dans le cache local de l'application (cacheDir/subtitles/), éliminant les blocages IPC du ContentProvider et garantissant l'extension réelle (.srt, .vtt, .ass, etc.).
   - Attachement du sous-titre sans réinitialisation de la vidéo (setMediaItem(mediaItem, false)), évitant le déchargement des tampons et le buffering lourd.
   - Injection directe de l'identifiant de piste (.setId(externalTrack.id)) et du libellé pour que les sélections et synchronisations d'ExoPlayer correspondent aux états UI.
   - Préservation des pistes externes dans PlayerViewModel.updateTracks() lors des retours d'événements du lecteur.
   - Fermeture automatique des feuilles de dialogue à la sélection pour un affichage immédiat à l'écran.

## Vérifications

- [x] Simulation de fusion sans conflit (git merge-tree) avec origin/main.
- [x] Tests unitaires validés : ./gradlew testDebugUnitTest (dont nouveau test de persistance des pistes externes dans PlayerViewModelTest).
- [x] Analyse statique validée : ./gradlew detekt (0 erreur, 0 avertissement).