### PR TITLE
fix(player): éliminer la boucle infinie de rechargement et le sautillement du menu de sous-titres

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
@@ -22,7 +22,9 @@ import android.util.Rational
 import android.view.ViewGroup
 import android.view.WindowManager
 import java.io.File
-import java.io.FileOutputStream
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+import java.nio.charset.CodingErrorAction
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -389,11 +391,12 @@ fun PlayerScreen(
                 val audioList = mutableListOf<AudioTrackUiState>()
                 val subList = mutableListOf<SubtitleTrackUiState>()
 
-                for (group in tracks.groups) {
+                for (groupIndex in 0 until tracks.groups.size) {
+                    val group = tracks.groups[groupIndex]
                     val trackType = group.type
                     for (i in 0 until group.length) {
                         val format = group.getTrackFormat(i)
-                        val id = format.id ?: "$trackType-$i"
+                        val id = format.id ?: "$trackType-$groupIndex-$i"
                         val isSelected = group.isTrackSelected(i)
 
                         if (trackType == C.TRACK_TYPE_AUDIO) {
@@ -451,6 +454,7 @@ fun PlayerScreen(
 
         val selAudioId = uiState.selectedAudioTrackId
         if (selAudioId != null) {
+            builder.clearOverridesOfType(C.TRACK_TYPE_AUDIO)
             findTrackOverride(tracks, C.TRACK_TYPE_AUDIO, selAudioId)?.let {
                 builder.setOverrideForType(it)
             }
@@ -458,9 +462,11 @@ fun PlayerScreen(
 
         val selSubId = uiState.selectedSubtitleTrackId
         if (selSubId == null) {
+            builder.clearOverridesOfType(C.TRACK_TYPE_TEXT)
             builder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
         } else {
             builder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
+            builder.clearOverridesOfType(C.TRACK_TYPE_TEXT)
             findTrackOverride(tracks, C.TRACK_TYPE_TEXT, selSubId)?.let {
                 builder.setOverrideForType(it)
             }
@@ -469,48 +475,13 @@ fun PlayerScreen(
         exoPlayer.trackSelectionParameters = builder.build()
     }
 
-    LaunchedEffect(uiState.subtitleTracks) {
-        val externalTrack = uiState.subtitleTracks.firstOrNull { it.isExternal && it.isSelected && !it.uriString.isNullOrEmpty() }
-        if (externalTrack != null) {
-            val currentVideo = uiState.currentVideo ?: return@LaunchedEffect
-            val uri = extractUri(currentVideo) ?: return@LaunchedEffect
-
-            val uriString = externalTrack.uriString ?: return@LaunchedEffect
-            val mimeType = when {
-                uriString.endsWith(".vtt", ignoreCase = true) -> MimeTypes.TEXT_VTT
-                uriString.endsWith(".ass", ignoreCase = true) ||
-                    uriString.endsWith(".ssa", ignoreCase = true) -> MimeTypes.TEXT_SSA
-                else -> MimeTypes.APPLICATION_SUBRIP
-            }
-
-            val subUri = if (uriString.startsWith("content://") || uriString.startsWith("file://")) {
-                Uri.parse(uriString)
-            } else {
-                Uri.fromFile(File(uriString))
-            }
-            val subConfig = MediaItem.SubtitleConfiguration.Builder(subUri)
-                .setId(externalTrack.id)
-                .setLabel(externalTrack.label)
-                .setMimeType(mimeType)
-                .setLanguage("fr")
-                .setSelectionFlags(C.SELECTION_FLAG_DEFAULT or C.SELECTION_FLAG_FORCED)
-                .build()
-
-            val currentMediaItem = exoPlayer.currentMediaItem
-            val mediaItem = (currentMediaItem?.buildUpon() ?: MediaItem.Builder().setUri(uri))
-                .setSubtitleConfigurations(listOf(subConfig))
-                .build()
-
-            exoPlayer.setMediaItem(mediaItem, /* resetPosition = */ false)
-            exoPlayer.prepare()
-            exoPlayer.playWhenReady = true
-        }
-    }
+    var attachedSubtitleUris by remember { mutableStateOf<Set<String>>(emptySet()) }
 
     LaunchedEffect(uiState.currentVideo) {
         val video = uiState.currentVideo ?: return@LaunchedEffect
         val uri = extractUri(video) ?: return@LaunchedEffect
 
+        attachedSubtitleUris = emptySet()
         exoPlayer.stop()
         exoPlayer.clearMediaItems()
         isPlayerReady = false
@@ -523,6 +494,53 @@ fun PlayerScreen(
         }
         exoPlayer.prepare()
         exoPlayer.playWhenReady = true
+    }
+
+    val externalTracks = remember(uiState.subtitleTracks) {
+        uiState.subtitleTracks.filter { it.isExternal && !it.uriString.isNullOrBlank() }
+    }
+    val externalUris = remember(externalTracks) {
+        externalTracks.mapNotNull { it.uriString }.toSet()
+    }
+
+    LaunchedEffect(externalUris) {
+        if (externalUris.isEmpty() || externalUris == attachedSubtitleUris) return@LaunchedEffect
+        val currentVideo = uiState.currentVideo ?: return@LaunchedEffect
+        val uri = extractUri(currentVideo) ?: return@LaunchedEffect
+
+        val subConfigs = externalTracks.map { track ->
+            val trackUriString = track.uriString!!
+            val mimeType = when {
+                trackUriString.endsWith(".vtt", ignoreCase = true) -> MimeTypes.TEXT_VTT
+                trackUriString.endsWith(".ass", ignoreCase = true) ||
+                    trackUriString.endsWith(".ssa", ignoreCase = true) -> MimeTypes.TEXT_SSA
+                else -> MimeTypes.APPLICATION_SUBRIP
+            }
+
+            val subUri = if (trackUriString.startsWith("content://") || trackUriString.startsWith("file://")) {
+                Uri.parse(trackUriString)
+            } else {
+                Uri.fromFile(File(trackUriString))
+            }
+            MediaItem.SubtitleConfiguration.Builder(subUri)
+                .setId(track.id)
+                .setLabel(track.label)
+                .setMimeType(mimeType)
+                .setLanguage(track.language ?: "fr")
+                .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
+                .build()
+        }
+
+        val currentPos = exoPlayer.currentPosition.coerceAtLeast(0L)
+        val currentMediaItem = exoPlayer.currentMediaItem
+        val mediaItem = (currentMediaItem?.buildUpon() ?: MediaItem.Builder().setUri(uri))
+            .setSubtitleConfigurations(subConfigs)
+            .build()
+
+        attachedSubtitleUris = externalUris
+        exoPlayer.setMediaItem(mediaItem, currentPos)
+        exoPlayer.prepare()
+        exoPlayer.play()
     }
 
     LaunchedEffect(exoPlayer, isPlayerReady, uiState.isPlaying) {
@@ -1004,11 +1022,12 @@ private fun getScreenBrightness(activity: Activity?): Float {
 }
 
 private fun findTrackOverride(tracks: Tracks, trackType: @C.TrackType Int, targetId: String): TrackSelectionOverride? {
-    for (group in tracks.groups) {
+    for (groupIndex in 0 until tracks.groups.size) {
+        val group = tracks.groups[groupIndex]
         if (group.type != trackType) continue
         for (i in 0 until group.length) {
             val format = group.getTrackFormat(i)
-            val id = format.id ?: "$trackType-$i"
+            val id = format.id ?: "$trackType-$groupIndex-$i"
             if (id == targetId) {
                 return TrackSelectionOverride(group.mediaTrackGroup, i)
             }
@@ -1041,17 +1060,56 @@ private fun resolveExtension(fileName: String): String = when {
     else -> ".srt"
 }
 
+private val UTF8_BOM = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+private val UTF16_LE_BOM = byteArrayOf(0xFF.toByte(), 0xFE.toByte())
+private val UTF16_BE_BOM = byteArrayOf(0xFE.toByte(), 0xFF.toByte())
+
+private fun hasPrefix(bytes: ByteArray, prefix: ByteArray): Boolean {
+    return bytes.size >= prefix.size && prefix.indices.none { bytes[it] != prefix[it] }
+}
+
+@Suppress("ReturnCount")
+private fun normalizeSubtitleEncoding(bytes: ByteArray): ByteArray {
+    if (hasPrefix(bytes, UTF8_BOM)) {
+        return bytes.copyOfRange(UTF8_BOM.size, bytes.size)
+    }
+    if (hasPrefix(bytes, UTF16_LE_BOM)) {
+        return String(bytes, UTF16_LE_BOM.size, bytes.size - UTF16_LE_BOM.size, Charsets.UTF_16LE)
+            .toByteArray(Charsets.UTF_8)
+    }
+    if (hasPrefix(bytes, UTF16_BE_BOM)) {
+        return String(bytes, UTF16_BE_BOM.size, bytes.size - UTF16_BE_BOM.size, Charsets.UTF_16BE)
+            .toByteArray(Charsets.UTF_8)
+    }
+
+    val isUtf8 = runCatching {
+        val decoder = Charsets.UTF_8.newDecoder()
+        decoder.onMalformedInput(CodingErrorAction.REPORT)
+        decoder.onUnmappableCharacter(CodingErrorAction.REPORT)
+        decoder.decode(ByteBuffer.wrap(bytes))
+        true
+    }.getOrDefault(false)
+
+    return if (isUtf8) {
+        bytes
+    } else {
+        val cp1252 = Charset.forName("windows-1252")
+        String(bytes, cp1252).toByteArray(Charsets.UTF_8)
+    }
+}
+
 private fun copyUriToCache(context: Context, uri: Uri): Pair<String, String> {
     val fileName = resolveDisplayName(context, uri)
     val extension = resolveExtension(fileName)
     val subDir = File(context.cacheDir, "subtitles").apply { mkdirs() }
     val cacheFile = File(subDir, "local_${System.currentTimeMillis()}$extension")
     val copied = runCatching {
-        context.contentResolver.openInputStream(uri)?.use { input ->
-            FileOutputStream(cacheFile).use { output ->
-                input.copyTo(output)
-            }
-        }
+        val rawBytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            ?: return@runCatching false
+        if (rawBytes.isEmpty()) return@runCatching false
+
+        val normalized = normalizeSubtitleEncoding(rawBytes)
+        cacheFile.writeBytes(normalized)
         cacheFile.exists() && cacheFile.length() > 0
     }.getOrDefault(false)
 

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -476,7 +476,11 @@ class PlayerViewModel(
             val mergedSubtitles = subtitles.map { sub ->
                 val matchingExt = externalTracks.find { it.id == sub.id }
                 if (matchingExt != null) {
-                    sub.copy(isExternal = true, uriString = matchingExt.uriString)
+                    sub.copy(
+                        label = matchingExt.label,
+                        isExternal = true,
+                        uriString = matchingExt.uriString,
+                    )
                 } else {
                     sub
                 }
@@ -494,12 +498,20 @@ class PlayerViewModel(
             } else {
                 audio
             }
-            state.copy(
-                audioTracks = finalAudio,
-                subtitleTracks = finalSubtitles,
-                selectedAudioTrackId = selectedAudio,
-                selectedSubtitleTrackId = selectedSub,
-            )
+
+            val isAudioUnchanged = state.audioTracks == finalAudio && state.selectedAudioTrackId == selectedAudio
+            val isSubUnchanged = state.subtitleTracks == finalSubtitles && state.selectedSubtitleTrackId == selectedSub
+
+            if (isAudioUnchanged && isSubUnchanged) {
+                state
+            } else {
+                state.copy(
+                    audioTracks = finalAudio,
+                    subtitleTracks = finalSubtitles,
+                    selectedAudioTrackId = selectedAudio,
+                    selectedSubtitleTrackId = selectedSub,
+                )
+            }
         }
     }
 
@@ -599,6 +611,8 @@ class PlayerViewModel(
                     availableEpisodes = episodes,
                     showResumeBanner = hasResume,
                     resumePositionMs = pos,
+                    subtitleTracks = emptyList(),
+                    selectedSubtitleTrackId = null,
                 )
             }
 

--- a/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
@@ -27,6 +27,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -383,6 +384,48 @@ class PlayerViewModelTest {
         assertTrue(extTrack!!.isExternal)
         assertTrue(extTrack.isSelected)
         assertEquals(extId, state4.selectedSubtitleTrackId)
+    }
+
+    @Test
+    fun `selectSubtitleTrack null disables subtitles and updateTracks preserves external label`() = runTest {
+        val viewModel = PlayerViewModel(video1.name, container)
+        backgroundScope.launch { viewModel.uiState.collect {} }
+        advanceUntilIdle()
+
+        val audio = listOf(AudioTrackUiState(id = "a1", label = "Français", isSelected = true))
+        val sub = listOf(SubtitleTrackUiState(id = "s1", label = "Français SRT", isSelected = true))
+        viewModel.updateTracks(audio, sub)
+        advanceUntilIdle()
+
+        viewModel.addExternalSubtitle("danseaveclesloups.srt", "file:///cache/sub.srt")
+        advanceUntilIdle()
+
+        val extId = viewModel.uiState.value.selectedSubtitleTrackId
+        assertNotNull(extId)
+
+        // ExoPlayer emits track changes with external track included
+        viewModel.updateTracks(
+            audio,
+            listOf(
+                SubtitleTrackUiState(id = "s1", label = "Français SRT", isSelected = false),
+                SubtitleTrackUiState(id = extId!!, label = "Piste 2", isSelected = true),
+            ),
+        )
+        advanceUntilIdle()
+
+        val stateAfterExo = viewModel.uiState.value
+        val extTrack = stateAfterExo.subtitleTracks.find { it.id == extId }
+        assertNotNull(extTrack)
+        assertTrue(extTrack!!.isExternal)
+        assertEquals("danseaveclesloups.srt", extTrack.label)
+        assertEquals("file:///cache/sub.srt", extTrack.uriString)
+
+        // Disable subtitles
+        viewModel.selectSubtitleTrack(null)
+        advanceUntilIdle()
+        val disabledState = viewModel.uiState.value
+        assertNull(disabledState.selectedSubtitleTrackId)
+        assertTrue(disabledState.subtitleTracks.none { it.isSelected })
     }
 
     @Test


### PR DESCRIPTION
## Résumé des changements

Cette PR corrige deux anomalies critiques survenues lors de l'ajout ou de la sélection de sous-titres locaux :

1. **Écran noir permanent et vidéo bloquée en pause** :
   - Suppression du `LaunchedEffect(uiState.subtitleTracks)` qui déclenchait un rechargement continu du média (`exoPlayer.setMediaItem`) en boucle infinie (réaction en chaîne entre `onTracksChanged`, `viewModel.updateTracks` et la recomposition Compose).
   - L'attachement à `MediaItem` est désormais exécuté **une seule fois** par fichier de sous-titre via un suivi des URIs attachées (`attachedSubtitleUris`).
   - La sélection et la désélection des sous-titres (internes ou externes) s'effectuent désormais instantanément via `TrackSelectionParameters` (`clearOverridesOfType(C.TRACK_TYPE_TEXT)` et `TrackSelectionOverride`), sans aucun rechargement de média, préservant la lecture et la position sans mise en mémoire tampon parasite.
   - Préservation de la position de lecture et reprise explicite via `exoPlayer.play()` lors de l'attachement.

2. **Sautillement et clignotement du menu des sous-titres** :
   - Élimination des recompositions Compose en cascade.
   - Ajout d'une condition de déduplication dans `PlayerViewModel.updateTracks(...)` afin de ne plus émettre de nouvel état si les pistes et sélections sont identiques.

3. **Robustesse d'encodage des fichiers de sous-titres** :
   - Amélioration de `copyUriToCache` pour détecter UTF-8 (avec/sans BOM), UTF-16, et convertir automatiquement les encodages Windows-1252 / ISO-8859-1 en UTF-8, garantissant la bonne prise en charge des caractères accentués français dans les fichiers `.srt`.

## Tests & Vérifications

- [x] **Simulation de fusion** : `git merge-tree` avec `origin/main` validé (0 conflit).
- [x] **Tests unitaires** : `.\gradlew.bat testDebugUnitTest` validé avec succès (100% passants, dont test de non-régression dans `PlayerViewModelTest`).
- [x] **Linter Detekt** : `.\gradlew.bat detekt` validé avec succès (0 warning, 0 erreur).
- [x] **Compilation** : `.\gradlew.bat assembleDebug` réussi.
- [x] **Validation sur émulateur** : Application testée sur émulateur Android API 36, confirmant la stabilité du menu et l'absence de rechargement intempestif.
- [x] **Checks CI distants** : Workflow GitHub Actions `Tests & analyse statique` passé avec succès (vert).
