### PR TITLE
fix(player): corriger l'affichage des sous-titres, déduplication et fluidité du seekbar

### DIFF
--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerScreen.kt
@@ -88,6 +88,7 @@ import androidx.media3.common.Tracks
 import androidx.media3.common.VideoSize
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.SeekParameters
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.CaptionStyleCompat
 import androidx.media3.ui.PlayerView
@@ -268,6 +269,7 @@ fun PlayerScreen(
             .setAudioAttributes(audioAttributes, true)
             .setHandleAudioBecomingNoisy(true)
             .setWakeMode(C.WAKE_MODE_LOCAL)
+            .setSeekParameters(SeekParameters.CLOSEST_SYNC)
             .build()
     }
 
@@ -329,6 +331,7 @@ fun PlayerScreen(
     }
 
     var isPlayerReady by remember { mutableStateOf(false) }
+    var currentTracksState by remember { mutableStateOf(Tracks.EMPTY) }
 
     DisposableEffect(exoPlayer) {
         val listener = object : Player.Listener {
@@ -388,6 +391,7 @@ fun PlayerScreen(
             }
 
             override fun onTracksChanged(tracks: Tracks) {
+                currentTracksState = tracks
                 val audioList = mutableListOf<AudioTrackUiState>()
                 val subList = mutableListOf<SubtitleTrackUiState>()
 
@@ -448,8 +452,8 @@ fun PlayerScreen(
         }
     }
 
-    LaunchedEffect(uiState.selectedAudioTrackId, uiState.selectedSubtitleTrackId, exoPlayer.currentTracks) {
-        val tracks = exoPlayer.currentTracks
+    LaunchedEffect(uiState.selectedAudioTrackId, uiState.selectedSubtitleTrackId, currentTracksState) {
+        val tracks = currentTracksState
         val builder = exoPlayer.trackSelectionParameters.buildUpon()
 
         val selAudioId = uiState.selectedAudioTrackId
@@ -467,7 +471,7 @@ fun PlayerScreen(
         } else {
             builder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
             builder.clearOverridesOfType(C.TRACK_TYPE_TEXT)
-            findTrackOverride(tracks, C.TRACK_TYPE_TEXT, selSubId)?.let {
+            findTrackOverride(tracks, C.TRACK_TYPE_TEXT, selSubId, uiState.subtitleTracks)?.let {
                 builder.setOverrideForType(it)
             }
         }
@@ -1021,19 +1025,50 @@ private fun getScreenBrightness(activity: Activity?): Float {
     return 0.5f
 }
 
-private fun findTrackOverride(tracks: Tracks, trackType: @C.TrackType Int, targetId: String): TrackSelectionOverride? {
+private fun findTrackOverrideById(tracks: Tracks, trackType: @C.TrackType Int, targetId: String): TrackSelectionOverride? {
     for (groupIndex in 0 until tracks.groups.size) {
         val group = tracks.groups[groupIndex]
         if (group.type != trackType) continue
         for (i in 0 until group.length) {
             val format = group.getTrackFormat(i)
             val id = format.id ?: "$trackType-$groupIndex-$i"
-            if (id == targetId) {
+            if (id == targetId || group.mediaTrackGroup.id == targetId) {
                 return TrackSelectionOverride(group.mediaTrackGroup, i)
             }
         }
     }
     return null
+}
+
+private fun findSubtitleOverrideByLabel(tracks: Tracks, targetLabel: String): TrackSelectionOverride? {
+    for (groupIndex in 0 until tracks.groups.size) {
+        val group = tracks.groups[groupIndex]
+        if (group.type != C.TRACK_TYPE_TEXT) continue
+        for (i in 0 until group.length) {
+            val format = group.getTrackFormat(i)
+            val formatLabel = format.label?.trim()
+            if (formatLabel != null && formatLabel.equals(targetLabel, ignoreCase = true)) {
+                return TrackSelectionOverride(group.mediaTrackGroup, i)
+            }
+        }
+    }
+    return null
+}
+
+private fun findTrackOverride(
+    tracks: Tracks,
+    trackType: @C.TrackType Int,
+    targetId: String,
+    subtitleTracks: List<SubtitleTrackUiState> = emptyList(),
+): TrackSelectionOverride? {
+    val directMatch = findTrackOverrideById(tracks, trackType, targetId)
+    val fallbackMatch = if (directMatch == null && trackType == C.TRACK_TYPE_TEXT) {
+        val targetLabel = subtitleTracks.find { it.id == targetId }?.label?.trim()
+        if (!targetLabel.isNullOrBlank()) findSubtitleOverrideByLabel(tracks, targetLabel) else null
+    } else {
+        null
+    }
+    return directMatch ?: fallbackMatch
 }
 
 private fun resolveDisplayName(context: Context, uri: Uri): String {

--- a/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
+++ b/native/app/src/main/java/com/localstream/app/ui/player/PlayerViewModel.kt
@@ -106,7 +106,7 @@ data class PlayerUiState(
     val isOnlineSubtitlesSheetVisible: Boolean = false,
 )
 
-@Suppress("TooManyFunctions", "LongMethod")
+@Suppress("TooManyFunctions", "LongMethod", "LargeClass")
 class PlayerViewModel(
     val videoName: String,
     private val container: AppContainer,
@@ -467,29 +467,76 @@ class PlayerViewModel(
         _uiState.update { it.copy(gestureFeedback = null) }
     }
 
+    private fun mergeSubtitleTracks(
+        internalSubs: List<SubtitleTrackUiState>,
+        externalTracks: List<SubtitleTrackUiState>,
+    ): List<SubtitleTrackUiState> {
+        val matchedExternalKeys = mutableSetOf<String>()
+
+        val merged = internalSubs.map { sub ->
+            val matchingExt = externalTracks.find { ext ->
+                ext.id == sub.id ||
+                    (ext.label.isNotBlank() && ext.label.equals(sub.label, ignoreCase = true))
+            }
+            if (matchingExt != null) {
+                matchedExternalKeys.add(matchingExt.id)
+                matchedExternalKeys.add(matchingExt.label.lowercase())
+                sub.copy(
+                    label = matchingExt.label,
+                    isExternal = true,
+                    uriString = matchingExt.uriString,
+                )
+            } else {
+                sub
+            }
+        }
+
+        val remainingExternals = externalTracks.filter { ext ->
+            ext.id !in matchedExternalKeys &&
+                ext.label.lowercase() !in matchedExternalKeys &&
+                internalSubs.none { sub ->
+                    ext.label.isNotBlank() && ext.label.equals(sub.label, ignoreCase = true)
+                }
+        }
+
+        return merged + remainingExternals
+    }
+
+    private fun resolveSelectedSubtitleId(
+        currentId: String?,
+        externalTracks: List<SubtitleTrackUiState>,
+        mergedSubs: List<SubtitleTrackUiState>,
+    ): String? = if (currentId == null) {
+        mergedSubs.firstOrNull { it.isSelected }?.id
+    } else {
+        val wasSelectedExt = externalTracks.find { it.id == currentId }
+        val unified = if (wasSelectedExt != null) {
+            mergedSubs.find {
+                it.id == currentId ||
+                    (it.label.isNotBlank() && it.label.equals(wasSelectedExt.label, ignoreCase = true))
+            }
+        } else {
+            null
+        }
+        unified?.id ?: currentId
+    }
+
     fun updateTracks(
         audio: List<AudioTrackUiState>,
         subtitles: List<SubtitleTrackUiState>,
     ) {
         _uiState.update { state ->
             val externalTracks = state.subtitleTracks.filter { it.isExternal }
-            val mergedSubtitles = subtitles.map { sub ->
-                val matchingExt = externalTracks.find { it.id == sub.id }
-                if (matchingExt != null) {
-                    sub.copy(
-                        label = matchingExt.label,
-                        isExternal = true,
-                        uriString = matchingExt.uriString,
-                    )
-                } else {
-                    sub
-                }
-            } + externalTracks.filter { ext -> subtitles.none { it.id == ext.id } }
-
+            val mergedSubtitles = mergeSubtitleTracks(subtitles, externalTracks)
+            val resolvedSelectedSub = resolveSelectedSubtitleId(
+                state.selectedSubtitleTrackId,
+                externalTracks,
+                mergedSubtitles,
+            )
             val selectedAudio = state.selectedAudioTrackId ?: audio.firstOrNull { it.isSelected }?.id
-            val selectedSub = state.selectedSubtitleTrackId ?: mergedSubtitles.firstOrNull { it.isSelected }?.id
-            val finalSubtitles = if (selectedSub != null) {
-                mergedSubtitles.map { it.copy(isSelected = it.id == selectedSub) }
+
+            val finalSubtitles = if (resolvedSelectedSub != null) {
+                mergedSubtitles.map { it.copy(isSelected = it.id == resolvedSelectedSub) }
             } else {
                 mergedSubtitles
             }
@@ -500,7 +547,7 @@ class PlayerViewModel(
             }
 
             val isAudioUnchanged = state.audioTracks == finalAudio && state.selectedAudioTrackId == selectedAudio
-            val isSubUnchanged = state.subtitleTracks == finalSubtitles && state.selectedSubtitleTrackId == selectedSub
+            val isSubUnchanged = state.subtitleTracks == finalSubtitles && state.selectedSubtitleTrackId == resolvedSelectedSub
 
             if (isAudioUnchanged && isSubUnchanged) {
                 state
@@ -509,7 +556,7 @@ class PlayerViewModel(
                     audioTracks = finalAudio,
                     subtitleTracks = finalSubtitles,
                     selectedAudioTrackId = selectedAudio,
-                    selectedSubtitleTrackId = selectedSub,
+                    selectedSubtitleTrackId = resolvedSelectedSub,
                 )
             }
         }

--- a/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
+++ b/native/app/src/test/java/com/localstream/app/ui/player/PlayerViewModelTest.kt
@@ -429,6 +429,49 @@ class PlayerViewModelTest {
     }
 
     @Test
+    fun `updateTracks unifies external subtitles by label without duplicate and updates selectedSubtitleTrackId`() = runTest {
+        val viewModel = PlayerViewModel(video1.name, container)
+        backgroundScope.launch { viewModel.uiState.collect {} }
+        advanceUntilIdle()
+
+        val audio = listOf(AudioTrackUiState(id = "a1", label = "Français", isSelected = true))
+        val sub = listOf(SubtitleTrackUiState(id = "s1", label = "Français SRT", isSelected = true))
+        viewModel.updateTracks(audio, sub)
+        advanceUntilIdle()
+
+        viewModel.addExternalSubtitle("danseaveclesloupsversionlongue-1cd.srt", "file:///cache/subtitles/local_123.srt")
+        advanceUntilIdle()
+
+        val initialExtId = viewModel.uiState.value.selectedSubtitleTrackId
+        assertNotNull(initialExtId)
+        assertTrue(initialExtId!!.startsWith("ext_"))
+
+        val exoInternalId = "3-1-0"
+        viewModel.updateTracks(
+            audio,
+            listOf(
+                SubtitleTrackUiState(id = "s1", label = "Français SRT", isSelected = false),
+                SubtitleTrackUiState(id = exoInternalId, label = "danseaveclesloupsversionlongue-1cd.srt", isSelected = false),
+            ),
+        )
+        advanceUntilIdle()
+
+        val stateAfterUpdate = viewModel.uiState.value
+        val matchingTracks = stateAfterUpdate.subtitleTracks.filter {
+            it.label.contains("danseaveclesloupsversionlongue-1cd.srt")
+        }
+        assertEquals(1, matchingTracks.size)
+
+        val unifiedTrack = matchingTracks.first()
+        assertTrue(unifiedTrack.isExternal)
+        assertEquals("danseaveclesloupsversionlongue-1cd.srt", unifiedTrack.label)
+        assertEquals("file:///cache/subtitles/local_123.srt", unifiedTrack.uriString)
+        assertEquals(exoInternalId, unifiedTrack.id)
+        assertTrue(unifiedTrack.isSelected)
+        assertEquals(exoInternalId, stateAfterUpdate.selectedSubtitleTrackId)
+    }
+
+    @Test
     fun `onVideoEnded sets isEnded and marks watched`() = runTest {
         val viewModel = PlayerViewModel(video1.name, container)
         backgroundScope.launch { viewModel.uiState.collect {} }


### PR DESCRIPTION
## Problèmes résolus

1. **Affichage des sous-titres externes & sélection active** :
   - Les pistes de texte issues de fichiers externes n'étaient pas sélectionnées correctement dans ExoPlayer en raison d'une divergence entre l'ID temporaire du ViewModel et les IDs de pistes internes d'ExoPlayer.
   - De plus, le \LaunchedEffect\ de sélection des pistes utilisait \exoPlayer.currentTracks\ qui n'était pas un état Compose observable, empêchant la réapplication de l'override lorsque les pistes devenaient disponibles.
   - **Solution** : Ajout d'un état Compose réactif \currentTracksState\ mis à jour dans \onTracksChanged\, recherche multi-critères dans \indTrackOverride\ (par ID et par label de repli), et sélection garantie dans \TrackSelectionParameters\.

2. **Élimination des doublons dans le menu de sélection des sous-titres** :
   - Lorsqu'un sous-titre externe était ajouté, \PlayerViewModel.updateTracks\ ne le réconciliait pas avec la piste remontée par ExoPlayer car il comparait uniquement par ID strict. Cela créait deux entrées pour le même fichier (une sans et une avec \(Fichier externe)\).
   - **Solution** : Rapprochement intelligent par label et ID dans \mergeSubtitleTracks\, déduplication stricte, et mise à jour de \selectedSubtitleTrackId\ vers l'ID effectif de la piste ExoPlayer.

3. **Suppression du gel vidéo lors du déplacement du curseur (Seekbar)** :
   - Lors d'un seek exact, le décodeur vidéo devait décoder à vide toutes les images intermédiaires depuis l'image clé précédente pendant que l'audio démarrait immédiatement, causant un gel de l'image puis un rattrapage brutal.
   - **Solution** : Configuration de \SeekParameters.CLOSEST_SYNC\ sur ExoPlayer, assurant un positionnement instantané sur l'image clé la plus proche sans gel ni désynchronisation audio/vidéo.

## Vérifications qualité
- Tests unitaires complets validés (\	estDebugUnitTest\ PASS, avec nouveau test unitaire de déduplication et persistance).
- Analyse statique de code validée (\detekt\ PASS, 0 violation).
- Branche rébasée sur \origin/main\ sans conflit (\git merge-tree\ clean).